### PR TITLE
Dynamic provider config

### DIFF
--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -114,6 +114,9 @@ Structured output supports all the same options as text generation, including:
 - Message history
 - Tools and function calling
 - System prompts
+- withClientOptions
+- withClientRetry
+- usingProviderConfig
 
 See the [Text Generation](./text-generation.md) documentation for details on these common settings.
 

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -199,4 +199,7 @@ $fake->assertRequest(function ($requests) {
     expect($requests[0]->provider)->toBe('anthropic');
     expect($requests[0]->model)->toBe('claude-3-sonnet');
 });
+
+// Assert provider configuration
+$fake->assertProviderConfig(['api_key' => 'sk-1234']);
 ```

--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -137,6 +137,10 @@ Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http
 
 Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http-client#main-content). You can use this method to set [retries](https://laravel.com/docs/11.x/http-client#retries) e.g. `->withClientRetry(3, 100)`.
 
+`usingClientConfig`
+
+This allows for complete or partial override of the providers configuration. This is great for multi-tenant applications where users supply their own API keys. These values are merged with the original configuration allowing for partial or complete config override.
+
 ## Response Handling
 
 The response object provides rich access to the generation results:

--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -137,7 +137,7 @@ Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http
 
 Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http-client#main-content). You can use this method to set [retries](https://laravel.com/docs/11.x/http-client#retries) e.g. `->withClientRetry(3, 100)`.
 
-`usingClientConfig`
+`usingProviderConfig`
 
 This allows for complete or partial override of the providers configuration. This is great for multi-tenant applications where users supply their own API keys. These values are merged with the original configuration allowing for partial or complete config override.
 

--- a/src/Concerns/BuildsTextRequests.php
+++ b/src/Concerns/BuildsTextRequests.php
@@ -46,6 +46,9 @@ trait BuildsTextRequests
 
     protected string $model;
 
+    /** @var array<string, mixed> */
+    protected array $providerConfig = [];
+
     /** @var array<string, array<string, mixed>> */
     protected $providerMeta = [];
 
@@ -193,5 +196,15 @@ trait BuildsTextRequests
             toolChoice: $this->toolChoice,
             providerMeta: $this->providerMeta,
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function usingProviderConfig(array $config): self
+    {
+        $this->providerConfig = $config;
+
+        return $this;
     }
 }

--- a/src/Prism.php
+++ b/src/Prism.php
@@ -27,8 +27,10 @@ class Prism
                 private readonly PrismFake $fake
             ) {}
 
-            public function resolve(ProviderEnum|string $name): Provider
+            public function resolve(ProviderEnum|string $name, array $providerConfig = []): Provider
             {
+                $this->fake->setProviderConfig($providerConfig);
+
                 return $this->fake;
             }
         });

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -35,7 +35,7 @@ class PrismManager
     {
         $name = $this->resolveName($name);
 
-        $config = array_merge($this->getConfig($name) ?? [], $providerConfig);
+        $config = array_merge($this->getConfig($name), $providerConfig);
 
         if (isset($this->customCreators[$name])) {
             return $this->callCustomCreator($name, $config);
@@ -129,15 +129,11 @@ class PrismManager
     }
 
     /**
-     * @return null|array<string, mixed>
+     * @return array<string, mixed>
      */
-    protected function getConfig(string $name): ?array
+    protected function getConfig(string $name): array
     {
-        if ($name !== '' && $name !== '0') {
-            return config("prism.providers.{$name}");
-        }
-
-        return ['driver' => 'null'];
+        return config("prism.providers.{$name}", []);
     }
 
     /**

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -27,13 +27,15 @@ class PrismManager
     ) {}
 
     /**
+     * @param  array<string, mixed>  $providerConfig
+     *
      * @throws InvalidArgumentException
      */
-    public function resolve(ProviderEnum|string $name): Provider
+    public function resolve(ProviderEnum|string $name, array $providerConfig = []): Provider
     {
         $name = $this->resolveName($name);
 
-        $config = $this->getConfig($name) ?? [];
+        $config = array_merge($this->getConfig($name) ?? [], $providerConfig);
 
         if (isset($this->customCreators[$name])) {
             return $this->callCustomCreator($name, $config);

--- a/src/Structured/Generator.php
+++ b/src/Structured/Generator.php
@@ -97,7 +97,7 @@ class Generator
     protected function sendProviderRequest(): ProviderResponse
     {
         $response = resolve(PrismManager::class)
-            ->resolve($this->provider)
+            ->resolve($this->provider, $this->providerConfig)
             ->structured($this->structuredRequest());
 
         $responseMessage = new AssistantMessage(

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -24,6 +24,8 @@ class PrismFake implements Provider
     /** @var array<int, StructuredRequest|TextRequest|EmbeddingRequest> */
     protected array $recorded = [];
 
+    protected $providerConfig = [];
+
     /**
      * @param  array<int, ProviderResponse|EmbeddingResponse>  $responses
      */
@@ -69,6 +71,14 @@ class PrismFake implements Provider
     }
 
     /**
+     * @param  array<string, mixed>  $config
+     */
+    public function setProviderConfig(array $config): void
+    {
+        $this->providerConfig = $config;
+    }
+
+    /**
      * @param  Closure(array<int, StructuredRequest|TextRequest|EmbeddingRequest>):void  $fn
      */
     public function assertRequest(Closure $fn): void
@@ -86,6 +96,14 @@ class PrismFake implements Provider
         PHPUnit::assertTrue(
             $prompts->contains($prompt),
             "Could not find the prompt {$prompt} in the recorded requests"
+        );
+    }
+
+    public function assertProviderConfig(array $providerConfig): void
+    {
+        PHPUnit::assertEqualsCanonicalizing(
+            $providerConfig,
+            $this->providerConfig
         );
     }
 

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -24,6 +24,7 @@ class PrismFake implements Provider
     /** @var array<int, StructuredRequest|TextRequest|EmbeddingRequest> */
     protected array $recorded = [];
 
+    /** @var array<string, mixed> */
     protected $providerConfig = [];
 
     /**
@@ -99,6 +100,9 @@ class PrismFake implements Provider
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $providerConfig
+     */
     public function assertProviderConfig(array $providerConfig): void
     {
         PHPUnit::assertEqualsCanonicalizing(

--- a/src/Text/Generator.php
+++ b/src/Text/Generator.php
@@ -50,7 +50,7 @@ class Generator
     protected function sendProviderRequest(): ProviderResponse
     {
         $response = resolve(PrismManager::class)
-            ->resolve($this->provider)
+            ->resolve($this->provider, $this->providerConfig)
             ->text($this->textRequest());
 
         $responseMessage = new AssistantMessage(

--- a/tests/PrismManagerTest.php
+++ b/tests/PrismManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use EchoLabs\Prism\Contracts\Provider as ContractsProvider;
 use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\PrismManager;
 use EchoLabs\Prism\Providers\Anthropic\Anthropic;
@@ -11,6 +12,8 @@ use EchoLabs\Prism\Providers\Mistral\Mistral;
 use EchoLabs\Prism\Providers\Ollama\Ollama;
 use EchoLabs\Prism\Providers\OpenAI\OpenAI;
 use EchoLabs\Prism\Providers\XAI\XAI;
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
 
 it('can resolve Anthropic', function (): void {
     $manager = new PrismManager($this->app);
@@ -45,4 +48,16 @@ it('can resolve XAI', function (): void {
 
     expect($manager->resolve(Provider::XAI))->toBeInstanceOf(XAI::class);
     expect($manager->resolve('xai'))->toBeInstanceOf(XAI::class);
+});
+
+it('allows for custom provider configuration', function (): void {
+    $manager = new PrismManager($this->app);
+
+    $manager->extend('test', function (Application $app, array $config) {
+        expect($config)->toBe(['api_key' => '1234']);
+
+        return Mockery::mock(ContractsProvider::class);
+    });
+
+    $manager->resolve('test', ['api_key' => '1234']);
 });

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -122,3 +122,23 @@ it("throws an exception when it can't runs out of responses", function (): void 
         ->withPrompt('What is the meaning of life?')
         ->generate();
 });
+
+it('asserts provider config', function (): void {
+    $fake = Prism::fake([
+        new ProviderResponse(
+            text: 'The meaning of life is 42',
+            toolCalls: [],
+            usage: new Usage(42, 42),
+            finishReason: FinishReason::Stop,
+            response: ['id' => 'cpl_1234', 'model' => 'claude-3-sonnet'],
+        ),
+    ]);
+
+    Prism::text()
+        ->using('anthropic', 'claude-3-sonnet')
+        ->withPrompt('What is the meaning of life?')
+        ->usingProviderConfig(['api_key' => '1234'])
+        ->generate();
+
+    $fake->assertProviderConfig(['api_key' => '1234']);
+});


### PR DESCRIPTION
## Description

Closes #92 

This PR adds support for overriding / updating the provider configuration on the fly. This is great for multi-tenant situations where users may bring their own API keys.

```php
Prism::text()
    ->usingProviderConfig(['api_key' => '1234']);

Prism::structured()
    ->usingProviderConfig(['api_key' => '1234']);
```

These values are merged with the original provider config values so partial overrides are possible.