### PR TITLE
[Bug Fix] Structured requests use tools and generation

### DIFF
--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -7,6 +7,9 @@ use EchoLabs\Prism\Enums\StructuredMode;
 use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Providers\OpenAI\Maps\FinishReasonMap;
 use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
+use EchoLabs\Prism\Providers\OpenAI\Maps\ToolCallMap;
+use EchoLabs\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use EchoLabs\Prism\Providers\OpenAI\Maps\ToolMap;
 use EchoLabs\Prism\Providers\OpenAI\Support\StructuredModeResolver;
 use EchoLabs\Prism\Structured\Request;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
@@ -51,6 +54,8 @@ class Structured
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,
                 'response_format' => $responseFormat,
+                'tools' => ToolMap::map($request->tools),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice),
             ]))
         );
     }
@@ -124,7 +129,7 @@ class Structured
 
         return new ProviderResponse(
             text: data_get($data, 'choices.0.message.content') ?? '',
-            toolCalls: [],
+            toolCalls: ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', [])),
             usage: new Usage(
                 data_get($data, 'usage.prompt_tokens'),
                 data_get($data, 'usage.completion_tokens'),

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace EchoLabs\Prism\Structured;
 
 use EchoLabs\Prism\Concerns\ConfiguresClient;
+use EchoLabs\Prism\Concerns\ConfiguresGeneration;
 use EchoLabs\Prism\Concerns\ConfiguresModels;
 use EchoLabs\Prism\Concerns\ConfiguresProviders;
 use EchoLabs\Prism\Concerns\ConfiguresStructuredOutput;
+use EchoLabs\Prism\Concerns\ConfiguresTools;
 use EchoLabs\Prism\Concerns\HasMessages;
 use EchoLabs\Prism\Concerns\HasPrompts;
 use EchoLabs\Prism\Concerns\HasProviderMeta;
 use EchoLabs\Prism\Concerns\HasSchema;
+use EchoLabs\Prism\Concerns\HasTools;
 use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
@@ -19,13 +22,16 @@ use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 class PendingRequest
 {
     use ConfiguresClient;
+    use ConfiguresGeneration;
     use ConfiguresModels;
     use ConfiguresProviders;
     use ConfiguresStructuredOutput;
+    use ConfiguresTools;
     use HasMessages;
     use HasPrompts;
     use HasProviderMeta;
     use HasSchema;
+    use HasTools;
 
     public function generate(): Response
     {
@@ -58,10 +64,13 @@ class PendingRequest
             prompt: $this->prompt,
             messages: $messages,
             temperature: $this->temperature,
+            maxSteps: $this->maxSteps,
             maxTokens: $this->maxTokens,
             topP: $this->topP,
+            tools: $this->tools,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
+            toolChoice: $this->toolChoice,
             providerMeta: $this->providerMeta,
             schema: $this->schema,
             mode: $this->structuredMode,

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -9,13 +9,13 @@ use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Contracts\Schema;
 use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Enums\StructuredMode;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use EchoLabs\Prism\Enums\ToolChoice;
 
 class Request
 {
     /**
      * @param  array<int, Message>  $messages
+     * @param  array<int, Tool>  $tools
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerMeta
@@ -25,17 +25,20 @@ class Request
         public readonly string $model,
         public readonly ?string $prompt,
         public readonly array $messages,
+        public readonly int $maxSteps,
         public readonly ?int $maxTokens,
         public readonly int|float|null $temperature,
         public readonly int|float|null $topP,
+        public readonly array $tools,
         public readonly array $clientOptions,
         public readonly array $clientRetry,
+        public readonly string|ToolChoice|null $toolChoice,
         public readonly Schema $schema,
         public readonly array $providerMeta,
         public readonly StructuredMode $mode,
     ) {}
 
-    public function addMessage(UserMessage|SystemMessage $message): self
+    public function addMessage(Message $message): self
     {
         $messages = array_merge($this->messages, [$message]);
 
@@ -44,11 +47,14 @@ class Request
             model: $this->model,
             prompt: $this->prompt,
             messages: $messages,
+            maxSteps: $this->maxSteps,
             maxTokens: $this->maxTokens,
             temperature: $this->temperature,
             topP: $this->topP,
+            tools: $this->tools,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
+            toolChoice: $this->toolChoice,
             schema: $this->schema,
             providerMeta: $this->providerMeta,
             mode: $this->mode,

--- a/src/Structured/Response.php
+++ b/src/Structured/Response.php
@@ -7,6 +7,8 @@ namespace EchoLabs\Prism\Structured;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
+use EchoLabs\Prism\ValueObjects\ToolCall;
+use EchoLabs\Prism\ValueObjects\ToolResult;
 use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
 
@@ -15,6 +17,8 @@ class Response
     /**
      * @param  Collection<int, Step>  $steps
      * @param  Collection<int, Message>  $responseMessages
+     * @param  ToolCall[]  $toolCalls
+     * @param  ToolResult[]  $toolResults
      * @param  array<mixed>  $structured
      */
     public function __construct(
@@ -23,6 +27,8 @@ class Response
         public readonly string $text,
         public readonly ?array $structured,
         public readonly FinishReason $finishReason,
+        public readonly array $toolCalls,
+        public readonly array $toolResults,
         public readonly Usage $usage,
         public readonly ResponseMeta $responseMeta,
     ) {}

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -51,6 +51,8 @@ class ResponseBuilder
                 ? $this->decodeObject($finalStep->text)
                 : [],
             finishReason: $finalStep->finishReason,
+            toolCalls: $finalStep->toolCalls,
+            toolResults: $finalStep->toolResults,
             usage: $this->calculateTotalUsage(),
             responseMeta: $finalStep->responseMeta,
         );

--- a/src/Structured/Step.php
+++ b/src/Structured/Step.php
@@ -7,11 +7,15 @@ namespace EchoLabs\Prism\Structured;
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
+use EchoLabs\Prism\ValueObjects\ToolCall;
+use EchoLabs\Prism\ValueObjects\ToolResult;
 use EchoLabs\Prism\ValueObjects\Usage;
 
 class Step
 {
     /**
+     * @param  ToolCall[]  $toolCalls
+     * @param  ToolResult[]  $toolResults
      * @param  array<mixed>  $object
      * @param  Message[]  $messages
      */
@@ -19,6 +23,8 @@ class Step
         public readonly string $text,
         public readonly ?array $object,
         public readonly FinishReason $finishReason,
+        public readonly array $toolCalls,
+        public readonly array $toolResults,
         public readonly Usage $usage,
         public readonly ResponseMeta $responseMeta,
         public readonly array $messages,


### PR DESCRIPTION
The refactor in this commit 65937a26413e6b1fe1d57ff56a9e8e4dc791100a removed the ability to work with tools or set max steps when using a structured response.