### PR TITLE
Allow for client options + refactors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "rector/rector": "^1.1",
     "projektgopher/whisky": "^0.7.0",
     "orchestra/testbench": "^9.4",
-    "mockery/mockery": "^1.6"
+    "mockery/mockery": "^1.6",
+    "symplify/rule-doc-generator-contracts": "^11.2"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -57,15 +57,12 @@
       "@clear",
       "@prepare"
     ],
-    "phpstan": [
-      "phpstan analyse -c phpstan.neon.dist"
-    ],
     "format": [
-      "pint",
-      "rector process --no-diffs"
+      "@php vendor/bin/pint --ansi",
+      "@php vendor/bin/rector process --no-diffs"
     ],
     "test": [
-      "@php vendor/bin/pest"
+      "@php vendor/bin/pest --parallel"
     ],
     "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
     "prepare": "@php vendor/bin/testbench package:discover --ansi",
@@ -75,12 +72,8 @@
       "@build",
       "@php vendor/bin/testbench serve --ansi"
     ],
-    "lint": [
-      "@php vendor/bin/pint --ansi",
+    "types": [
       "@php vendor/bin/phpstan analyse --verbose --ansi"
-    ],
-    "toc": [
-      "markdown-toc -i README.md"
     ]
   },
   "extra": {

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use EchoLabs\Prism\Rectors\ReorderMethodsRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
@@ -15,6 +16,7 @@ return RectorConfig::configure()
     ])
     ->withRules([
         InlineConstructorDefaultToPropertyRector::class,
+        ReorderMethodsRector::class,
     ])
     ->withSets([
         LevelSetList::UP_TO_PHP_83,

--- a/src/Concerns/HasClientOptions.php
+++ b/src/Concerns/HasClientOptions.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Concerns;
+
+trait HasClientOptions
+{
+    /** @var array<string, mixed> */
+    protected array $clientOptions = [];
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function withClientOptions(array $options): self
+    {
+        $this->clientOptions = $options;
+
+        return $this;
+    }
+}

--- a/src/Concerns/HasModel.php
+++ b/src/Concerns/HasModel.php
@@ -7,4 +7,11 @@ namespace EchoLabs\Prism\Concerns;
 trait HasModel
 {
     protected string $model;
+
+    public function usingModel(string $model): self
+    {
+        $this->model = $model;
+
+        return $this;
+    }
 }

--- a/src/Concerns/HasProvider.php
+++ b/src/Concerns/HasProvider.php
@@ -18,4 +18,9 @@ trait HasProvider
 
         return $this;
     }
+
+    public function provider(): Provider
+    {
+        return $this->provider;
+    }
 }

--- a/src/Concerns/HasProvider.php
+++ b/src/Concerns/HasProvider.php
@@ -18,9 +18,4 @@ trait HasProvider
 
         return $this;
     }
-
-    public function provider(): Provider
-    {
-        return $this->provider;
-    }
 }

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -12,4 +12,9 @@ interface Provider
     public function usingModel(string $model): Provider;
 
     public function text(TextRequest $request): ProviderResponse;
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function withClientOptions(array $options): Provider;
 }

--- a/src/Generators/TextGenerator.php
+++ b/src/Generators/TextGenerator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Generators;
 
-use Closure;
 use EchoLabs\Prism\Concerns\HandlesToolCalls;
+use EchoLabs\Prism\Concerns\HasClientOptions;
 use EchoLabs\Prism\Concerns\HasProvider;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\FinishReason;
