### PR TITLE
Fix: Readme file contributor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ echo $prism()->text;
 
 ## Authors
 
-This library is created by [TJ Miller](https://tjmiller.me) with contributions from the [Open Source Community](https://github.com/vercel/ai/graphs/contributors).
+This library is created by [TJ Miller](https://tjmiller.me) with contributions from the [Open Source Community](https://github.com/echolabsdev/prism/graphs/contributors).
 
 ## License
 


### PR DESCRIPTION
Currently, the "Open Source Community" link under the Author section in the readme file directs to Vercel's AI repository instead of the repository's "Contributors" page. I have prepared the PR for your review.