### PR TITLE
Text document handling [Anthropic only]

### DIFF
--- a/docs/components/ProviderSupport.vue
+++ b/docs/components/ProviderSupport.vue
@@ -157,7 +157,7 @@ export default {
   name: "CompatibilityMatrix",
   data() {
     return {
-      features: ["Text", "Structured", "Embeddings", "Image", "Tools"],
+      features: ["Text", "Structured", "Embeddings", "Image", "Tools", "Documents"],
       providers: [
         {
           name: "Amazon Bedrock",
@@ -166,6 +166,7 @@ export default {
           embeddings: Planned,
           image: Planned,
           tools: Planned,
+          documents: Unsupported,
         },
         {
           name: "Anthropic",
@@ -174,6 +175,7 @@ export default {
           embeddings: Unsupported,
           image: Supported,
           tools: Supported,
+          documents: Supported,
         },
         {
           name: "Azure OpenAI",
@@ -182,6 +184,7 @@ export default {
           embeddings: Planned,
           image: Planned,
           tools: Planned,
+          documents: Unsupported,
         },
         {
           name: "DeepSeek",
@@ -190,6 +193,7 @@ export default {
           embeddings: Unsupported,
           image: Unsupported,
           tools: Supported,
+          documents: Unsupported,
         },
         {
           name: "Gemini",
@@ -198,6 +202,7 @@ export default {
           embeddings: Supported,
           image: Supported,
           tools: Planned,
+          documents: Unsupported,
         },
         {
           name: "Groq",
@@ -206,6 +211,7 @@ export default {
           embeddings: Planned,
           image: Supported,
           tools: Supported,
+          documents: Unsupported,
         },
         {
           name: "Mistral",
@@ -214,6 +220,7 @@ export default {
           embeddings: Supported,
           image: Supported,
           tools: Supported,
+          documents: Unsupported,
         },
         {
           name: "Ollama",
@@ -222,6 +229,7 @@ export default {
           embeddings: Supported,
           image: Supported,
           tools: Supported,
+          documents: Unsupported,
         },
         {
           name: "OpenAI",
@@ -230,6 +238,7 @@ export default {
           embeddings: Supported,
           image: Supported,
           tools: Supported,
+          documents: Unsupported,
         },
         {
           name: "xAI",
@@ -238,6 +247,7 @@ export default {
           embeddings: Unsupported,
           image: Supported,
           tools: Supported,
+          documents: Unsupported,
         },
       ],
     };

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -72,7 +72,7 @@ Prism::text()
             Document::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')), 'application/pdf'),
         ]),
         new UserMessage('Here is the document from a local path', [
-            Document::fromPath('tests/Fixtures/test-pdf.pdf', 'application/pdf'),
+            Document::fromPath('tests/Fixtures/test-pdf.pdf'),
         ]),
     ])
     ->generate();
@@ -80,6 +80,28 @@ Prism::text()
 ```
 Anthropic use vision to process PDFs, and consequently there are some limitations detailed in their [feature documentation](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support).
 
+### Txt and md Document Support
+
+Prism supports txt/md documents on UserMessages via the `$additionalContent` parameter:
+
+```php
+use EchoLabs\Enums\Provider;
+use EchoLabs\Prism\Prism;
+use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+
+Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withMessages([
+        new UserMessage('Here is the document from a text string (e.g. from your database)', [
+            Document::fromText('Hello world!'),
+        ]),
+        new UserMessage('Here is the document from a local path', [
+            Document::fromPath('tests/Fixtures/test-txt.txt'),
+        ]),
+    ])
+    ->generate();
+
+```
 
 ## Considerations
 ### Message Order

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -178,7 +178,7 @@ class MessageMap
         return array_map(fn (Document $document): array => array_filter([
             'type' => 'document',
             'source' => [
-                'type' => 'base64',
+                'type' => $document->dataFormat,
                 'media_type' => $document->mimeType,
                 'data' => $document->document,
             ],

--- a/src/ValueObjects/Messages/Support/Document.php
+++ b/src/ValueObjects/Messages/Support/Document.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\ValueObjects\Messages\Support;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Facades\File;
 
 /**
  * Note: Prism currently only supports Documents with Anthropic.
  */
 class Document
 {
+    public readonly string $dataFormat;
+
     public function __construct(
         public readonly string $document,
         public readonly string $mimeType,
-        public readonly ?string $dataFormat = null
-    ) 
-    {
-        $this->dataFormat ??= Str::startsWith($this->mimeType, 'text/') ? 'text' : 'base64';
+        ?string $dataFormat = null
+    ) {
+        // Done this way to avoid assigning a readonly property twice.
+        $this->dataFormat = $dataFormat ?? (Str::startsWith($this->mimeType, 'text/') ? 'text' : 'base64');
     }
 
     public static function fromPath(string $path): self

--- a/tests/Fixtures/test-text.md
+++ b/tests/Fixtures/test-text.md
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/Fixtures/test-text.txt
+++ b/tests/Fixtures/test-text.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -74,7 +74,7 @@ it('maps user messages with images from base64', function (): void {
         ->toBe('image/png');
 });
 
-it('maps user messages with documents from path', function (): void {
+it('maps user messages with PDF documents from path', function (): void {
     $mappedMessage = MessageMap::map([
         new UserMessage('Here is the document', [
             Document::fromPath('tests/Fixtures/test-pdf.pdf'),
@@ -91,7 +91,7 @@ it('maps user messages with documents from path', function (): void {
         ->toBe('application/pdf');
 });
 
-it('maps user messages with documents from base64', function (): void {
+it('maps user messages with PDF documents from base64', function (): void {
     $mappedMessage = MessageMap::map([
         new UserMessage('Here is the document', [
             Document::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')), 'application/pdf'),
@@ -106,6 +106,57 @@ it('maps user messages with documents from base64', function (): void {
         ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')));
     expect(data_get($mappedMessage, '0.content.1.source.media_type'))
         ->toBe('application/pdf');
+});
+
+it('maps user messages with txt documents from path', function (): void {
+    $mappedMessage = MessageMap::map([
+        new UserMessage('Here is the document', [
+            Document::fromPath('tests/Fixtures/test-text.txt'),
+        ]),
+    ]);
+
+    expect(data_get($mappedMessage, '0.content.1.type'))
+        ->toBe('document');
+    expect(data_get($mappedMessage, '0.content.1.source.type'))
+        ->toBe('text');
+    expect(data_get($mappedMessage, '0.content.1.source.data'))
+        ->toContain(file_get_contents('tests/Fixtures/test-text.txt'));
+    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+        ->toBe('text/plain');
+});
+
+it('maps user messages with md documents from path', function (): void {
+    $mappedMessage = MessageMap::map([
+        new UserMessage('Here is the document', [
+            Document::fromPath('tests/Fixtures/test-text.md'),
+        ]),
+    ]);
+
+    expect(data_get($mappedMessage, '0.content.1.type'))
+        ->toBe('document');
+    expect(data_get($mappedMessage, '0.content.1.source.type'))
+        ->toBe('text');
+    expect(data_get($mappedMessage, '0.content.1.source.data'))
+        ->toContain(file_get_contents('tests/Fixtures/test-text.md'));
+    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+        ->toBe('text/plain');
+});
+
+it('maps user messages with txt documents from text string', function (): void {
+    $mappedMessage = MessageMap::map([
+        new UserMessage('Here is the document', [
+            Document::fromText('Hello world!'),
+        ]),
+    ]);
+
+    expect(data_get($mappedMessage, '0.content.1.type'))
+        ->toBe('document');
+    expect(data_get($mappedMessage, '0.content.1.source.type'))
+        ->toBe('text');
+    expect(data_get($mappedMessage, '0.content.1.source.data'))
+        ->toContain('Hello world!');
+    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+        ->toBe('text/plain');
 });
 
 it('does not maps user messages with images from url', function (): void {


### PR DESCRIPTION
The recent Anthropic citations release brings with it support for text documents (independent of whether you are using citations or not).

This PR adds support for text documents, ahead of a larger PR to support citations. 