@@ -25,7 +25,7 @@ use Illuminate\Contracts\View\View;
 
 class TextGenerator
 {
-    use HandlesToolCalls, HasProvider;
+    use HandlesToolCalls, HasClientOptions, HasProvider;
 
     protected ?string $prompt = null;
 
@@ -55,13 +55,6 @@ class TextGenerator
     public function __invoke(): TextResponse
     {
         return $this->generate();
-    }
-
-    public function withProviderCustomizations(Closure $fn): self
-    {
-        $fn($this->provider);
-
-        return $this;
     }
 
     public function withPrompt(string|View $prompt): self
@@ -173,7 +166,10 @@ class TextGenerator
 
     protected function sendProviderRequest(): ProviderResponse
     {
-        $response = $this->provider->text($this->textRequest());
+        $response = $this
+            ->provider
+            ->withClientOptions($this->clientOptions)
+            ->text($this->textRequest());
 
         $this->state->addResponseMessage(
             new AssistantMessage(

--- a/src/Generators/TextGenerator.php
+++ b/src/Generators/TextGenerator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Generators;
 
+use Closure;
 use EchoLabs\Prism\Concerns\HandlesToolCalls;
 use EchoLabs\Prism\Concerns\HasProvider;
 use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Providers\ProviderResponse;
@@ -57,9 +57,11 @@ class TextGenerator
         return $this->generate();
     }
 
-    public function provider(): Provider
+    public function withProviderCustomizations(Closure $fn): self
     {
-        return $this->provider;
+        $fn($this->provider);
+
+        return $this;
     }
 
     public function withPrompt(string|View $prompt): self

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -46,6 +46,22 @@ class PrismManager
         throw new InvalidArgumentException("Provider [{$name}] is not supported.");
     }
 
+    /**
+     * @throws RuntimeException
+     */
+    public function extend(string $provider, Closure $callback): self
+    {
+        if (($callback = $callback->bindTo($this, $this)) instanceof \Closure) {
+            $this->customCreators[$provider] = $callback;
+
+            return $this;
+        }
+
+        throw new RuntimeException(
+            sprintf('Couldn\'t bind %s', $provider)
+        );
+    }
+
     protected function resolveName(ProviderEnum|string $name): string
     {
         if ($name instanceof ProviderEnum) {
@@ -106,22 +122,6 @@ class PrismManager
     protected function callCustomCreator(string $provider, array $config): Provider
     {
         return $this->customCreators[$provider]($this->app, $config);
-    }
-
-    /**
-     * @throws RuntimeException
-     */
-    public function extend(string $provider, Closure $callback): self
-    {
-        if (($callback = $callback->bindTo($this, $this)) instanceof \Closure) {
-            $this->customCreators[$provider] = $callback;
-
-            return $this;
-        }
-
-        throw new RuntimeException(
-            sprintf('Couldn\'t bind %s', $provider)
-        );
     }
 
     /**

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -31,14 +31,10 @@ class PrismManager
     {
         $name = $this->resolveName($name);
 
-        $config = $this->getConfig($name);
-
-        if (is_null($config)) {
-            throw new InvalidArgumentException("Provider [{$name}] config is not defined.");
-        }
+        $config = $this->getConfig($name) ?? [];
 
         if (isset($this->customCreators[$name])) {
-            return $this->callCustomCreator($config);
+            return $this->callCustomCreator($name, $config);
         }
 
         $factory = sprintf('create%sProvider', ucfirst($name));
@@ -107,24 +103,24 @@ class PrismManager
     /**
      * @param  array<string, mixed>  $config
      */
-    protected function callCustomCreator(array $config): Provider
+    protected function callCustomCreator(string $provider, array $config): Provider
     {
-        return $this->customCreators[$config['driver']]($this->app, $config);
+        return $this->customCreators[$provider]($this->app, $config);
     }
 
     /**
      * @throws RuntimeException
      */
-    public function extend(string $driver, Closure $callback): self
+    public function extend(string $provider, Closure $callback): self
     {
         if (($callback = $callback->bindTo($this, $this)) instanceof \Closure) {
-            $this->customCreators[$driver] = $callback;
+            $this->customCreators[$provider] = $callback;
 
             return $this;
         }
 
         throw new RuntimeException(
-            sprintf('Couldn\'t bind %s', $driver)
+            sprintf('Couldn\'t bind %s', $provider)
         );
     }
 

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -24,15 +24,6 @@ class Anthropic implements Provider
         public readonly string $apiVersion,
     ) {}
 
-    protected function client(): Client
-    {
-        return new Client(
-            apiKey: $this->apiKey,
-            apiVersion: $this->apiVersion,
-            options: $this->clientOptions,
-        );
-    }
-
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
@@ -91,6 +82,15 @@ class Anthropic implements Provider
                 'id' => data_get($data, 'id'),
                 'model' => data_get($data, 'model'),
             ]
+        );
+    }
+
+    protected function client(): Client
+    {
+        return new Client(
+            apiKey: $this->apiKey,
+            apiVersion: $this->apiVersion,
+            options: $this->clientOptions,
         );
     }
 

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Anthropic;
 
+use EchoLabs\Prism\Concerns\HasClientOptions;
+use EchoLabs\Prism\Concerns\HasModel;
 use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
@@ -15,33 +17,27 @@ use Throwable;
 
 class Anthropic implements Provider
 {
-    protected Client $client;
-
-    protected string $model;
+    use HasClientOptions, HasModel;
 
     public function __construct(
         public readonly string $apiKey,
         public readonly string $apiVersion,
-    ) {
-        $this->client = new Client(
-            $this->apiKey,
-            $this->apiVersion,
-        );
-    }
+    ) {}
 
