### PR TITLE
feat: Add getters to ConfiguresProviders

### DIFF
--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -41,4 +41,19 @@ trait ConfiguresProviders
 
         return $this;
     }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    public function getProviderKey(): string
+    {
+        return $this->providerKey;
+    }
+
+    public function getProviderEnum(): ProviderEnum
+    {
+        return ProviderEnum::from($this->providerKey);
+    }
 }

--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -42,18 +42,13 @@ trait ConfiguresProviders
         return $this;
     }
 
-    public function getModel(): string
+    public function model(): string
     {
         return $this->model;
     }
 
-    public function getProviderKey(): string
+    public function providerKey(): string
     {
         return $this->providerKey;
-    }
-
-    public function getProviderEnum(): ProviderEnum
-    {
-        return ProviderEnum::from($this->providerKey);
     }
 }

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -39,6 +39,15 @@ test('it sets provider meta', function (): void {
         ->toHaveKey('openai', ['key' => 'value']);
 });
 
+test('it allows you to get the model and provider', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4');
+
+    expect($request->getModel())->toBe('gpt-4');
+    expect($request->getProviderKey())->toBe('openai');
+    expect($request->getProviderEnum())->toBe(Provider::OpenAI);
+});
+
 test('it configures the client options', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -43,9 +43,8 @@ test('it allows you to get the model and provider', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4');
 
-    expect($request->getModel())->toBe('gpt-4');
-    expect($request->getProviderKey())->toBe('openai');
-    expect($request->getProviderEnum())->toBe(Provider::OpenAI);
+    expect($request->model())->toBe('gpt-4');
+    expect($request->providerKey())->toBe('openai');
 });
 
 test('it configures the client options', function (): void {


### PR DESCRIPTION
A micro PR to add getters to `ConfiguresProviders` - for convenience where they have been dynamically set and you need to apply some logic based on the `PendingRequest`.
