### PR TITLE
feat: rate limit exceptions and Anthropic implmentation 

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -170,6 +170,10 @@ export default defineConfig({
                 text: "Custom Providers",
                 link: "/advanced/custom-providers",
               },
+              {
+                text: "Handling Rate Limits",
+                link: "/advanced/rate-limits",
+              }
             ],
           },
           {

--- a/docs/advanced/rate-limits.md
+++ b/docs/advanced/rate-limits.md
@@ -1,0 +1,132 @@
+# Handling Rate Limits
+
+Hitting issues with rate limits? We've got you covered!
+
+In this guide we will look at handling:
+- situations where you actually hit a rate limit (i.e. HTTP 429); and
+- dynamic rate limiting (figuring out when you can make your next request, from a successful request).
+
+## Provider support
+
+Rate limit handling is a new feature in Prism. 
+
+We currently only support Anthropic, but we're working to add support for more providers.
+
+If you are keen to contribute, take a look at the issues tab on Github - implementing rate limits for a provider is a great first contribution!
+
+## The ProviderRateLimit value object
+
+Throughout this guide, we'll talk about the `ProviderRateLimit` value object.
+
+Each `ProviderRateLimit` has four properties:
+- name - the name given to that rate limit by the provider - e.g. "input-tokens"
+- limit - the current limit set on your API key by the provider - e.g. for input-tokens, perhaps 80000
+- remaining - how many you have left - e.g. for input-tokens if you have used 30000 out of your 80000 limit - this will be 50000
+- resetsAt - a Carbon instance with the date and time at which remaining will reset to limit
+
+## Handling a rate limit hit
+
+Prism throws a `PrismRateLimitedException` when you hit a rate limit.
+
+You can catch that exception, gracefully fail and inspect the `rateLimits` property which contains an array of `ProviderRateLimit`s. 
+
+```php
+use EchoLabs\Prism\Prism;
+use EchoLabs\Enums\Provider;
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use EchoLabs\Prism\Exceptions\PrismRateLimitedException;
+
+try {
+    Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+        ->withPrompt('Hello world!')
+        ->generate();
+}
+catch (PrismRateLimitedException $e) {
+    /** @var ProviderRateLimit $rate_limit */ 
+    foreach ($e->rateLimits as $rate_limit) {
+        // Loop through rate limits...
+    }
+    
+    // Log, fail gracefully, etc.
+}
+```
+
+### Figuring out which rate limit you have hit
+
+In a simple world, they'd only be one rate limit. 
+
+However most providers implement various rate limits (e.g. request, input tokens, output tokens, etc.) and provide you with information on all of them on all requests, regardless of which you have hit.
+
+For simple rate limits like "requests", the `remaining` property on `ProviderRateLimit` will be 0 if you have hit it. These are easy to find:
+
+```php 
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use Illuminate\Support\Arr;
+
+try {
+    // Your request
+}
+catch (PrismRateLimitedException $e) {
+    $hit_limit = Arr::first($e->rateLimits, fn(ProviderRateLimit $rate_limit) => $rate_limit->remaining === 0);
+}
+```
+
+For less simple rate limits like input tokens, the `remaining` property may not be zero. For instance, if you have 5,000 input tokens remaining and submit a request requiring 6,000 tokens, you'll be rate limited but remaining will still show 5,000.
+
+Here, you may need to implement some logic to approximate how many tokens your request will use before sending it, and then test against that:
+
+```php 
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use Illuminate\Support\Arr;
+
+try {
+    // Your request
+}
+catch (PrismRateLimitedException $e) {
+    $input_token_limit = Arr::first($e->rateLimits, fn(ProviderRateLimit $rate_limit) => $rate_limit->name === 'input-tokens');
+
+    if ($input_token_limit < $your_token_estimate) {
+        // Handle
+    }
+}
+```
+
+To help with approximating input token usage, we plan to implement Anthopic's token counting endpoint in a future release. 
+
+For providers that don't have a token counting endpoint, you could either roll your own token counter or use something like [tiktoken](https://github.com/openai/tiktoken) if you are comfortable calling out to Python.
+
+Once you know which rate limit you have hit, you'll want to ensure your app does not continue making requests until after the `ProviderRateLimit` `resetsAt` property. 
+
+If you aren't sure where to start with that, check out the [What should you do with rate limit information](#what-should-you-do-with-rate-limit-information) section below.
+
+## Dynamic rate limiting
+
+Prism adds the same rate limit information to every successful request:
+
+```php
+use EchoLabs\Prism\Prism;
+use EchoLabs\Enums\Provider;
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt('Hello world!')
+    ->generate();
+    
+/** @var ProviderRateLimit $rate_limit */ 
+foreach ($response->responseMeta->rateLimits as $rate_limit) {
+    // Handle
+}
+
+```
+
+Armed with that information, you'll probably want to [update your app's rate limiter(s)](#what-should-you-do-with-rate-limit-information).
+
+## What should you do with rate limit information?
+
+You'll likely want to implement a rate limiter within your app. Thankfully Laravel, as always, makes this very easy!
+
+You should take a look at the [rate limiting](https://laravel.com/docs/11.x/rate-limiting) docs, and if you are firing requests from your queue, check out the [job middleware](https://laravel.com/docs/11.x/queues#job-middleware) docs.
+
+You should implement a rate limiter / job middleware for each of the provider rate limits your application typically hits. 

--- a/src/Concerns/ChecksSelf.php
+++ b/src/Concerns/ChecksSelf.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EchoLabs\Prism\Concerns;
+
+trait ChecksSelf
+{
+    /**
+     * @param  class-string  $classString
+     */
+    public function is(string $classString): bool
+    {
+        return $this instanceof $classString;
+    }
+}

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -4,4 +4,10 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Contracts;
 
-interface PrismRequest {}
+interface PrismRequest
+{
+    /**
+     * @param  class-string  $classString
+     */
+    public function is(string $classString): bool;
+}

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Contracts;
+
+interface PrismRequest {}

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Embeddings;
 
 use Closure;
+use EchoLabs\Prism\Concerns\ChecksSelf;
 use EchoLabs\Prism\Contracts\PrismRequest;
 
 class Request implements PrismRequest
 {
+    use ChecksSelf;
+
     /**
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Embeddings;
 
 use Closure;
+use EchoLabs\Prism\Contracts\PrismRequest;
 
-class Request
+class Request implements PrismRequest
 {
     /**
      * @param  array<string, mixed>  $clientOptions

--- a/src/Exceptions/PrismRateLimitedException.php
+++ b/src/Exceptions/PrismRateLimitedException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Exceptions;
+
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+
+class PrismRateLimitedException extends PrismException
+{
+    /**
+     * @param  ProviderRateLimit[]  $rateLimits
+     */
+    public function __construct(
+        public readonly array $rateLimits,
+        public readonly ?int $retryAfter = null
+    ) {
+        $message = 'You hit a provider rate limit';
+
+        if ($retryAfter) {
+            $message .= ' - retry after '.$retryAfter.' seconds';
+        }
+
+        $message .= '. Details: '.json_encode($rateLimits);
+
+        parent::__construct($message);
+    }
+
+    /**
+     * @param  ProviderRateLimit[]  $rateLimits
+     */
+    public static function make(array $rateLimits = [], ?int $retryAfter = null): self
+    {
+        return new self(rateLimits: $rateLimits, retryAfter: $retryAfter);
+    }
+}

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
+
+use EchoLabs\Prism\Contracts\PrismRequest;
+use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\ValueObjects\ProviderResponse;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Throwable;
+
+abstract class AnthropicHandlerAbstract
+{
+    protected PrismRequest $request;
+
+    protected Response $httpResponse;
+
+    public function __construct(protected PendingRequest $client) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    abstract public static function buildHttpRequestPayload(PrismRequest $request): array;
+
+    public function handle(PrismRequest $request): ProviderResponse
+    {
+        $this->request = $request;
+
+        try {
+            $this->prepareRequest();
+            $this->httpResponse = $this->sendRequest();
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($this->request->model, $e); // @phpstan-ignore property.notFound
+        }
+
+        $data = $this->httpResponse->json();
+
+        if (data_get($data, 'type') === 'error') {
+            throw PrismException::providerResponseError(vsprintf(
+                'Anthropic Error: [%s] %s',
+                [
+                    data_get($data, 'error.type', 'unknown'),
+                    data_get($data, 'error.message'),
+                ]
+            ));
+        }
+
+        return $this->buildProviderResponse();
+    }
+
+    abstract protected function prepareRequest(): void;
+
+    abstract protected function buildProviderResponse(): ProviderResponse;
+
+    protected function sendRequest(): Response
+    {
+        return $this->client->post(
+            'messages',
+            static::buildHttpRequestPayload($this->request)
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function extractText(array $data): string
+    {
+        return array_reduce(data_get($data, 'content', []), function (string $text, array $content): string {
+            if (data_get($content, 'type') === 'text') {
+                $text .= data_get($content, 'text');
+            }
+
+            return $text;
+        }, '');
+    }
+}

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -34,7 +34,7 @@ abstract class AnthropicHandlerAbstract
         $this->request = $request;
 
         try {
-            $this->prepareRequest();
+            $this->request = $this->prepareRequest();
             $this->httpResponse = $this->sendRequest();
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($this->request->model, $e); // @phpstan-ignore property.notFound
@@ -45,7 +45,7 @@ abstract class AnthropicHandlerAbstract
         return $this->buildProviderResponse();
     }
 
-    abstract protected function prepareRequest(): void;
+    abstract protected function prepareRequest(): PrismRequest;
 
     abstract protected function buildProviderResponse(): ProviderResponse;
 

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -119,13 +119,13 @@ abstract class AnthropicHandlerAbstract
 
             return new ProviderRateLimit(
                 name: $limit_name,
-                limit: data_get($fields, 'limit')
+                limit: data_get($fields, 'limit') !== null
                     ? (int) data_get($fields, 'limit')
                     : null,
-                remaining: data_get($fields, 'remaining')
+                remaining: data_get($fields, 'remaining') !== null
                     ? (int) data_get($fields, 'remaining')
                     : null,
-                resetsAt: data_get($fields, 'reset') ? new Carbon($resets_at) : null
+                resetsAt: data_get($fields, 'reset') !== null ? new Carbon($resets_at) : null
             );
         }));
     }

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -4,42 +4,57 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
-use EchoLabs\Prism\Structured\Request;
+use EchoLabs\Prism\Structured\Request as StructuredRequest;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ProviderResponse;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
 use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Http\Client\Response;
