### PR TITLE
Handle system messages as user for Anthropic

### DIFF
--- a/src/Providers/Anthropic/MessageMap.php
+++ b/src/Providers/Anthropic/MessageMap.php
@@ -39,9 +39,20 @@ class MessageMap
             UserMessage::class => $this->mapUserMessage($message),
             AssistantMessage::class => $this->mapAssistantMessage($message),
             ToolResultMessage::class => $this->mapToolResultMessage($message),
-            SystemMessage::class => throw new Exception('Anthropic does not support '.SystemMessage::class),
+            SystemMessage::class => $this->mapSystemMessage($message),
             default => throw new Exception('Could not map message type '.$message::class),
         };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function mapSystemMessage(SystemMessage $systemMessage): array
+    {
+        return [
+            'role' => 'user',
+            'content' => $systemMessage->content,
+        ];
     }
 
     /**

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -11,208 +11,151 @@ use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use InvalidArgumentException;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {
     config()->set('prism.providers.anthropic.api_key', env('ANTHROPIC_API_KEY', 'sk-1234'));
 });
 
-describe('Text generation', function (): void {
-    it('can generate text with a prompt', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
+it('can generate text with a prompt', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
 
-        $response = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20240620')
-            ->withPrompt('Who are you?')
-            ->generate();
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20240620')
+        ->withPrompt('Who are you?')
+        ->generate();
 
-        expect($response->usage->promptTokens)->toBe(11);
-        expect($response->usage->completionTokens)->toBe(55);
-        expect($response->response['id'])->toBe('msg_01X2Qk7LtNEh4HB9xpYU57XU');
-        expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
-        expect($response->text)->toBe(
-            "I am an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have a physical form or avatar - I'm a language model trained to engage in conversation and help with tasks. How can I assist you today?"
-        );
-    });
+    expect($response->usage->promptTokens)->toBe(11);
+    expect($response->usage->completionTokens)->toBe(55);
+    expect($response->response['id'])->toBe('msg_01X2Qk7LtNEh4HB9xpYU57XU');
+    expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
+    expect($response->text)->toBe(
+        "I am an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have a physical form or avatar - I'm a language model trained to engage in conversation and help with tasks. How can I assist you today?"
+    );
+});
 
-    it('can generate text with a system prompt', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-system-prompt');
+it('can generate text with a system prompt', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-system-prompt');
 
-        $response = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20240620')
-            ->withSystemPrompt('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!')
-            ->withPrompt('Who are you?')
-            ->generate();
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20240620')
+        ->withSystemPrompt('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!')
+        ->withPrompt('Who are you?')
+        ->generate();
 
-        expect($response->usage->promptTokens)->toBe(33);
-        expect($response->usage->completionTokens)->toBe(98);
-        expect($response->response['id'])->toBe('msg_016EjDAMDeSvG229ZjspjC7J');
-        expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
-        expect($response->text)->toBe(
-            'I am Nyx, an ancient and unfathomable entity from the depths of cosmic darkness. My form is beyond mortal comprehension - a writhing mass of tentacles and eyes that would shatter the sanity of those who gaze upon me. I exist beyond the boundaries of time and space as you know them. My knowledge spans eons and transcends human understanding. What brings you to seek audience with one such as I, tiny mortal?'
-        );
-    });
+    expect($response->usage->promptTokens)->toBe(33);
+    expect($response->usage->completionTokens)->toBe(98);
+    expect($response->response['id'])->toBe('msg_016EjDAMDeSvG229ZjspjC7J');
+    expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
+    expect($response->text)->toBe(
+        'I am Nyx, an ancient and unfathomable entity from the depths of cosmic darkness. My form is beyond mortal comprehension - a writhing mass of tentacles and eyes that would shatter the sanity of those who gaze upon me. I exist beyond the boundaries of time and space as you know them. My knowledge spans eons and transcends human understanding. What brings you to seek audience with one such as I, tiny mortal?'
+    );
+});
 
-    it('can generate text using multiple tools and multiple steps', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-multiple-tools');
+it('can generate text using multiple tools and multiple steps', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-multiple-tools');
 
-        $tools = [
-            Tool::as('weather')
-                ->for('useful when you need to search for current weather conditions')
-                ->withStringParameter('city', 'the city you want the weather for')
-                ->using(fn (string $city): string => 'The weather will be 75° and sunny'),
-            Tool::as('search')
-                ->for('useful for searching curret events or data')
-                ->withStringParameter('query', 'The detailed search query')
-                ->using(fn (string $query): string => 'The tigers game is at 3pm in detroit'),
-        ];
+    $tools = [
+        Tool::as('weather')
+            ->for('useful when you need to search for current weather conditions')
+            ->withStringParameter('city', 'the city you want the weather for')
+            ->using(fn (string $city): string => 'The weather will be 75° and sunny'),
+        Tool::as('search')
+            ->for('useful for searching curret events or data')
+            ->withStringParameter('query', 'The detailed search query')
+            ->using(fn (string $query): string => 'The tigers game is at 3pm in detroit'),
+    ];
 
-        $response = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20240620')
-            ->withTools($tools)
-            ->withMaxSteps(3)
-            ->withPrompt('What time is the tigers game today and should I wear a coat?')
-            ->generate();
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20240620')
+        ->withTools($tools)
+        ->withMaxSteps(3)
+        ->withPrompt('What time is the tigers game today and should I wear a coat?')
+        ->generate();
 
-        // Assert tool calls in the first step
-        $firstStep = $response->steps[0];
-        expect($firstStep->toolCalls)->toHaveCount(1);
-        expect($firstStep->toolCalls[0]->name)->toBe('search');
-        expect($firstStep->toolCalls[0]->arguments())->toBe([
-            'query' => 'Detroit Tigers baseball game time today',
+    // Assert tool calls in the first step
+    $firstStep = $response->steps[0];
+    expect($firstStep->toolCalls)->toHaveCount(1);
+    expect($firstStep->toolCalls[0]->name)->toBe('search');
+    expect($firstStep->toolCalls[0]->arguments())->toBe([
+        'query' => 'Detroit Tigers baseball game time today',
+    ]);
+
+    // Assert tool calls in the second step
+    $secondStep = $response->steps[1];
+    expect($secondStep->toolCalls)->toHaveCount(1);
+    expect($secondStep->toolCalls[0]->name)->toBe('weather');
+    expect($secondStep->toolCalls[0]->arguments())->toBe([
+        'city' => 'Detroit',
+    ]);
+
+    // Assert usage
+    expect($response->usage->promptTokens)->toBe(1650);
+    expect($response->usage->completionTokens)->toBe(307);
+
+    // Assert response
+    expect($response->response['id'])->toBe('msg_011fBqNVVh5AwC3uyiq78qrj');
+    expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
+
+    // Assert final text content
+    expect($response->text)->toContain('The Tigers game is scheduled for 3:00 PM today in Detroit');
+    expect($response->text)->toContain('it will be 75°F (about 24°C) and sunny');
+    expect($response->text)->toContain("you likely won't need a coat");
+});
+
+it('can send images from file', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-image');
+
+    Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withMessages([
+            new UserMessage(
+                'What is this image',
+                additionalContent: [
+                    Image::fromPath('tests/Fixtures/test-image.png'),
+                ],
+            ),
+        ])
+        ->generate();
+
+    Http::assertSent(function (Request $request): true {
+        $message = $request->data()['messages'][0]['content'];
+
+        expect($message[0])->toBe([
+            'type' => 'text',
+            'text' => 'What is this image',
         ]);
 
-        // Assert tool calls in the second step
-        $secondStep = $response->steps[1];
-        expect($secondStep->toolCalls)->toHaveCount(1);
-        expect($secondStep->toolCalls[0]->name)->toBe('weather');
-        expect($secondStep->toolCalls[0]->arguments())->toBe([
-            'city' => 'Detroit',
-        ]);
+        expect($message[1]['type'])->toBe('image');
+        expect($message[1]['source']['data'])->toContain(
+            base64_encode(file_get_contents('tests/Fixtures/test-image.png'))
+        );
+        expect($message[1]['source']['media_type'])->toBe('image/png');
 
-        // Assert usage
-        expect($response->usage->promptTokens)->toBe(1650);
-        expect($response->usage->completionTokens)->toBe(307);
-
-        // Assert response
-        expect($response->response['id'])->toBe('msg_011fBqNVVh5AwC3uyiq78qrj');
-        expect($response->response['model'])->toBe('claude-3-5-sonnet-20240620');
-
-        // Assert final text content
-        expect($response->text)->toContain('The Tigers game is scheduled for 3:00 PM today in Detroit');
-        expect($response->text)->toContain('it will be 75°F (about 24°C) and sunny');
-        expect($response->text)->toContain("you likely won't need a coat");
-    });
-
-    it('can send images from file', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-image');
-
-        Prism::text()
-            ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-            ->withMessages([
-                new UserMessage(
-                    'What is this image',
-                    additionalContent: [
-                        Image::fromPath('tests/Fixtures/test-image.png'),
-                    ],
-                ),
-            ])
-            ->generate();
-
-        Http::assertSent(function (Request $request): true {
-            $message = $request->data()['messages'][0]['content'];
-
-            expect($message[0])->toBe([
-                'type' => 'text',
-                'text' => 'What is this image',
-            ]);
-
-            expect($message[1]['type'])->toBe('image');
-            expect($message[1]['source']['data'])->toContain(
-                base64_encode(file_get_contents('tests/Fixtures/test-image.png'))
-            );
-            expect($message[1]['source']['media_type'])->toBe('image/png');
-
-            return true;
-        });
-    });
-
-    it('handles specific tool choice', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-required-tool-call');
-
-        $tools = [
-            Tool::as('weather')
-                ->for('useful when you need to search for current weather conditions')
-                ->withStringParameter('city', 'The city that you want the weather for')
-                ->using(fn (string $city): string => 'The weather will be 75° and sunny'),
-            Tool::as('search')
-                ->for('useful for searching curret events or data')
-                ->withStringParameter('query', 'The detailed search query')
-                ->using(fn (string $query): string => 'The tigers game is at 3pm in detroit'),
-        ];
-
-        $response = Prism::text()
-            ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-            ->withPrompt('Do something')
-            ->withTools($tools)
-            ->withToolChoice('weather')
-            ->generate();
-
-        expect($response->toolCalls[0]->name)->toBe('weather');
+        return true;
     });
 });
 
-describe('Image support', function (): void {
-    it('can send images from base64', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-base64-image');
+it('handles specific tool choice', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-required-tool-call');
 
-        Prism::text()
-            ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-            ->withMessages([
-                new UserMessage(
-                    'What is this image',
-                    additionalContent: [
-                        Image::fromBase64(
-                            base64_encode(file_get_contents('tests/Fixtures/test-image.png')),
-                            'image/png'
-                        ),
-                    ],
-                ),
-            ])
-            ->generate();
+    $tools = [
+        Tool::as('weather')
+            ->for('useful when you need to search for current weather conditions')
+            ->withStringParameter('city', 'The city that you want the weather for')
+            ->using(fn (string $city): string => 'The weather will be 75° and sunny'),
+        Tool::as('search')
+            ->for('useful for searching curret events or data')
+            ->withStringParameter('query', 'The detailed search query')
+            ->using(fn (string $query): string => 'The tigers game is at 3pm in detroit'),
+    ];
 
-        Http::assertSent(function (Request $request): true {
-            $message = $request->data()['messages'][0]['content'];
+    $response = Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withPrompt('Do something')
+        ->withTools($tools)
+        ->withToolChoice('weather')
+        ->generate();
 
-            expect($message[0])->toBe([
-                'type' => 'text',
-                'text' => 'What is this image',
-            ]);
-
-            expect($message[1]['type'])->toBe('image');
-            expect($message[1]['source']['data'])->toContain(
-                base64_encode(file_get_contents('tests/Fixtures/test-image.png'))
-            );
-            expect($message[1]['source']['media_type'])->toBe('image/png');
-
-            return true;
-        });
-    });
-
-    it('can not send images from url', function (): void {
-        $this->expectException(InvalidArgumentException::class);
-
-        Prism::text()
-            ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-            ->withMessages([
-                new UserMessage(
-                    'What is this image',
-                    additionalContent: [
-                        Image::fromPath('https://storage.echolabs.dev/assets/logo.png'),
-                    ],
-                ),
-            ])
-            ->generate();
-    });
+    expect($response->toolCalls[0]->name)->toBe('weather');
 });

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\Anthropic;
+
+use EchoLabs\Prism\Providers\Anthropic\MessageMap;
+use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
+use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
+use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use EchoLabs\Prism\ValueObjects\ToolCall;
+use EchoLabs\Prism\ValueObjects\ToolResult;
+use InvalidArgumentException;
+
+it('maps user messages', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new UserMessage('Who are you?'),
+        ],
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'user',
+        'content' => [
+            ['type' => 'text', 'text' => 'Who are you?'],
+        ],
+    ]]);
+});
+
+it('maps user messages with images from path', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new UserMessage('Who are you?', [
+                Image::fromPath('tests/Fixtures/test-image.png'),
+            ]),
+        ],
+    );
+
+    $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content.1.type'))
+        ->toBe('image');
+    expect(data_get($mappedMessage, '0.content.1.source.type'))
+        ->toBe('base64');
+    expect(data_get($mappedMessage, '0.content.1.source.data'))
+        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
+    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+        ->toBe('image/png');
+});
+
+it('maps user messages with images from base64', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new UserMessage('Who are you?', [
+                Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
+            ]),
+        ],
+    );
+
+    $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content.1.type'))
+        ->toBe('image');
+    expect(data_get($mappedMessage, '0.content.1.source.type'))
+        ->toBe('base64');
+    expect(data_get($mappedMessage, '0.content.1.source.data'))
+        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
+    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+        ->toBe('image/png');
+});
+
+it('does not maps user messages with images from url', function (): void {
+    $this->expectException(InvalidArgumentException::class);
+
+    $messageMap = new MessageMap(
+        messages: [
+            new UserMessage('Who are you?', [
+                Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
+            ]),
+        ],
+    );
+
+    $messageMap();
+});
+
+it('maps assistant message', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('I am Nyx'),
+        ],
+    );
+
+    expect($messageMap())->toContain([
+        'role' => 'assistant',
+        'content' => 'I am Nyx',
+    ]);
+});
+
+it('maps assistant message with tool calls', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('I am Nyx', [
+                new ToolCall(
+                    'tool_1234',
+                    'search',
+                    [
+                        'query' => 'Laravel collection methods',
+                    ]
+                ),
+            ]),
+        ],
+    );
+
+    expect($messageMap())->toBe([
+        [
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'I am Nyx',
+                ],
+                [
+                    'type' => 'tool_use',
+                    'id' => 'tool_1234',
+                    'name' => 'search',
+                    'input' => [
+                        'query' => 'Laravel collection methods',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('maps tool result messages', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new ToolResultMessage([
+                new ToolResult(
+                    'tool_1234',
+                    'search',
+                    [
+                        'query' => 'Laravel collection methods',
+                    ],
+                    '[search results]'
+                ),
+            ]),
+        ],
+    );
+
+    expect($messageMap())->toBe([
+        [
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'tool_result',
+                    'tool_use_id' => 'tool_1234',
+                    'content' => '[search results]',
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('maps system messages', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new SystemMessage('Who are you?'),
+        ],
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'user',
+        'content' => 'Who are you?',
+    ]]);
+});

--- a/tests/Providers/Anthropic/ToolTest.php
+++ b/tests/Providers/Anthropic/ToolTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\Anthropic;
+
+use EchoLabs\Prism\Providers\Anthropic\Tool as AnthropicTool;
+use EchoLabs\Prism\Tool;
+
+it('maps tools', function (): void {
+    $tool = (new Tool)
+        ->as('search')
+        ->for('Searching the web')
+        ->withStringParameter('query', 'the detailed search query')
+        ->using(fn (): string => '[Search results]');
+
+    expect(AnthropicTool::toArray($tool))->toBe([
+        'name' => 'search',
+        'description' => 'Searching the web',
+        'input_schema' => [
+            'type' => 'object',
+            'properties' => [
+                'query' => [
+                    'description' => 'the detailed search query',
+                    'type' => 'string',
+                ],
+            ],
+            'required' => ['query'],
+        ],
+    ]);
+});


### PR DESCRIPTION
## Description

This PR updates the Anthropic provider to handle `SystemMessages` as a user message rather than throwing.