### PR TITLE
Proxy retry call to Laravel HTTP client

### DIFF
--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -132,6 +132,10 @@ The value is passed through to the provider. The range depends on the provider a
 
 Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http-client#main-content). You can use this method to pass any of Guzzles [request options](https://docs.guzzlephp.org/en/stable/request-options.html) e.g. `->withClientOptions(['timeout' => 30])`.
 
+`withClientRetry`
+
+Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http-client#main-content). You can use this method to set [retries](https://laravel.com/docs/11.x/http-client#retries) e.g. `->withClientRetry(3, 100)`.
+
 ## Response Handling
 
 The response object provides rich access to the generation results:

--- a/src/Concerns/BuildsTextRequests.php
+++ b/src/Concerns/BuildsTextRequests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Concerns;
 
+use Closure;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Enums\ToolChoice;
@@ -12,14 +13,13 @@ use EchoLabs\Prism\Text\Request;
 use EchoLabs\Prism\Tool;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Contracts\View\View;
-use Closure;
 
 trait BuildsTextRequests
 {
     /** @var array<string, mixed> */
     protected array $clientOptions = [];
 
-    /** @var array<mixed> */
+    /** @var array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool} */
     protected array $clientRetry = [0];
 
     protected ?string $prompt = null;
@@ -144,8 +144,12 @@ trait BuildsTextRequests
     /**
      * @param  array<int>|int  $times
      */
-    public function withClientRetry(array|int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true): self
-    {
+    public function withClientRetry(
+        array|int $times,
+        Closure|int $sleepMilliseconds = 0,
+        ?callable $when = null,
+        bool $throw = true
+    ): self {
         $this->clientRetry = [$times, $sleepMilliseconds, $when, $throw];
 
         return $this;

--- a/src/Concerns/BuildsTextRequests.php
+++ b/src/Concerns/BuildsTextRequests.php
@@ -12,11 +12,15 @@ use EchoLabs\Prism\Text\Request;
 use EchoLabs\Prism\Tool;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Contracts\View\View;
+use Closure;
 
 trait BuildsTextRequests
 {
     /** @var array<string, mixed> */
     protected array $clientOptions = [];
+
+    /** @var array<mixed> */
+    protected array $clientRetry = [0];
 
     protected ?string $prompt = null;
 
@@ -137,6 +141,16 @@ trait BuildsTextRequests
         return $this;
     }
 
+    /**
+     * @param  array<int>|int  $times
+     */
+    public function withClientRetry(array|int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true): self
+    {
+        $this->clientRetry = [$times, $sleepMilliseconds, $when, $throw];
+
+        return $this;
+    }
+
     public function withToolChoice(string|ToolChoice|Tool $toolChoice): self
     {
         $this->toolChoice = $toolChoice instanceof Tool
@@ -158,6 +172,7 @@ trait BuildsTextRequests
             topP: $this->topP,
             tools: $this->tools,
             clientOptions: $this->clientOptions,
+            clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
         );
     }

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -21,21 +21,23 @@ class Anthropic implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders([
             'x-api-key' => $this->apiKey,
             'anthropic-version' => $this->apiVersion,
         ])
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl('https://api.anthropic.com/v1');
     }
 }

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -21,20 +21,22 @@ class Groq implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
         ]))
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl($this->url);
     }
 }

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -21,20 +21,22 @@ class Mistral implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
         ]))
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl($this->url);
     }
 }

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -21,20 +21,22 @@ class Ollama implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
         ]))
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl($this->url);
     }
 }

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -22,21 +22,23 @@ class OpenAI implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
             'OpenAI-Organization' => $this->organization,
         ]))
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl($this->url);
     }
 }

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -21,20 +21,22 @@ class XAI implements Provider
     #[\Override]
     public function text(Request $request): ProviderResponse
     {
-        $handler = new Text($this->client($request->clientOptions));
+        $handler = new Text($this->client($request->clientOptions, $request->clientRetry));
 
         return $handler->handle($request);
     }
 
     /**
      * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options = []): PendingRequest
+    protected function client(array $options = [], array $retry = []): PendingRequest
     {
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
         ]))
             ->withOptions($options)
+            ->retry(...$retry)
             ->baseUrl($this->url);
     }
 }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -14,6 +14,7 @@ class Request
      * @param  array<int, Message>  $messages
      * @param  array<int, Tool>  $tools
      * @param  array<string, mixed>  $clientOptions
+     * @param  array<mixed>  $clientRetry
      */
     public function __construct(
         public readonly string $model,
@@ -25,6 +26,7 @@ class Request
         public readonly int|float|null $topP,
         public readonly array $tools,
         public readonly array $clientOptions,
+        public readonly array $clientRetry,
         public readonly string|ToolChoice|null $toolChoice,
     ) {}
 }

--- a/tests/Generators/TextGeneratorTest.php
+++ b/tests/Generators/TextGeneratorTest.php
@@ -43,6 +43,31 @@ it('allows for client options', function (): void {
     expect($provider->request->clientOptions)->toBe(['timeout' => '100']);
 });
 
+it('allows for client retry', function (): void {
+    $provider = new TestProvider;
+
+    resolve(PrismManager::class)->extend('test', fn (): \Tests\TestDoubles\TestProvider => $provider);
+
+    (new Generator)
+        ->using('test', 'claude-3-5-sonnet-20240620')
+        ->withClientRetry(3, 100)
+        ->generate();
+
+    expect($provider->request->clientRetry)->toBe([3, 100, null, true]);
+});
+
+it('defaults to no client retry', function (): void {
+    $provider = new TestProvider;
+
+    resolve(PrismManager::class)->extend('test', fn (): \Tests\TestDoubles\TestProvider => $provider);
+
+    (new Generator)
+        ->using('test', 'claude-3-5-sonnet-20240620')
+        ->generate();
+
+    expect($provider->request->clientRetry)->toBe([0]);
+});
+
 it('allows for provider string or enum', function (): void {
     $provider = new TestProvider;
 

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -17,6 +17,9 @@ class TestProvider implements Provider
     /** @var array<string, mixed> */
     public array $clientOptions;
 
+    /** @var array<mixed> */
+    public array $clientRetry;
+
     /** @var array<int, ProviderResponse> */
     public array $responses = [];
 


### PR DESCRIPTION
Allow for client retry to be passed to Laravel HTTP wrapper (https://laravel.com/docs/11.x/http-client#retries).

```php
Prism::text()
  ->using(Provider::Anthropic, 'claude-3-5-sonnet-20240620')
  ->withClientRetry(3, 100)
  ->generate()
```

or

```php
Prism::text()
  ->using(Provider::Anthropic, 'claude-3-5-sonnet-20240620')
  ->withClientRetry(3, 100, function (Exception $exception, PendingRequest $request) {
    // 529 - overloaded_error: Anthropic's API is temporarily overloaded.
    // https://docs.anthropic.com/en/api/errors
    return $exception->getCode() === 529;
  })
  ->generate()
```