### PR TITLE
Anthropic: allow for multiple system prompts

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -27,7 +27,12 @@ While Anthropic models don't have native JSON mode or structured output like som
 ## Limitations
 ### Messages
 
-Does not support the `SystemMessage` message type, we automatically convert `SystemMessage` to `UserMessage`.
+Most providers' API include system messages in the messages array with a "system" role. Anthropic does not support the system role, and instead has a "system" property, separate from messages.
+
+Therefore, for Anthropic we:
+* Filter all `SystemMessage`s out, omitting them from messages.
+* Always submit the prompt defined with `->withSystemPrompt()` at the top of the system prompts array.
+* Move all `SystemMessage`s to the system prompts array in the order they were declared.
 
 ### Images
 

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -67,7 +67,7 @@ class Structured
                 'messages' => MessageMap::map($request->messages),
                 'max_tokens' => $request->maxTokens ?? 2048,
             ], array_filter([
-                'system' => $request->systemPrompt,
+                'system' => MessageMap::mapSystemMessages($request->messages, $request->systemPrompt),
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,
                 'tools' => ToolMap::map($request->tools),

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -65,7 +65,7 @@ class Text
                 'messages' => MessageMap::map($request->messages),
                 'max_tokens' => $request->maxTokens ?? 2048,
             ], array_filter([
-                'system' => $request->systemPrompt,
+                'system' => MessageMap::mapSystemMessages($request->messages, $request->systemPrompt),
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,
                 'tools' => ToolMap::map($request->tools),

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -23,7 +23,26 @@ class MessageMap
      */
     public static function map(array $messages): array
     {
-        return array_map(fn (Message $message): array => self::mapMessage($message), $messages);
+        return array_values(array_map(
+            fn (Message $message): array => self::mapMessage($message),
+            array_filter($messages, fn (Message $message): bool => !$message instanceof SystemMessage)
+        ));
+    }
+    
+    /**
+     * @param  array<int, Message>  $messages
+     * @param null|string    $systemPrompt
+     * @return array<int, mixed>
+     */
+    public static function mapSystemMessages(array $messages, ?string $systemPrompt): array
+    {
+        return array_values(array_merge(
+            $systemPrompt !== null ? [self::mapSystemMessage(new SystemMessage($systemPrompt))] : [],
+            array_map(
+                fn (Message $message): array => self::mapMessage($message),
+                array_filter($messages, fn (Message $message): bool => $message instanceof SystemMessage)
+            )
+        ));
     }
 
     /**
@@ -46,8 +65,8 @@ class MessageMap
     protected static function mapSystemMessage(SystemMessage $systemMessage): array
     {
         return [
-            'role' => 'user',
-            'content' => $systemMessage->content,
+            'type' => 'text',
+            'text' => $systemMessage->content,
         ];
     }
 

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -25,13 +25,12 @@ class MessageMap
     {
         return array_values(array_map(
             fn (Message $message): array => self::mapMessage($message),
-            array_filter($messages, fn (Message $message): bool => !$message instanceof SystemMessage)
+            array_filter($messages, fn (Message $message): bool => ! $message instanceof SystemMessage)
         ));
     }
-    
+
     /**
      * @param  array<int, Message>  $messages
-     * @param null|string    $systemPrompt
      * @return array<int, mixed>
      */
     public static function mapSystemMessages(array $messages, ?string $systemPrompt): array

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -28,7 +28,7 @@ it('maps user messages', function (): void {
 it('filters system messages out when calling map', function (): void {
     expect(MessageMap::map([
         new UserMessage('Who are you?'),
-        new SystemMessage('I am Groot.')
+        new SystemMessage('I am Groot.'),
     ]))->toBe([[
         'role' => 'user',
         'content' => [
@@ -159,6 +159,6 @@ it('maps system messages', function (): void {
         [
             'type' => 'text',
             'text' => 'Who are you?',
-        ]
+        ],
     ]);
 });

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -25,6 +25,18 @@ it('maps user messages', function (): void {
     ]]);
 });
 
+it('filters system messages out when calling map', function (): void {
+    expect(MessageMap::map([
+        new UserMessage('Who are you?'),
+        new SystemMessage('I am Groot.')
+    ]))->toBe([[
+        'role' => 'user',
+        'content' => [
+            ['type' => 'text', 'text' => 'Who are you?'],
+        ],
+    ]]);
+});
+
 it('maps user messages with images from path', function (): void {
     $mappedMessage = MessageMap::map([
         new UserMessage('Who are you?', [
@@ -136,10 +148,17 @@ it('maps tool result messages', function (): void {
 });
 
 it('maps system messages', function (): void {
-    expect(MessageMap::map([
-        new SystemMessage('Who are you?'),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => 'Who are you?',
-    ]]);
+    expect(MessageMap::mapSystemMessages(
+        [new SystemMessage('Who are you?'), new UserMessage('I am rocket.')],
+        'I am Thanos. Me first.'
+    ))->toBe([
+        [
+            'type' => 'text',
+            'text' => 'I am Thanos. Me first.',
+        ],
+        [
+            'type' => 'text',
+            'text' => 'Who are you?',
+        ]
+    ]);
 });


### PR DESCRIPTION
Most providers' API include system messages in the messages array with a "system" role, and allow you to make multiple. Anthropic does not support the system role, and instead has a "system" property, separate from messages.

Prism currently allows for one system prompt via `->withSystemPrompt()`, and converts all `SystemMessage`s into `UserMessage`s. 

It is not well documented, but the system property allows for an array of system prompts. See for instance [the example in the prompt caching docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching). I have validated that this works.

This PR:
* Filters out all `SystemMessage`s from the main map, therefore omitting them from messages.
* Moves the system property to the array of prompts format.
* Always submits the prompt defined with `->withSystemPrompt()` at the top of the system prompts array (same behaviour as other providers implementations, which puts it at the top of the messages array).
* Move all `SystemMessage`s to the system prompts array in the order they were declared.

**Why is this needed?**

Primarily because Anthropic prompt caching supports system prompts but requires you to use the array format to specify the cache_control property. This is therefore a precursor to implementing prompt caching.

**Why not just move to an array format, with a single system prompt?**

* If your system prompt has a cacheable part, and un uncacheable part, you need to split it into two prompts.
* When it comes to implementing prompt caching, by treating `SystemMessage`s correctly as system prompts, you would be able to use the same API for both system prompts and user prompts. E.g. (making some assumptions about the desired API):

```
->withMessages([
    (new SystemMessage('Cache me'))->withProviderMeta(Provider::Anthropic, ['cache_control' => ['type' => 'ephemeral']]),
    (new UserMessage('Cache me too'))->withProviderMeta(Provider::Anthropic, ['cache_control' => ['type' => 'ephemeral']]),
    new UserMessage('Please do not cache me')
])
```

**Is this a breaking change?**

Kind of, but not really! 

If you were using SystemMessages before, they would have been submitted as UserMessages in the order that they were defined (i.e. potentially between UserMessages). SystemMessages would now still be sent in the correct order compared to each other, but are taken out of the context of the UserMessages.

However, given the docs currently state that all SystemMessages are converted to UserMessages, I cannot imagine many (if any) people are doing this.

This is also really a limitation of Anthropic's API implementation, which doesn't allow you to place system prompts between other prompts.