### PR TITLE
Draft: Add support for Vision

### DIFF
--- a/src/Providers/Anthropic/MessageMap.php
+++ b/src/Providers/Anthropic/MessageMap.php
@@ -9,6 +9,7 @@ use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use EchoLabs\Prism\ValueObjects\ImageCall;
 use EchoLabs\Prism\ValueObjects\ToolCall;
 use EchoLabs\Prism\ValueObjects\ToolResult;
 use Exception;
@@ -62,6 +63,26 @@ class MessageMap
      */
     protected function mapUserMessage(UserMessage $message): array
     {
+        if ($message->hasImages()) {
+            return [
+                'role' => 'user',
+                'content' => [
+                    ...array_map(fn (ImageCall $image) => [
+                        'type' => 'image',
+                        'source' => [
+                            'type' => 'base64',
+                            'media_type' => $image->fileType,
+                            'data' => $image->url,
+                        ],
+                    ], $message->images),
+                    [
+                        'type' => 'text',
+                        'text' => $message->content(),
+                    ],
+                ],
+            ];
+        }
+
         return [
             'role' => 'user',
             'content' => $message->content(),

--- a/src/Providers/OpenAI/MessageMap.php
+++ b/src/Providers/OpenAI/MessageMap.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Providers\OpenAI;
 
 use EchoLabs\Prism\Contracts\Message;
+use EchoLabs\Prism\ValueObjects\ImageCall;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use EchoLabs\Prism\ValueObjects\ImageCall;
 use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
 
@@ -77,6 +79,25 @@ class MessageMap
 
     protected function mapUserMessage(UserMessage $message): void
     {
+        if ($message->hasImages()) {
+            $this->mappedMessages[] = [
+                'role' => 'user',
+                'content' => [
+                    ...array_map(fn (ImageCall $image) => [
+                        'type' => 'image_url',
+                        'image_url' => [
+                            'url' => $image->url,
+                        ],
+                    ], $message->images),
+                    [
+                        'type' => 'text',
+                        'text' => $message->content(),
+                    ],
+                ],
+            ];
+            return;
+        }
+
         $this->mappedMessages[] = [
             'role' => 'user',
             'content' => $message->content(),

--- a/src/ValueObjects/ImageCall.php
+++ b/src/ValueObjects/ImageCall.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\ValueObjects;
+
+class ImageCall
+{
+    public function __construct(
+        public readonly string $url,
+        public readonly ?string $fileType = null,
+    ) {
+    }
+}

--- a/src/ValueObjects/Messages/UserMessage.php
+++ b/src/ValueObjects/Messages/UserMessage.php
@@ -5,16 +5,27 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\ValueObjects\Messages;
 
 use EchoLabs\Prism\Contracts\Message;
+use EchoLabs\Prism\ValueObjects\ImageCall;
 
 class UserMessage implements Message
 {
+    /**
+     * @param  ImageCall[]  $images
+     */
     public function __construct(
         protected readonly string $content,
-    ) {}
+        public readonly array $images = [],
+    ) {
+    }
 
     #[\Override]
     public function content(): string
     {
         return $this->content;
+    }
+
+    public function hasImages(): bool
+    {
+        return count($this->images) > 0;
     }
 }


### PR DESCRIPTION
Adds support for Vision to [OpenAI](https://platform.openai.com/docs/guides/vision) and [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/vision).

