### PR TITLE
Fix typo for structured response exceptions

### DIFF
--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -63,7 +63,7 @@ class PrismException extends Exception
     public static function structuredDecodingError(string $responseText): self
     {
         return new self(sprintf(
-            'Structred object could not be decoded. Received: %s',
+            'Structured object could not be decoded. Received: %s',
             $responseText
         ));
     }


### PR DESCRIPTION
Hi! Noticed a typo while using Prism on a project of my own using the structured output for some document analysis via Llama/OpenRouter. Wanted to get my feet wet as I love this project and the direction it's going, definitely want to contribute more! 