### PR TITLE
refacor: provider meta as string keys

### DIFF
--- a/src/Concerns/HasProviderMeta.php
+++ b/src/Concerns/HasProviderMeta.php
@@ -12,9 +12,9 @@ trait HasProviderMeta
     /**
      * @param  array<string, mixed>  $meta
      */
-    public function withProviderMeta(Provider $provider, array $meta): self
+    public function withProviderMeta(string|Provider $provider, array $meta): self
     {
-        $this->providerMeta[$provider->value] = $meta;
+        $this->providerMeta[is_string($provider) ? $provider : $provider->value] = $meta;
 
         return $this;
     }
@@ -22,8 +22,12 @@ trait HasProviderMeta
     /**
      * @return array<string, mixed>> $meta
      */
-    public function providerMeta(Provider $provider): array
+    public function providerMeta(string|Provider $provider): array
     {
-        return data_get($this->providerMeta, $provider->value, []);
+        return data_get(
+            $this->providerMeta,
+            is_string($provider) ? $provider : $provider->value,
+            []
+        );
     }
 }

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -55,9 +55,13 @@ class Request
         );
     }
 
-    public function providerMeta(Provider $provider, string $valuePath = ''): mixed
+    public function providerMeta(string|Provider $provider, string $valuePath = ''): mixed
     {
-        $providerMeta = data_get($this->providerMeta, $provider->value, []);
+        $providerMeta = data_get(
+            $this->providerMeta,
+            is_string($provider) ? $provider : $provider->value,
+            []
+        );
 
         return data_get($providerMeta, $valuePath, $providerMeta);
     }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -6,6 +6,7 @@ namespace EchoLabs\Prism\Text;
 
 use Closure;
 use EchoLabs\Prism\Contracts\Message;
+use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Enums\ToolChoice;
 use EchoLabs\Prism\Tool;
 
@@ -53,5 +54,16 @@ class Request
             toolChoice: $this->toolChoice,
             providerMeta: $this->providerMeta,
         );
+    }
+
+    public function providerMeta(string|Provider $provider, string $valuePath = ''): mixed
+    {
+        $providerMeta = data_get(
+            $this->providerMeta,
+            is_string($provider) ? $provider : $provider->value,
+            []
+        );
+
+        return data_get($providerMeta, $valuePath, $providerMeta);
     }
 }

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -136,3 +136,49 @@ test('you can run toRequest multiple times', function (): void {
     $request->toRequest();
     $request->toRequest();
 })->throwsNoExceptions();
+
+test('it sets provider meta with enum', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta)
+        ->toHaveKey('openai', ['key' => 'value']);
+});
+
+test('it sets provider meta with string', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withProviderMeta('openai', ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta)
+        ->toHaveKey('openai', ['key' => 'value']);
+});
+
+test('it gets provider meta on a request with an enum', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta(Provider::OpenAI, 'key'))->toBe('value');
+});
+
+test('it gets provider meta on a request with a string', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta('openai', 'key'))->toBe('value');
+});

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -28,7 +28,7 @@ test('it can configure the provider and model', function (): void {
     expect($generated->model)->toBe('gpt-4');
 });
 
-test('it sets provider meta', function (): void {
+test('it sets provider meta with enum', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')
         ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
@@ -37,6 +37,53 @@ test('it sets provider meta', function (): void {
 
     expect($generated->providerMeta)
         ->toHaveKey('openai', ['key' => 'value']);
+});
+
+test('it sets provider meta with string', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withProviderMeta('openai', ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta)
+        ->toHaveKey('openai', ['key' => 'value']);
+});
+
+test('it gets provider meta on a pending request with an enum', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    expect($request->providerMeta(Provider::OpenAI))->toBe(['key' => 'value']);
+});
+
+test('it gets provider meta on a pending request with a string', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    expect($request->providerMeta('openai'))->toBe(['key' => 'value']);
+});
+
+test('it gets provider meta on a request with an enum', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta(Provider::OpenAI, 'key'))->toBe('value');
+});
+
+test('it gets provider meta on a request with a string', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withProviderMeta(Provider::OpenAI, ['key' => 'value']);
+
+    $generated = $request->toRequest();
+
+    expect($generated->providerMeta('openai', 'key'))->toBe('value');
 });
 
 test('it allows you to get the model and provider', function (): void {


### PR DESCRIPTION
A nice easy and self-explanatory one.

I ran into this building the Bedrock installable provider, as currently hooking in as a customer provider which has no enum case.