### PR TITLE
fix(tools): catch unknown named parameter errors

### DIFF
--- a/src/Concerns/CallsTools.php
+++ b/src/Concerns/CallsTools.php
@@ -38,6 +38,10 @@ trait CallsTools
                         result: $result,
                     );
                 } catch (Throwable $e) {
+                    if ($e instanceof PrismException) {
+                        throw $e;
+                    }
+
                     throw PrismException::toolCallFailed($toolCall, $e);
                 }
 

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -15,6 +15,7 @@ use EchoLabs\Prism\Schema\EnumSchema;
 use EchoLabs\Prism\Schema\NumberSchema;
 use EchoLabs\Prism\Schema\ObjectSchema;
 use EchoLabs\Prism\Schema\StringSchema;
+use Error;
 use InvalidArgumentException;
 use Throwable;
 use TypeError;
@@ -171,7 +172,11 @@ class Tool
     {
         try {
             return call_user_func($this->fn, ...$args);
-        } catch (ArgumentCountError|InvalidArgumentException|TypeError $e) {
+        } catch (ArgumentCountError|Error|InvalidArgumentException|TypeError $e) {
+            if ($e::class === Error::class && ! str_starts_with($e->getMessage(), 'Unknown named parameter')) {
+                throw $e;
+            }
+
             throw PrismException::invalidParameterInTool($this->name, $e);
         }
     }

--- a/tests/ToolTest.php
+++ b/tests/ToolTest.php
@@ -144,3 +144,20 @@ it('can throw a prism custom exception for invalid parameters', function (): voi
 
     $searchTool->handle([]);
 });
+
+it('can throw a prism custom exception for unknown named parameters', function (): void {
+    $searchTool = (new Tool)
+        ->as('search')
+        ->for('useful for searching current data')
+        ->withParameter(new StringSchema('query', 'the search query'))
+        ->using(function (string $query): string {
+            expect($query)->toBe('What time is the event?');
+
+            return 'The event is at 3pm eastern';
+        });
+
+    $this->expectException(PrismException::class);
+    $this->expectExceptionMessage('Invalid parameters for tool : search');
+
+    $searchTool->handle(input: 'What time is the event?');
+});


### PR DESCRIPTION
While debugging failed tool calls, I was finding it hard to understand quickly why `Calling tool failed` was being thrown.

It was due to the model inventing named parameters to send as an argument to the function.

This change helps expose this problem quicker by:
- Catching PHPs `Unknown named parameter` errors as an additional `invalidParameterInTool` error.
- Throwing a previous `PrismException` rather than `toolCallFailed` when the tool fails.