### PR TITLE
feat(gemini): support structured outputs

### DIFF
--- a/docs/components/ProviderSupport.vue
+++ b/docs/components/ProviderSupport.vue
@@ -198,7 +198,7 @@ export default {
         {
           name: "Gemini",
           text: Supported,
-          structured: Planned,
+          structured: Supported,
           embeddings: Supported,
           image: Supported,
           tools: Supported,

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -7,7 +7,3 @@
     'url' => env('GEMINI_URL', 'https://generativelanguage.googleapis.com/v1beta/models'),
 ],
 ```
-
-## Limitations
-
-- The structured output is not supported.

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -9,6 +9,7 @@ use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
 use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
 use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Providers\Gemini\Handlers\Embeddings;
+use EchoLabs\Prism\Providers\Gemini\Handlers\Structured;
 use EchoLabs\Prism\Providers\Gemini\Handlers\Text;
 use EchoLabs\Prism\Stream\Request as StreamRequest;
 use EchoLabs\Prism\Structured\Request as StructuredRequest;
@@ -40,7 +41,12 @@ readonly class Gemini implements Provider
     #[\Override]
     public function structured(StructuredRequest $request): StructuredResponse
     {
-        throw new \Exception(sprintf('%s does not support structured mode', class_basename($this)));
+        $handler = new Structured($this->client(
+            $request->clientOptions(),
+            $request->clientRetry()
+        ));
+
+        return $handler->handle($request);
     }
 
     #[\Override]

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace EchoLabs\Prism\Providers\Gemini\Handlers;
+
+use EchoLabs\Prism\Enums\Provider;
+use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\MessageMap;
+use EchoLabs\Prism\Providers\Gemini\Maps\SchemaMap;
+use EchoLabs\Prism\Structured\Request;
+use EchoLabs\Prism\Structured\Response as StructuredResponse;
+use EchoLabs\Prism\Structured\ResponseBuilder;
+use EchoLabs\Prism\Structured\Step;
+use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use EchoLabs\Prism\ValueObjects\ResponseMeta;
+use EchoLabs\Prism\ValueObjects\Usage;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Throwable;
+
+class Structured
+{
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(protected PendingRequest $client)
+    {
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    public function handle(Request $request): StructuredResponse
+    {
+        try {
+            $response = $this->sendRequest($request);
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+
+        $data = $response->json();
+
+        if (! $data || data_get($data, 'error')) {
+            throw PrismException::providerResponseError(vsprintf(
+                'Gemini Error: [%s] %s',
+                [
+                    data_get($data, 'error.code', 'unknown'),
+                    data_get($data, 'error.message', 'unknown'),
+                ]
+            ));
+        }
+
+        $text = data_get($data, 'candidates.0.content.parts.0.text') ?? '';
+
+        $responseMessage = new AssistantMessage($text);
+        $this->responseBuilder->addResponseMessage($responseMessage);
+        $request->addMessage($responseMessage);
+
+        $this->responseBuilder->addStep(
+            new Step(
+                text: $text,
+                finishReason: FinishReasonMap::map(
+                    data_get($data, 'candidates.0.finishReason'),
+                ),
+                usage: new Usage(
+                    data_get($data, 'usageMetadata.promptTokenCount', 0),
+                    data_get($data, 'usageMetadata.candidatesTokenCount', 0)
+                ),
+                responseMeta: new ResponseMeta(
+                    id: data_get($data, 'id', ''),
+                    model: data_get($data, 'modelVersion'),
+                ),
+                messages: $request->messages(),
+                systemPrompts: $request->systemPrompts(),
+            )
+        );
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    public function sendRequest(Request $request): Response
+    {
+        $endpoint = "{$request->model()}:generateContent";
+
+        $payload = (new MessageMap($request->messages(), $request->systemPrompts()))();
+
+        $responseSchema = new SchemaMap($request->schema());
+
+        $payload['generationConfig'] = array_merge([
+            'response_mime_type' => 'application/json',
+            'response_schema' => $responseSchema->toArray(),
+        ], array_filter([
+            'temperature' => $request->temperature(),
+            'topP' => $request->topP(),
+            'maxOutputTokens' => $request->maxTokens(),
+        ]));
+
+        $safetySettings = $request->providerMeta(Provider::Gemini, 'safetySettings');
+        if (! empty($safetySettings)) {
+            $payload['safetySettings'] = $safetySettings;
+        }
+
+        return $this->client->post($endpoint, $payload);
+    }
+}

--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace EchoLabs\Prism\Providers\Gemini\Maps;
+
+use EchoLabs\Prism\Contracts\Schema;
+use EchoLabs\Prism\Schema\ArraySchema;
+use EchoLabs\Prism\Schema\BooleanSchema;
+use EchoLabs\Prism\Schema\NumberSchema;
+use EchoLabs\Prism\Schema\ObjectSchema;
+
+class SchemaMap
+{
+    public function __construct(
+        private readonly Schema $schema,
+    ) {}
+
+    /**
+     * @return array<mixed>
+     */
+    public function toArray(): array
+    {
+        return array_merge([
+            'type' => $this->mapType(),
+            ...array_filter([
+                ...$this->schema->toArray(),
+                'additionalProperties' => null,
+            ]),
+        ], array_filter([
+            'items' => property_exists($this->schema, 'items') ?
+                (new self($this->schema->items))->toArray() :
+                null,
+            'properties' => property_exists($this->schema, 'properties') ?
+                array_reduce($this->schema->properties, fn (array $carry, Schema $property) => [
+                    ...$carry,
+                    $property->name() => (new self($property))->toArray(),
+                ], []) :
+                null,
+        ]));
+    }
+
+    protected function mapType(): string
+    {
+        switch ($this->schema::class) {
+            case ArraySchema::class:
+                return 'array';
+            case BooleanSchema::class:
+                return 'boolean';
+            case NumberSchema::class:
+                return 'number';
+            case ObjectSchema::class:
+                return 'object';
+            default:
+                return 'string';
+        }
+    }
+}


### PR DESCRIPTION
Created this PR before realising [this one](https://github.com/echolabsdev/prism/pull/173) existed.

The main difference is this PR updates the structured output to match the schema format Google defines. It then passes this directly using `response_schema` rather than appending a message.

To me this seems the preferred way of doing it:
- The schema matching the defined format is going to help the model know how to use your schema.
- Passing the schema via `response_schema` means you get validation (and relevant errors) on your schema