### PR TITLE
fix(openai): function definitions without parameters

### DIFF
--- a/src/Providers/OpenAI/Maps/ToolMap.php
+++ b/src/Providers/OpenAI/Maps/ToolMap.php
@@ -20,11 +20,13 @@ class ToolMap
             'function' => [
                 'name' => $tool->name(),
                 'description' => $tool->description(),
-                'parameters' => [
-                    'type' => 'object',
-                    'properties' => $tool->parameters(),
-                    'required' => $tool->requiredParameters(),
-                ],
+                ...count($tool->parameters()) ? [
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => $tool->parameters(),
+                        'required' => $tool->requiredParameters(),
+                    ],
+                ] : [],
             ],
             'strict' => data_get($tool->providerMeta(Provider::OpenAI), 'strict', null),
         ]), $tools);


### PR DESCRIPTION
OpenAI supports functions that don't take any parameters.

If you pass an empty array of parameters an error is returned:
```Sending to model (model-name) failed: OpenAI Error:  [invalid_request_error] Invalid schema for function 'tool_name': [] is not of type 'object'.```

You instead don't send `parameters` when defining a function without arguments.