-use Throwable;
 
-class Structured
+class Structured extends AnthropicHandlerAbstract
 {
+    /**
+     * @var StructuredRequest
+     */
+    protected PrismRequest $request; // Redeclared for type hinting
+
     public function __construct(protected PendingRequest $client) {}
 
-    public function handle(Request $request): ProviderResponse
+    /**
+     * @param  StructuredRequest  $request
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public static function buildHttpRequestPayload(PrismRequest $request): array
     {
-        try {
-            $request = $this->appendMessageForJsonMode($request);
-            $response = $this->sendRequest($request);
-            $data = $response->json();
-
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model, $e);
+        if (! $request instanceof StructuredRequest) {
+            throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
         }
 
-        if (data_get($data, 'type') === 'error') {
-            throw PrismException::providerResponseError(vsprintf(
-                'Anthropic Error: [%s] %s',
-                [
-                    data_get($data, 'error.type', 'unknown'),
-                    data_get($data, 'error.message'),
-                ]
-            ));
-        }
+        return array_merge([
+            'model' => $request->model,
+            'messages' => MessageMap::map($request->messages),
+            'max_tokens' => $request->maxTokens ?? 2048,
+        ], array_filter([
+            'system' => MessageMap::mapSystemMessages($request->messages, $request->systemPrompt),
+            'temperature' => $request->temperature,
+            'top_p' => $request->topP,
+        ]));
+    }
+
+    #[\Override]
+    protected function prepareRequest(): void
+    {
+        $this->appendMessageForJsonMode();
+    }
+
+    #[\Override]
+    protected function buildProviderResponse(): ProviderResponse
+    {
+        $data = $this->httpResponse->json();
 
         return new ProviderResponse(
             text: $this->extractText($data),
@@ -58,41 +73,11 @@ class Structured
         );
     }
 
-    public function sendRequest(Request $request): Response
+    protected function appendMessageForJsonMode(): void
     {
-        return $this->client->post(
-            'messages',
-            array_merge([
-                'model' => $request->model,
-                'messages' => MessageMap::map($request->messages),
-                'max_tokens' => $request->maxTokens ?? 2048,
-            ], array_filter([
-                'system' => MessageMap::mapSystemMessages($request->messages, $request->systemPrompt),
-                'temperature' => $request->temperature,
-                'top_p' => $request->topP,
-            ]))
-        );
-    }
-
-    /**
-     * @param  array<string, mixed>  $data
-     */
-    protected function extractText(array $data): string
-    {
-        return array_reduce(data_get($data, 'content', []), function (string $text, array $content): string {
-            if (data_get($content, 'type') === 'text') {
-                $text .= data_get($content, 'text');
-            }
-
-            return $text;
-        }, '');
-    }
-
-    protected function appendMessageForJsonMode(Request $request): Request
-    {
-        return $request->addMessage(new UserMessage(sprintf(
+        $this->request->addMessage(new UserMessage(sprintf(
             "Respond with ONLY JSON that matches the following schema: \n %s",
-            json_encode($request->schema->toArray(), JSON_PRETTY_PRINT)
+            json_encode($this->request->schema->toArray(), JSON_PRETTY_PRINT)
         )));
     }
 }

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -30,7 +30,7 @@ class Structured extends AnthropicHandlerAbstract
     #[\Override]
     public static function buildHttpRequestPayload(PrismRequest $request): array
     {
-        if (! $request instanceof StructuredRequest) {
+        if (! $request->is(StructuredRequest::class)) {
             throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
         }
 

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -69,6 +69,7 @@ class Structured extends AnthropicHandlerAbstract
             responseMeta: new ResponseMeta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits()
             )
         );
     }

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -45,10 +45,13 @@ class Structured extends AnthropicHandlerAbstract
         ]));
     }
 
