### PR TITLE
fix(gemini): support tool calling without params

### DIFF
--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -124,7 +124,9 @@ class MessageMap
             $parts[] = [
                 'functionCall' => [
                     'name' => $toolCall->name,
-                    'args' => $toolCall->arguments(),
+                    ...count($toolCall->arguments()) ? [
+                        'args' => $toolCall->arguments(),
+                    ] : [],
                 ],
             ];
         }

--- a/src/Providers/Gemini/Maps/ToolMap.php
+++ b/src/Providers/Gemini/Maps/ToolMap.php
@@ -21,11 +21,13 @@ class ToolMap
         return array_map(fn (Tool $tool): array => [
             'name' => $tool->name(),
             'description' => $tool->description(),
-            'parameters' => [
-                'type' => 'object',
-                'properties' => $tool->parameters(),
-                'required' => $tool->requiredParameters(),
-            ],
+            ...$tool->hasParameters() ? [
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $tool->parameters(),
+                    'required' => $tool->requiredParameters(),
+                ],
+            ] : [],
         ], $tools);
     }
 }

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -162,6 +162,11 @@ class Tool
         return $this->description;
     }
 
+    public function hasParameters(): bool
+    {
+        return (bool) count($this->parameters);
+    }
+
     /**
      * @param  string|int|float  $args
      *


### PR DESCRIPTION
In the same vein as https://github.com/echolabsdev/prism/pull/165 this PR allows calling tools with Gemini that don't require parameters 