### PR TITLE
[WIP] Gemini Structured Outputs

### DIFF
--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -9,6 +9,7 @@ use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
 use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
 use EchoLabs\Prism\Providers\Gemini\Handlers\Embeddings;
 use EchoLabs\Prism\Providers\Gemini\Handlers\Text;
+use EchoLabs\Prism\Providers\Gemini\Handlers\Structured;
 use EchoLabs\Prism\Providers\ProviderResponse;
 use EchoLabs\Prism\Structured\Request as StructuredRequest;
 use EchoLabs\Prism\Text\Request as TextRequest;
@@ -36,7 +37,12 @@ class Gemini implements Provider
     #[\Override]
     public function structured(StructuredRequest $request): ProviderResponse
     {
-        throw new \Exception(sprintf('%s does not support structured mode', class_basename($this)));
+		$handler = new Structured($this->client(
+			$request->clientOptions,
+			$request->clientRetry
+		));
+
+		return $handler->handle($request);
     }
 
     #[\Override]

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace EchoLabs\Prism\Providers\Gemini\Handlers;
+
+use EchoLabs\Prism\Enums\Provider;
+use EchoLabs\Prism\Enums\StructuredMode;
+use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\MessageMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\ToolCallMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\ToolMap;
+use EchoLabs\Prism\Providers\Gemini\Support\StructuredModeResolver;
+use EchoLabs\Prism\Providers\ProviderResponse;
+use EchoLabs\Prism\Schema\ObjectSchema;
+use EchoLabs\Prism\Structured\Request;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
+use EchoLabs\Prism\ValueObjects\Usage;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Throwable;
+
+class Structured
+{
+	public function __construct(protected PendingRequest $client) {}
+
+	public function handle(Request $request): ProviderResponse
+	{
+		try {
+			$response = $this->sendRequest($request);
+		} catch (Throwable $e) {
+			throw PrismException::providerRequestError($request->model, $e);
+		}
+
+		$data = $response->json();
+
+		if (data_get($data, 'error') || ! $data) {
+			throw PrismException::providerResponseError(vsprintf(
+				'Gemini Error: [%s] %s',
+				[
+					data_get($data, 'error.code', 'unknown'),
+					data_get($data, 'error.message', 'unknown'),
+				]
+			));
+		}
+
+		return new ProviderResponse(
+			text: data_get($data, 'candidates.0.content.parts.0.text') ?? '',
+			toolCalls: [],
+			usage: new Usage(
+				data_get($data, 'usageMetadata.promptTokenCount', 0),
+				data_get($data, 'usageMetadata.candidatesTokenCount', 0)
+			),
+			finishReason: FinishReasonMap::map(data_get($data, 'candidates.0.finishReason')),
+			response: [
+				'id' => data_get($data, 'id'),
+				'model' => data_get($data, 'modelVersion'),
+			]
+		);
+	}
+
+	public function sendRequest(Request $request): Response
+	{
+		$endpoint = "{$request->model}:generateContent";
+
+		$payload = (new MessageMap($request->messages, $request->systemPrompt))();
+
+		$generationConfig = array_filter([
+			'temperature' => $request->temperature,
+			'topP' => $request->topP,
+			'maxOutputTokens' => $request->maxTokens,
+			'response_mime_type' => "application/json",
+			'response_schema' => $this->mapResponseFormat($request)
+		]);
+
+		if ($generationConfig !== []) {
+			$payload['generationConfig'] = $generationConfig;
+		}
+
+		$safetySettings = data_get($request->providerMeta, 'safetySettings');
+		if (! empty($safetySettings)) {
+			$payload['safetySettings'] = $safetySettings;
+		}
+
+		return $this->client->post($endpoint, $payload);
+
+	}
+
+	/**
+	 * @param  array<string, string>  $message
+	 */
+	protected function handleRefusal(array $message): void
+	{
+		if (! is_null(data_get($message, 'refusal', null))) {
+			throw new PrismException(sprintf('Gemini Refusal: %s', $message['refusal']));
+		}
+	}
+
+	/**
+	 * @return array|null
+	 */
+	protected function mapResponseFormat(Request $request): ?array
+	{
+		// StructuredModeResolver not necessary for Gemini as there is no additional "modes"
+
+		// WIP - as the ObjectSchema is not aware of the Provider, the
+		$removeProperties = function ($array) use (&$removeProperties) {
+			return collect($array)->map(function ($value, $key) use (&$removeProperties) {
+				// If value is an array, recursively process it
+				if (is_array($value)) {
+					$value = $removeProperties($value);
+				}
+
+				return $value;
+			})->reject(function ($value, $key) {
+				return $key === 'additionalProperties'; // Gemini does not allow this value
+			})->all();
+		};
+
+
+		return $removeProperties($request->schema->toArray());
+
+	}
+
+	protected function appendMessageForJsonMode(Request $request): Request
+	{
+		return $request->addMessage(new SystemMessage(sprintf(
+			"Respond with JSON that matches the following schema: \n %s",
+			json_encode($request->schema->toArray(), JSON_PRETTY_PRINT)
+		)));
+	}
+}

--- a/src/Providers/Gemini/Maps/ToolCallMap.php
+++ b/src/Providers/Gemini/Maps/ToolCallMap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Providers\Gemini\Maps;
+
+use EchoLabs\Prism\ValueObjects\ToolCall;
+
+class ToolCallMap
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @return array<int, ToolCall>
+     */
+    public static function map(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall): ToolCall => new ToolCall(
+            id: data_get($toolCall, 'id'),
+            name: data_get($toolCall, 'function.name'),
+            arguments: data_get($toolCall, 'function.arguments'),
+        ), $toolCalls);
+    }
+}

--- a/src/Providers/Gemini/Support/StructuredModeResolver.php
+++ b/src/Providers/Gemini/Support/StructuredModeResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Providers\Gemini\Support;
+
+use EchoLabs\Prism\Enums\StructuredMode as StructuredModeEnum;
+
+class StructuredModeResolver
+{
+	public static function forModel(string $model): StructuredModeEnum
+	{
+		if (self::supportsStructuredMode($model)) {
+			return StructuredModeEnum::Structured;
+		}
+
+		return StructuredModeEnum::Json;
+	}
+
+	protected static function supportsStructuredMode(string $model): bool
+	{
+		return in_array($model, [
+			'gemini-2.0-flash-exp',
+			'gemini-1.5-pro',
+			'gemini-1.5-flash',
+			'gemini-1.5-flash-8b'
+		]);
+	}
+
+}


### PR DESCRIPTION
Hey folks, this is a bit beyond my comfort zone, but wanted to share my WIP code for structured outputs with Gemini. 

This code is working for me with a handful of somewhat complex schemas (I've explicitly used/ tested the `Object`, `Array`, `String` and `Number` schemas, with nesting), although I acknowledge I haven't attached any tests here (yet).

Some observations that may need to be addressed more meaningfully:

- The `ObjectSchema` defines an `allowAdditionalProperties` key which is valid for OpenAI, but not for Gemini. As the schema itself isn't aware of the `Provider` being chosen, without doing some injection/ facade/ whatever, it was easier to just strip this key out after the `toArray()` map. There may need to be a longer term decision made here based on how other providers treat their schema definitions, or perhaps a provider-specific `map()` or `toArray()` handler for the `schema`.
- Gemini doesn't appear to have multiple structured options like OpenAI, so the `StructuredModeResolver` is a bit superfluous. Granted it's still a valid check on if a specific model supports structured mode, but I skipped this logic inclusion in my WIP pass here as all "current" Gemini models (excluding v1 Pro) support structured outputs.


Thoughts on a path forward to formalizing this?