+    /**
+     * @return StructuredRequest
+     */
     #[\Override]
-    protected function prepareRequest(): void
+    protected function prepareRequest(): PrismRequest
     {
-        $this->appendMessageForJsonMode();
+        return $this->appendMessageForJsonMode();
     }
 
     #[\Override]
@@ -74,11 +77,15 @@ class Structured extends AnthropicHandlerAbstract
         );
     }
 
-    protected function appendMessageForJsonMode(): void
+    /**
+     * @return StructuredRequest
+     */
+    protected function appendMessageForJsonMode(): PrismRequest
     {
-        $this->request->addMessage(new UserMessage(sprintf(
+        return $this->request->addMessage(new UserMessage(sprintf(
             "Respond with ONLY JSON that matches the following schema: \n %s",
             json_encode($this->request->schema->toArray(), JSON_PRETTY_PRINT)
         )));
+
     }
 }

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -65,6 +65,7 @@ class Text extends AnthropicHandlerAbstract
             responseMeta: new ResponseMeta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits()
             )
         );
     }

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -27,7 +27,7 @@ class Text extends AnthropicHandlerAbstract
     #[\Override]
     public static function buildHttpRequestPayload(PrismRequest $request): array
     {
-        if (! $request instanceof TextRequest) {
+        if (! $request->is(TextRequest::class)) {
             throw new \InvalidArgumentException('Request must be an instance of '.TextRequest::class);
         }
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -45,7 +45,10 @@ class Text extends AnthropicHandlerAbstract
     }
 
     #[\Override]
-    protected function prepareRequest(): void {}
+    protected function prepareRequest(): PrismRequest
+    {
+        return $this->request;
+    }
 
     #[\Override]
     protected function buildProviderResponse(): ProviderResponse

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -6,13 +6,14 @@ namespace EchoLabs\Prism\Structured;
 
 use Closure;
 use EchoLabs\Prism\Contracts\Message;
+use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Contracts\Schema;
 use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Enums\StructuredMode;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 
-class Request
+class Request implements PrismRequest
 {
     /**
      * @param  array<int, Message>  $messages

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Structured;
 
 use Closure;
+use EchoLabs\Prism\Concerns\ChecksSelf;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Contracts\Schema;
@@ -15,6 +16,8 @@ use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 
 class Request implements PrismRequest
 {
+    use ChecksSelf;
+
     /**
      * @param  array<int, Message>  $messages
      * @param  array<string, mixed>  $clientOptions

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -6,10 +6,11 @@ namespace EchoLabs\Prism\Text;
 
 use Closure;
 use EchoLabs\Prism\Contracts\Message;
+use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Enums\ToolChoice;
 use EchoLabs\Prism\Tool;
 
-class Request
+class Request implements PrismRequest
 {
     /**
      * @param  array<int, Message>  $messages

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Text;
 
 use Closure;
+use EchoLabs\Prism\Concerns\ChecksSelf;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Enums\ToolChoice;
@@ -12,6 +13,8 @@ use EchoLabs\Prism\Tool;
 
 class Request implements PrismRequest
 {
+    use ChecksSelf;
+
     /**
      * @param  array<int, Message>  $messages
      * @param  array<int, Tool>  $tools

--- a/src/ValueObjects/ProviderRateLimit.php
+++ b/src/ValueObjects/ProviderRateLimit.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EchoLabs\Prism\ValueObjects;
+
+use Carbon\Carbon;
+
+class ProviderRateLimit
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ?int $limit = null,
+        public readonly ?int $remaining = null,
+        public readonly ?Carbon $resetsAt = null
+    ) {}
+}

--- a/src/ValueObjects/ResponseMeta.php
+++ b/src/ValueObjects/ResponseMeta.php
@@ -6,8 +6,12 @@ namespace EchoLabs\Prism\ValueObjects;
 
 class ResponseMeta
 {
+    /**
+     * @param  ProviderRateLimit[]  $rateLimits
+     */
     public function __construct(
         public readonly string $id,
-        public readonly string $model
+        public readonly string $model,
+        public readonly array $rateLimits = []
     ) {}
 }

--- a/tests/Fixtures/FixtureResponse.php
+++ b/tests/Fixtures/FixtureResponse.php
@@ -48,7 +48,7 @@ class FixtureResponse
         });
     }
 
