### PR TITLE
feat(openai): update structured output models

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -45,9 +45,10 @@ class StructuredModeResolver
     protected static function unsupported(string $model): bool
     {
         return in_array($model, [
-            'o1',
             'o1-mini',
+            'o1-mini-2024-09-12',
             'o1-preview',
+            'o1-preview-2024-09-12',
         ]);
     }
 }

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -202,7 +202,8 @@ it('throws an exception for o1 models', function (string $model): void {
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
         ->generate();
 })->with([
-    'o1',
     'o1-mini',
+    'o1-mini-2024-09-12',
     'o1-preview',
+    'o1-preview-2024-09-12',
 ]);


### PR DESCRIPTION
This PR updates the current OpenAI models that don't support Structured Outputs.

The `o1` model that now shorthands to `o1-2024-12-17` introduced support for structured responses, as per this [blog post](https://openai.com/index/o1-and-new-tools-for-developers/) and testing.