### PR TITLE
Rename object to structured for structured response

### DIFF
--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -30,7 +30,7 @@ $response = Prism::structured()
     ->generate();
 
 // Access your structured data
-$review = $response->object;
+$review = $response->structured;
 echo $review['title'];    // "Inception"
 echo $review['rating'];   // "5 stars"
 echo $review['summary'];  // "A mind-bending..."
@@ -81,7 +81,7 @@ $response = Prism::structured()
     ->generate();
 
 // Access the structured data as a PHP array
-$data = $response->object;
+$data = $response->structured;
 
 // Get the raw response text if needed
 echo $response->text;
@@ -100,11 +100,11 @@ $rawResponse = $response->response;
 > [!TIP]
 > Always validate the structured data before using it in your application:
 ```php
-if ($response->object === null) {
+if ($response->structured === null) {
     // Handle parsing failure
 }
 
-if (!isset($response->object['required_field'])) {
+if (!isset($response->structured['required_field'])) {
     // Handle missing required data
 }
 ```

--- a/src/Structured/Response.php
+++ b/src/Structured/Response.php
@@ -16,7 +16,7 @@ class Response
     /**
      * @param  Collection<int, Step>  $steps
      * @param  Collection<int, Message>  $responseMessages
-     * @param  array<mixed>  $object
+     * @param  array<mixed>  $structured
      * @param  ToolCall[]  $toolCalls
      * @param  ToolResult[]  $toolResults
      * @param  array{id: string, model: string}  $response
@@ -25,7 +25,7 @@ class Response
         public readonly Collection $steps,
         public readonly Collection $responseMessages,
         public readonly string $text,
-        public readonly ?array $object,
+        public readonly ?array $structured,
         public readonly FinishReason $finishReason,
         public readonly array $toolCalls,
         public readonly array $toolResults,

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -47,7 +47,7 @@ class ResponseBuilder
             steps: $this->steps,
             responseMessages: $this->responseMessages,
             text: $finalStep->text,
-            object: $finalStep->finishReason === FinishReason::Stop
+            structured: $finalStep->finishReason === FinishReason::Stop
                 ? $this->decodeObject($finalStep->text)
                 : [],
             finishReason: $finalStep->finishReason,

--- a/tests/Generators/StructuredGeneratorTest.php
+++ b/tests/Generators/StructuredGeneratorTest.php
@@ -196,7 +196,7 @@ it('generates a response from the provider', function (): void {
         ->generate();
 
     // Assert response
-    expect($response->object)->toBe(['forecast_summary' => '70° and sunny']);
+    expect($response->structured)->toBe(['forecast_summary' => '70° and sunny']);
     expect($response->finishReason)->toBe(FinishReason::Stop);
     expect($response->toolCalls)->toBeEmpty();
     expect($response->toolResults)->toBeEmpty();
@@ -334,7 +334,7 @@ it('correctly stops using max steps', function (): void {
         ->generate();
 
     // Assert Response
-    expect($response->object)->toBe(['forecast_summary' => 'The weather is 75 and sunny!']);
+    expect($response->structured)->toBe(['forecast_summary' => 'The weather is 75 and sunny!']);
     expect($response->finishReason)->toBe(FinishReason::Stop);
 
     // Assert steps

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -45,8 +45,8 @@ it('returns structured output', function (): void {
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->generate();
 
-    expect($response->object)->toBeArray();
-    expect($response->object)->toBe([
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toBe([
         'weather' => '90° and sunny',
         'game_time' => '3pm',
         'coat_required' => false,

--- a/tests/Providers/Ollama/StructuredTest.php
+++ b/tests/Providers/Ollama/StructuredTest.php
@@ -45,8 +45,8 @@ it('returns structured output', function (): void {
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->generate();
 
-    expect($response->object)->toBeArray();
-    expect($response->object)->toBe([
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toBe([
         'weather' => 'sunny, 90°',
         'game_time' => '3pm',
         'coat_required' => false,

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -48,8 +48,8 @@ it('returns structured output', function (): void {
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->generate();
 
-    expect($response->object)->toBeArray();
-    expect($response->object)->toBe([
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toBe([
         'weather' => 'The weather will be 90° and sunny',
         'game_time' => 'The Tigers game is at 3 pm in Detroit',
         'coat_required' => false,
@@ -89,8 +89,8 @@ it('returns structured output using json mode', function (): void {
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->generate();
 
-    expect($response->object)->toBeArray();
-    expect($response->object)->toBe([
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toBe([
         'weather' => 'The weather will be 90° and sunny',
         'game_time' => 'The tigers game is at 3pm in Detroit',
         'coat_required' => false,


### PR DESCRIPTION
## Description

Got some feedback that the response for structured output having the attribute `->object` is kind of misleading. This PR refactors the structured response to use `->structured` instead.

## Breaking Change(s)

- `object` is now `structured` in structured output response