### PR TITLE
Support null value maxTokens

### DIFF
--- a/src/Concerns/ConfiguresModels.php
+++ b/src/Concerns/ConfiguresModels.php
@@ -6,7 +6,7 @@ namespace EchoLabs\Prism\Concerns;
 
 trait ConfiguresModels
 {
-    protected ?int $maxTokens = null;
+    protected ?int $maxTokens = 2048;
 
     protected int|float|null $temperature = null;
 

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -40,7 +40,7 @@ class Structured
             array_merge([
                 'model' => $request->model,
                 'messages' => (new MessageMap($request->messages, $request->systemPrompt ?? ''))(),
-                'max_completion_tokens' => $request->maxTokens ?? 2048,
+                'max_completion_tokens' => $request->maxTokens,
             ], array_filter([
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -62,7 +62,7 @@ class Text
             array_merge([
                 'model' => $request->model,
                 'messages' => (new MessageMap($request->messages, $request->systemPrompt ?? ''))(),
-                'max_completion_tokens' => $request->maxTokens ?? 2048,
+                'max_completion_tokens' => $request->maxTokens,
             ], array_filter([
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -46,7 +46,7 @@ class Structured
             array_merge([
                 'model' => $request->model,
                 'messages' => (new MessageMap($request->messages, $request->systemPrompt ?? ''))(),
-                'max_completion_tokens' => $request->maxTokens ?? 2048,
+                'max_completion_tokens' => $request->maxTokens,
             ], array_filter([
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -64,7 +64,7 @@ class Text
             array_merge([
                 'model' => $request->model,
                 'messages' => (new MessageMap($request->messages, $request->systemPrompt ?? ''))(),
-                'max_completion_tokens' => $request->maxTokens ?? 2048,
+                'max_completion_tokens' => $request->maxTokens,
             ], array_filter([
                 'temperature' => $request->temperature,
                 'top_p' => $request->topP,


### PR DESCRIPTION
This PR defaults `maxTokens` to 2048 to keep the same behaviour as today, whilst respecting developer requests to set value to `null`.