### PR TITLE
fix: reinstate assistant message to steps

### DIFF
--- a/src/Structured/Generator.php
+++ b/src/Structured/Generator.php
@@ -24,9 +24,9 @@ class Generator
 
     public function generate(Request $request): Response
     {
-        $response = $this->sendProviderRequest($request);
-
         $this->messages = $request->messages;
+
+        $response = $this->sendProviderRequest($request);
 
         $this->responseBuilder->addStep(new Step(
             text: $response->text,

--- a/tests/Structured/GeneratorTest.php
+++ b/tests/Structured/GeneratorTest.php
@@ -172,7 +172,7 @@ it('tracks provider responses properly', function (): void {
     });
 });
 
-test('it adds system message and user message to first step', function (): void {
+test('it adds system message user message and assistant message response to first step', function (): void {
     Prism::fake([
         new ProviderResponse(
             text: json_encode(['I am a string']),
@@ -192,6 +192,7 @@ test('it adds system message and user message to first step', function (): void 
     $response = $request->generate();
 
     expect($response)->toBeInstanceOf(Response::class);
+    expect($response->steps[0]->messages)->toHaveCount(3);
 
     /** @var SystemMessage */
     $system_message = $response->steps[0]->messages[0];
@@ -206,4 +207,12 @@ test('it adds system message and user message to first step', function (): void 
     expect($user_message)->toBeInstanceOf(UserMessage::class)
         ->and($user_message->text())
         ->toBe('User Prompt');
+
+    /** @var AssistantMessage */
+    $assistant_message = $response->steps[0]->messages[2];
+
+    expect($assistant_message)->toBeInstanceOf(AssistantMessage::class)
+        ->and($assistant_message->content)
+        ->toBe(json_encode(['I am a string']));
+
 });

--- a/tests/Text/GeneratorTest.php
+++ b/tests/Text/GeneratorTest.php
@@ -307,7 +307,7 @@ test('it correctly builds message chain with tools', function (): void {
         );
 });
 
-test('it adds the system message and user message to first step', function (): void {
+test('it adds the system message user message and assistant response to first step', function (): void {
     $request = (new PendingRequest)
         ->using('test-provider', 'test-model')
         ->withSystemPrompt('System Prompt')
@@ -330,4 +330,11 @@ test('it adds the system message and user message to first step', function (): v
     expect($user_message)->toBeInstanceOf(UserMessage::class)
         ->and($user_message->text())
         ->toBe('User Prompt');
+
+    /** @var AssistantMessage */
+    $assistant_message = $response->steps[0]->messages[2];
+
+    expect($assistant_message)->toBeInstanceOf(AssistantMessage::class)
+        ->and($assistant_message->content)
+        ->toBe("I'm nyx!");
 });


### PR DESCRIPTION
This one is on me - in #146 I re-instated the system and user message to the first step, but accidently knocked off the assistant message. Oh the irony!

Have fixed + expanded the test for text and structured to cover this.