### PR TITLE
feat(openai): support required tool calling

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -34,8 +34,3 @@ $response = Prism::structured()
         ] // [!code focus]
     ]) // [!code focus]
 ```
-
-## Limitations
-### Tool Choice
-
-OpenAI does not support `ToolChoice::Any` when using `withToolChoice()`.

--- a/src/Concerns/ConfiguresTools.php
+++ b/src/Concerns/ConfiguresTools.php
@@ -10,12 +10,15 @@ use EchoLabs\Prism\Tool;
 trait ConfiguresTools
 {
     protected string|ToolChoice|null $toolChoice = null;
+    protected int $toolChoiceAutoAfter = 1;
 
-    public function withToolChoice(string|ToolChoice|Tool $toolChoice): self
+    public function withToolChoice(string|ToolChoice|Tool $toolChoice, int $toolChoiceAutoAfter = 1): self
     {
         $this->toolChoice = $toolChoice instanceof Tool
             ? $toolChoice->name()
             : $toolChoice;
+
+        $this->toolChoiceAutoAfter = $toolChoiceAutoAfter;
 
         return $this;
     }

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -28,14 +28,14 @@ abstract class AnthropicHandlerAbstract
     /**
      * @return array<string, mixed>
      */
-    abstract public static function buildHttpRequestPayload(PrismRequest $request): array;
+    abstract public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array;
 
-    protected function sendRequest(): void
+    protected function sendRequest(int $currentStep = 0): void
     {
         try {
             $this->httpResponse = $this->client->post(
                 'messages',
-                static::buildHttpRequestPayload($this->request)
+                static::buildHttpRequestPayload($this->request, $currentStep)
             );
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($this->request->model(), $e);

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -71,7 +71,7 @@ class Structured extends AnthropicHandlerAbstract
      * @return array<string, mixed>
      */
     #[\Override]
-    public static function buildHttpRequestPayload(PrismRequest $request): array
+    public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array
     {
         if (! $request->is(StructuredRequest::class)) {
             throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -50,7 +50,7 @@ class Text extends AnthropicHandlerAbstract
 
     public function handle(): Response
     {
-        $this->sendRequest();
+        $this->sendRequest($this->responseBuilder->steps->count());
 
         $this->prepareTempResponse();
 
@@ -76,7 +76,7 @@ class Text extends AnthropicHandlerAbstract
      * @return array<string, mixed>
      */
     #[\Override]
-    public static function buildHttpRequestPayload(PrismRequest $request): array
+    public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array
     {
         if (! $request->is(TextRequest::class)) {
             throw new \InvalidArgumentException('Request must be an instance of '.TextRequest::class);
@@ -98,7 +98,7 @@ class Text extends AnthropicHandlerAbstract
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'tools' => ToolMap::map($request->tools()),
-            'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $currentStep, $request->toolChoiceAutoAfter()),
         ]);
     }
 

--- a/src/Providers/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Providers/Anthropic/Maps/ToolChoiceMap.php
@@ -12,13 +12,19 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_null($toolChoice)) {
             return null;
         }
 
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return [
+                    'type' => 'auto',
+                ];
+            }
+
             return [
                 'type' => 'tool',
                 'name' => $toolChoice,
@@ -32,7 +38,7 @@ class ToolChoiceMap
         return [
             'type' => match ($toolChoice) {
                 ToolChoice::Auto => 'auto',
-                ToolChoice::Any => 'any',
+                ToolChoice::Any => $currentStep >= $autoAfter ? 'auto' : 'any',
                 ToolChoice::None => 'none',
             },
         ];

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -113,7 +113,7 @@ class Text
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfter()),
                 ]))
             );
 

--- a/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
@@ -12,9 +12,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -87,7 +87,9 @@ class Text
                     ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'generationConfig' => $generationConfig !== [] ? $generationConfig : null,
                     'tools' => $tools !== [] ? ['function_declarations' => $tools] : null,
-                    'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
+                    'tool_config' => $request->toolChoice() ?
+                        ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfter()) :
+                        null,
                     'safetySettings' => $request->providerMeta(Provider::Gemini, 'safetySettings'),
                 ])
             );

--- a/src/Providers/Gemini/Maps/ToolChoiceMap.php
+++ b/src/Providers/Gemini/Maps/ToolChoiceMap.php
@@ -11,9 +11,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return ['function_calling_config' => ['mode' => 'AUTO']];
+            }
+
             return [
                 'function_calling_config' => [
                     'mode' => 'ANY',
@@ -23,7 +27,7 @@ class ToolChoiceMap
         }
 
         return match ($toolChoice) {
-            ToolChoice::Any => ['function_calling_config' => ['mode' => 'ANY']],
+            ToolChoice::Any => ['function_calling_config' => ['mode' => $currentStep >= $autoAfter ? 'AUTO' : 'ANY']],
             ToolChoice::Auto => ['function_calling_config' => ['mode' => 'AUTO']],
             ToolChoice::None => ['function_calling_config' => ['mode' => 'NONE']],
             null => $toolChoice,

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -74,7 +74,7 @@ class Text
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfter()),
                 ])
             );
 

--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -12,9 +12,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -112,7 +112,7 @@ class Text
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfter()),
                 ]))
             );
 

--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -12,9 +12,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [
@@ -25,6 +29,7 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
+            ToolChoice::Any => $currentStep >= $autoAfter ? 'auto' : 'required',
             null => $toolChoice,
             default => throw new InvalidArgumentException('Invalid tool choice')
         };

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -112,7 +112,7 @@ class Text
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfter()),
                 ]))
             );
 

--- a/src/Providers/XAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/XAI/Maps/ToolChoiceMap.php
@@ -12,13 +12,17 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, int $autoAfter = 1): string|array|null
     {
         if (is_null($toolChoice)) {
             return null;
         }
 
         if (is_string($toolChoice)) {
+            if ($currentStep >= $autoAfter) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [
@@ -33,7 +37,7 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
-            ToolChoice::Any => 'required',
+            ToolChoice::Any => $currentStep >= $autoAfter ? 'auto' : 'required',
         };
     }
 }

--- a/src/Stream/PendingRequest.php
+++ b/src/Stream/PendingRequest.php
@@ -59,6 +59,7 @@ class PendingRequest
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
+            toolChoiceAutoAfter: $this->toolChoiceAutoAfter,
             providerMeta: $this->providerMeta,
         );
     }

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -58,6 +58,7 @@ class PendingRequest
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
+            toolChoiceAutoAfter: $this->toolChoiceAutoAfter,
             providerMeta: $this->providerMeta,
         );
     }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -38,6 +38,7 @@ class Request implements PrismRequest
         protected array $clientOptions,
         protected array $clientRetry,
         protected string|ToolChoice|null $toolChoice,
+        protected int $toolChoiceAutoAfter,
         array $providerMeta = [],
     ) {
         $this->providerMeta = $providerMeta;
@@ -46,6 +47,11 @@ class Request implements PrismRequest
     public function toolChoice(): string|ToolChoice|null
     {
         return $this->toolChoice;
+    }
+
+    public function toolChoiceAutoAfter(): int
+    {
+        return $this->toolChoiceAutoAfter;
     }
 
     /**

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -133,7 +133,7 @@ describe('Text generation for Groq', function (): void {
         $this->expectExceptionMessage('Invalid tool choice');
 
         Prism::text()
-            ->using('groq', 'gpt-4')
+            ->using('groq', 'llama3-groq-70b-8192-tool-use-preview')
             ->withPrompt('Who are you?')
             ->withToolChoice(ToolChoice::Any)
             ->generate();

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Facades\Tool;
 use EchoLabs\Prism\Prism;
 use Illuminate\Http\Client\Request;
@@ -202,15 +200,4 @@ it('handles specific tool choice', function (): void {
         ->generate();
 
     expect($response->toolCalls[0]->name)->toBe('weather');
-});
-
-it('throws an exception for ToolChoice::Any', function (): void {
-    $this->expectException(PrismException::class);
-    $this->expectExceptionMessage('Invalid tool choice');
-
-    Prism::text()
-        ->using('openai', 'gpt-4')
-        ->withPrompt('Who are you?')
-        ->withToolChoice(ToolChoice::Any)
-        ->generate();
 });


### PR DESCRIPTION
Prism docs mention a limitation that OpenAI doesn't support `ToolChoice::Any`, but there's a mappable option of `required` as per [their docs](https://platform.openai.com/docs/guides/function-calling#additional-configurations)

Using this option as-is has the same problem as using a named tool - it will loop forever using it.

This PR proposes respecting that tool setting for the first call, and reverting to the OpenAI default of `auto` for subsequent calls.