-    public static function fakeResponseSequence(string $requestPath, string $name): void
+    public static function fakeResponseSequence(string $requestPath, string $name, array $headers = []): void
     {
         $responses = collect(scandir(dirname(static::filePath($name))))
             ->filter(function (string $file) use ($name): int|false {
@@ -61,7 +61,7 @@ class FixtureResponse
             ->map(fn ($filePath) => Http::response(
                 file_get_contents($filePath),
                 200,
-                []
+                $headers
             ));
 
         Http::fake([

--- a/tests/Providers/Anthropic/AnthropicRateLimitExceptionTest.php
+++ b/tests/Providers/Anthropic/AnthropicRateLimitExceptionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use EchoLabs\Prism\Exceptions\PrismRateLimitedException;
+use EchoLabs\Prism\Prism;
+use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+
+it('throws a RateLimitException if the Anthropic responds with a 429', function (): void {
+    Http::fake([
+        'https://api.anthropic.com/*' => Http::response(
+            status: 429,
+        ),
+    ])->preventStrayRequests();
+
+    Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20240620')
+        ->withPrompt('Hello world!')
+        ->generate();
+
+})->throws(PrismRateLimitedException::class);
+
+it('sets the correct data on the RateLimitException', function (): void {
+    $requests_reset = Carbon::now()->addSeconds(30);
+
+    Http::fake([
+        'https://api.anthropic.com/*' => Http::response(
+            status: 429,
+            headers: [
+                'anthropic-ratelimit-requests-limit' => 1000,
+                'anthropic-ratelimit-requests-remaining' => 500,
+                'anthropic-ratelimit-requests-reset' => $requests_reset->toISOString(),
+                'anthropic-ratelimit-input-tokens-limit' => 80000,
+                'anthropic-ratelimit-input-tokens-remaining' => 0,
+                'anthropic-ratelimit-input-tokens-reset' => Carbon::now()->addSeconds(60)->toISOString(),
+                'anthropic-ratelimit-output-tokens-limit' => 16000,
+                'anthropic-ratelimit-output-tokens-remaining' => 15000,
+                'anthropic-ratelimit-output-tokens-reset' => Carbon::now()->addSeconds(5)->toISOString(),
+                'anthropic-ratelimit-tokens-limit' => 96000,
+                'anthropic-ratelimit-tokens-remaining' => 15000,
+                'anthropic-ratelimit-tokens-reset' => Carbon::now()->addSeconds(5)->toISOString(),
+                'retry-after' => 40,
+            ]
+        ),
+    ])->preventStrayRequests();
+
+    try {
+        Prism::text()
+            ->using('anthropic', 'claude-3-5-sonnet-20240620')
+            ->withPrompt('Hello world!')
+            ->generate();
+    } catch (PrismRateLimitedException $e) {
+        expect($e->retryAfter)->toEqual(40);
+        expect($e->rateLimits)->toHaveCount(4);
+        expect($e->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
+        expect($e->rateLimits[0]->name)->toEqual('requests');
+        expect($e->rateLimits[0]->limit)->toEqual(1000);
+        expect($e->rateLimits[0]->remaining)->toEqual(500);
+        expect($e->rateLimits[0]->resetsAt)->toEqual($requests_reset);
+    }
+});

--- a/tests/Providers/Anthropic/AnthropicRateLimitExceptionTest.php
+++ b/tests/Providers/Anthropic/AnthropicRateLimitExceptionTest.php
@@ -57,5 +57,9 @@ it('sets the correct data on the RateLimitException', function (): void {
         expect($e->rateLimits[0]->limit)->toEqual(1000);
         expect($e->rateLimits[0]->remaining)->toEqual(500);
         expect($e->rateLimits[0]->resetsAt)->toEqual($requests_reset);
+
+        expect($e->rateLimits[1]->name)->toEqual('input-tokens');
+        expect($e->rateLimits[1]->limit)->toEqual(80000);
+        expect($e->rateLimits[1]->remaining)->toEqual(0);
     }
 });


### PR DESCRIPTION
Re: #141 

### What does this PR do?

1. Refactors Anthropic handlers to extend an abstract base handler - to reduce duplication going forward - particularly as we'll possibly have more handlers imminently (e.g. token counting).
2. Creates a `RateLimitException`, which accepts an array of `ProviderRateLimit`s for the user to inspect.
3. Implements throwing the `RateLimitException` for Anthropic.
4. Adds an array of `ProviderRateLimit`s to `ResponseMeta` for Anthropic.
5. Adds an optional headers param to `FixtureResponse::fakeResponseSequence()` to support testing (4).

I have done (1) as a separate commit, in case you'd rather split into two PRs.

### Notes

- I have added an empty `PrismRequest` interface for strong typing on the abstract class. 
- I have moved the handlers' request and http response to properties for ease of accessing and type hinting. 

### Questions

How would you like to cover this in the docs? A new Rate Limits page under Core Concepts, with explanation of the exception, ResponsaMeta, and maybe a provider support table?

### Breaking changes

I don't think there should be any, other than where people have extended the Anthropic handler classes.