-    #[\Override]
-    public function usingModel(string $model): self
+    protected function client(): Client
     {
-        $this->model = $model;
-
-        return $this;
+        return new Client(
+            apiKey: $this->apiKey,
+            apiVersion: $this->apiVersion,
+            options: $this->clientOptions,
+        );
     }
 
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
         try {
-            $response = $this->client->messages(
+            $response = $this->client()->messages(
                 model: $this->model,
                 systemPrompt: $request->systemPrompt,
                 messages: (new MessageMap($request->messages))(),

--- a/src/Providers/Anthropic/Client.php
+++ b/src/Providers/Anthropic/Client.php
@@ -12,14 +12,20 @@ class Client
 {
     protected PendingRequest $client;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function __construct(
         public readonly string $apiKey,
         public readonly string $apiVersion,
+        public readonly array $options = [],
     ) {
         $this->client = Http::withHeaders([
             'x-api-key' => $this->apiKey,
             'anthropic-version' => $this->apiVersion,
-        ])->baseUrl('https://api.anthropic.com/v1');
+        ])
+            ->withOptions($this->options)
+            ->baseUrl('https://api.anthropic.com/v1');
     }
 
     /**

--- a/src/Providers/Mistral/Client.php
+++ b/src/Providers/Mistral/Client.php
@@ -12,13 +12,19 @@ class Client
 {
     protected PendingRequest $client;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function __construct(
         public readonly string $url,
         public readonly string $apiKey,
+        public readonly array $options = [],
     ) {
         $this->client = Http::withHeaders(array_filter([
             'Authorization' => sprintf('Bearer %s', $this->apiKey),
-        ]))->baseUrl($this->url);
+        ]))
+            ->withOptions($this->options)
+            ->baseUrl($this->url);
     }
 
     /**

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Mistral;
 
+use EchoLabs\Prism\Concerns\HasClientOptions;
+use EchoLabs\Prism\Concerns\HasModel;
 use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
@@ -15,33 +17,27 @@ use Throwable;
 
 class Mistral implements Provider
 {
-    protected Client $client;
-
-    protected string $model;
+    use HasClientOptions, HasModel;
 
     public function __construct(
         public readonly string $url,
         public readonly string $apiKey,
-    ) {
-        $this->client = new Client(
+    ) {}
+
+    public function client(): Client
+    {
+        return new Client(
             url: $this->url,
             apiKey: $this->apiKey,
+            options: $this->clientOptions,
         );
-    }
-
-    #[\Override]
-    public function usingModel(string $model): self
-    {
-        $this->model = $model;
-
-        return $this;
     }
 
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
         try {
-            $response = $this->client->messages(
+            $response = $this->client()->messages(
                 model: $this->model,
                 messages: (new MessageMap(
                     $request->messages,

--- a/src/Providers/Ollama/Client.php
+++ b/src/Providers/Ollama/Client.php
@@ -12,13 +12,19 @@ class Client
 {
     protected PendingRequest $client;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function __construct(
         public readonly string $url,
         public readonly ?string $apiKey,
+        public readonly array $options = [],
     ) {
         $this->client = Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))->baseUrl($this->url);
+        ]))
+            ->withOptions($options)
+            ->baseUrl($this->url);
     }
 
     /**

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Ollama;
 
+use EchoLabs\Prism\Concerns\HasClientOptions;
+use EchoLabs\Prism\Concerns\HasModel;
 use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
@@ -15,33 +17,27 @@ use Throwable;
 
 class Ollama implements Provider
 {
-    protected Client $client;
-
-    protected string $model;
+    use HasClientOptions, HasModel;
 
     public function __construct(
         public readonly string $url,
         public readonly ?string $apiKey,
-    ) {
-        $this->client = new Client(
+    ) {}
+
+    protected function client(): Client
+    {
+        return new Client(
             url: $this->url,
             apiKey: $this->apiKey,
+            options: $this->clientOptions,
         );
-    }
-
-    #[\Override]
-    public function usingModel(string $model): self
-    {
-        $this->model = $model;
-
-        return $this;
     }
 
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
         try {
-            $response = $this->client->messages(
+            $response = $this->client()->messages(
                 model: $this->model,
                 messages: (new MessageMap(
                     $request->messages,

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -24,15 +24,6 @@ class Ollama implements Provider
         public readonly ?string $apiKey,
     ) {}
 
-    protected function client(): Client
-    {
-        return new Client(
-            url: $this->url,
-            apiKey: $this->apiKey,
-            options: $this->clientOptions,
-        );
-    }
-
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
@@ -82,6 +73,15 @@ class Ollama implements Provider
                 'id' => data_get($data, 'id'),
                 'model' => data_get($data, 'model'),
             ]
+        );
+    }
+
+    protected function client(): Client
+    {
+        return new Client(
+            url: $this->url,
+            apiKey: $this->apiKey,
+            options: $this->clientOptions,
         );
     }
 

--- a/src/Providers/OpenAI/Client.php
+++ b/src/Providers/OpenAI/Client.php
@@ -12,15 +12,21 @@ class Client
 {
     protected PendingRequest $client;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function __construct(
         public readonly string $apiKey,
         public readonly string $url,
         public readonly ?string $organization = null,
+        public readonly array $options = [],
     ) {
         $this->client = Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
             'OpenAI-Organization' => $this->organization,
-        ]))->baseUrl($this->url);
+        ]))
+            ->withOptions($this->options)
+            ->baseUrl($this->url);
     }
 
     /**

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\OpenAI;
 
+use EchoLabs\Prism\Concerns\HasClientOptions;
+use EchoLabs\Prism\Concerns\HasModel;
 use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
@@ -15,35 +17,31 @@ use Throwable;
 
 class OpenAI implements Provider
 {
-    protected Client $client;
+    use HasClientOptions, HasModel;
 
-    protected string $model;
+    protected Client $client;
 
     public function __construct(
         public readonly string $apiKey,
         public readonly string $url,
         public readonly ?string $organization,
-    ) {
-        $this->client = new Client(
+    ) {}
+
+    protected function client(): Client
+    {
+        return new Client(
             apiKey: $this->apiKey,
             url: $this->url,
             organization: $this->organization,
+            options: $this->clientOptions,
         );
-    }
-
-    #[\Override]
-    public function usingModel(string $model): self
-    {
-        $this->model = $model;
-
-        return $this;
     }
 
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
         try {
-            $response = $this->client->messages(
+            $response = $this->client()->messages(
                 model: $this->model,
                 messages: (new MessageMap(
                     $request->messages,

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -27,16 +27,6 @@ class OpenAI implements Provider
         public readonly ?string $organization,
     ) {}
 
-    protected function client(): Client
-    {
-        return new Client(
-            apiKey: $this->apiKey,
-            url: $this->url,
-            organization: $this->organization,
-            options: $this->clientOptions,
-        );
-    }
-
     #[\Override]
     public function text(TextRequest $request): ProviderResponse
     {
@@ -86,6 +76,16 @@ class OpenAI implements Provider
                 'id' => data_get($data, 'id'),
                 'model' => data_get($data, 'model'),
             ]
+        );
+    }
+
+    protected function client(): Client
+    {
+        return new Client(
+            apiKey: $this->apiKey,
+            url: $this->url,
+            organization: $this->organization,
+            options: $this->clientOptions,
         );
     }
 

--- a/src/Rectors/ReorderMethodsRector.php
+++ b/src/Rectors/ReorderMethodsRector.php
@@ -9,7 +9,7 @@ use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ReorderMethodsRector extends AbstractRector
+class ReorderMethodsRector extends AbstractRector
 {
     #[\Override]
     public function getNodeTypes(): array
@@ -96,14 +96,14 @@ CODE_SAMPLE
         );
     }
 
-    private function reorderMethods(array $methods): array
+    protected function reorderMethods(array $methods): array
     {
         usort($methods, fn (ClassMethod $a, ClassMethod $b): int => $this->getMethodWeight($a) <=> $this->getMethodWeight($b));
 
         return $methods;
     }
 
-    private function getMethodWeight(ClassMethod $method): int
+    protected function getMethodWeight(ClassMethod $method): int
     {
         if ($this->isMagicMethod($method)) {
             return 0;
@@ -120,7 +120,7 @@ CODE_SAMPLE
         return 3; // private
     }
 
-    private function isMagicMethod(ClassMethod $method): bool
+    protected function isMagicMethod(ClassMethod $method): bool
     {
         return str_starts_with($method->name->toString(), '__');
     }

--- a/src/Rectors/ReorderMethodsRector.php
+++ b/src/Rectors/ReorderMethodsRector.php
@@ -96,6 +96,10 @@ CODE_SAMPLE
         );
     }
 
+    /**
+     * @param  array<int, ClassMethod>  $methods
+     * @return array<int, ClassMethod>
+     */
     protected function reorderMethods(array $methods): array
     {
         usort($methods, fn (ClassMethod $a, ClassMethod $b): int => $this->getMethodWeight($a) <=> $this->getMethodWeight($b));

--- a/src/Rectors/ReorderMethodsRector.php
+++ b/src/Rectors/ReorderMethodsRector.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace EchoLabs\Prism\Rectors;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ReorderMethodsRector extends AbstractRector
+{
+    #[\Override]
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    #[\Override]
+    public function refactor(Node $node): ?Node
+    {
+        $methods = $node->getMethods();
+
+        if (count($methods) <= 1) {
+            return null;
+        }
+
+        $reorderedMethods = $this->reorderMethods($methods);
+
+        if ($methods === $reorderedMethods) {
+            return null;
+        }
+
+        $node->stmts = array_merge(
+            array_filter($node->stmts, fn ($stmt): bool => ! $stmt instanceof ClassMethod),
+            $reorderedMethods
+        );
+
+        return $node;
+    }
+
+    #[\Override]
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Reorders class methods: magic methods first, then public, protected, and private.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    private function privateMethod()
+    {
+    }
+
+    public function publicMethod()
+    {
+    }
+
+    protected function protectedMethod()
+    {
+    }
+
+    public function __construct()
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct()
+    {
+    }
+
+    public function publicMethod()
+    {
+    }
+
+    protected function protectedMethod()
+    {
+    }
+
+    private function privateMethod()
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    private function reorderMethods(array $methods): array
+    {
+        usort($methods, fn (ClassMethod $a, ClassMethod $b): int => $this->getMethodWeight($a) <=> $this->getMethodWeight($b));
+
+        return $methods;
+    }
+
+    private function getMethodWeight(ClassMethod $method): int
+    {
+        if ($this->isMagicMethod($method)) {
+            return 0;
+        }
+
+        if ($method->isPublic()) {
+            return 1;
+        }
+
+        if ($method->isProtected()) {
+            return 2;
+        }
+
+        return 3; // private
+    }
+
+    private function isMagicMethod(ClassMethod $method): bool
+    {
+        return str_starts_with($method->name->toString(), '__');
+    }
+}

--- a/tests/Providers/OpenAITextTest.php
+++ b/tests/Providers/OpenAITextTest.php
@@ -19,7 +19,8 @@ it('can generate text with a prompt', function (): void {
 
     $response = Prism::text()
         ->using('openai', 'gpt-4')
-        ->withPrompt('Who are you?')();
+        ->withPrompt('Who are you?')
+        ->generate();
 
     expect($response->usage->promptTokens)->toBe(11);
     expect($response->usage->completionTokens)->toBe(67);

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TestDoubles;
+
+use EchoLabs\Prism\Contracts\Provider;
+use EchoLabs\Prism\Enums\FinishReason;
+use EchoLabs\Prism\Providers\ProviderResponse;
+use EchoLabs\Prism\Requests\TextRequest;
+use EchoLabs\Prism\ValueObjects\Usage;
+
+class TestProvider implements Provider
+{
+    public string $model;
+
+    public TextRequest $request;
+
+    /** @var array<string, mixed> */
+    public array $clientOptions;
+
+    /** @var array<int, ProviderResponse> */
+    public array $responses = [];
+
+    public $callCount = 0;
+
+    #[\Override]
+    public function usingModel(string $model): Provider
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function text(TextRequest $request): ProviderResponse
+    {
+        $this->callCount++;
+
+        $this->request = $request;
+
+        return $this->responses[$this->callCount - 1] ?? new ProviderResponse(
+            text: "I'm nyx!",
+            toolCalls: [],
+            usage: new Usage(10, 10),
+            finishReason: FinishReason::Stop,
+            response: ['id' => '123', 'model' => 'claude-3-5-sonnet-20240620']
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    #[\Override]
+    public function withClientOptions(array $options): Provider
+    {
+        $this->clientOptions = $options;
+
+        return $this;
+    }
+
+    public function withResponse(ProviderResponse $response): Provider
+    {
+        $this->responses[] = $response;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, ProviderResponse>  $responses
+     */
+    public function withResponseChain(array $responses): Provider
+    {
+
+        $this->responses = $responses;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Description

Allow for client options to be passed to the provider.

```php
Prism::text()
  ->using(Provider::Ollama, 'qwen2.5')
  ->withClientOptions(['timeout' => '30'])
  ->generate()
```

With client options will accept any of [Guzzle's request options](https://docs.guzzlephp.org/en/stable/request-options.html).