### PR TITLE
refactor: replace systemPrompt with systemPrompts

### DIFF
--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Concerns;
 
+use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use Illuminate\Contracts\View\View;
 
 trait HasPrompts
 {
     protected ?string $prompt = null;
 
-    protected ?string $systemPrompt = null;
+    /**
+     * @var SystemMessage[]
+     */
+    protected array $systemPrompts = [];
 
     public function withPrompt(string|View $prompt): self
     {
@@ -19,9 +24,29 @@ trait HasPrompts
         return $this;
     }
 
-    public function withSystemPrompt(string|View $message): self
+    public function withSystemPrompt(string|View|SystemMessage $message): self
     {
-        $this->systemPrompt = is_string($message) ? $message : $message->render();
+        if ($message instanceof SystemMessage) {
+            $this->systemPrompts[] = $message;
+
+            return $this;
+        }
+
+        $this->systemPrompts[] = new SystemMessage(is_string($message) ? $message : $message->render());
+
+        return $this;
+    }
+
+    /**
+     * @param  SystemMessage[]  $messages
+     */
+    public function withSystemPrompts(array $messages): self
+    {
+        if (count($this->systemPrompts) > 0) {
+            throw new PrismException('System prompts have already been set. Remove previous calls to withSystemPrompt or withSystemPrompts.');
+        }
+
+        $this->systemPrompts = $messages;
 
         return $this;
     }

--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use Illuminate\Contracts\View\View;
 
@@ -42,11 +41,7 @@ trait HasPrompts
      */
     public function withSystemPrompts(array $messages): self
     {
-        if (count($this->systemPrompts) > 0) {
-            throw new PrismException('System prompts have already been set. Remove previous calls to withSystemPrompt or withSystemPrompts.');
-        }
-
-        $this->systemPrompts = $messages;
+        $this->systemPrompts = array_merge($this->systemPrompts, $messages);
 
         return $this;
     }

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -10,4 +10,6 @@ interface PrismRequest
      * @param  class-string  $classString
      */
     public function is(string $classString): bool;
+
+    public function model(): string;
 }

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -49,6 +49,7 @@ class Request implements PrismRequest
         return $this->input;
     }
 
+    #[\Override]
     public function model(): string
     {
         return $this->model;

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -41,7 +41,7 @@ abstract class AnthropicHandlerAbstract
             $this->request = $this->prepareRequest();
             $this->httpResponse = $this->sendRequest();
         } catch (Throwable $e) {
-            throw PrismException::providerRequestError($this->request->model, $e); // @phpstan-ignore property.notFound
+            throw PrismException::providerRequestError($this->request->model(), $e);
         }
 
         $this->handleResponseErrors();

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -40,7 +40,7 @@ class Structured extends AnthropicHandlerAbstract
             'messages' => MessageMap::map($request->messages(), $request->providerMeta(Provider::Anthropic)),
             'max_tokens' => $request->maxTokens(),
         ], array_filter([
-            'system' => MessageMap::mapSystemMessages($request->messages(), $request->systemPrompt()),
+            'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
         ]));

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -37,7 +37,7 @@ class Text extends AnthropicHandlerAbstract
             'messages' => MessageMap::map($request->messages(), $request->providerMeta(Provider::Anthropic)),
             'max_tokens' => $request->maxTokens(),
         ], array_filter([
-            'system' => MessageMap::mapSystemMessages($request->messages(), $request->systemPrompt()),
+            'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'tools' => ToolMap::map($request->tools()),

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -39,7 +39,7 @@ class Structured
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_completion_tokens' => $request->maxTokens(),
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -61,7 +61,7 @@ class Text
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_completion_tokens' => $request->maxTokens(),
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/DeepSeek/Maps/MessageMap.php
+++ b/src/Providers/DeepSeek/Maps/MessageMap.php
@@ -20,17 +20,16 @@ class MessageMap
 
     /**
      * @param  array<int, Message>  $messages
+     * @param  SystemMessage[]  $systemPrompts
      */
     public function __construct(
         protected array $messages,
-        protected string $systemPrompt
+        protected array $systemPrompts
     ) {
-        if ($systemPrompt !== '' && $systemPrompt !== '0') {
-            $this->messages = array_merge(
-                [new SystemMessage($systemPrompt)],
-                $this->messages
-            );
-        }
+        $this->messages = array_merge(
+            $this->systemPrompts,
+            $this->messages
+        );
     }
 
     /**

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -70,7 +70,7 @@ class Text
     {
         $endpoint = "{$request->model()}:generateContent";
 
-        $payload = (new MessageMap($request->messages(), $request->systemPrompt()))();
+        $payload = (new MessageMap($request->messages(), $request->systemPrompts()))();
 
         $generationConfig = array_filter([
             'temperature' => $request->temperature(),

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -63,7 +63,7 @@ class Text
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens ?? 2048,
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/Groq/Maps/MessageMap.php
+++ b/src/Providers/Groq/Maps/MessageMap.php
@@ -20,17 +20,16 @@ class MessageMap
 
     /**
      * @param  array<int, Message>  $messages
+     * @param  SystemMessage[]  $systemPrompts
      */
     public function __construct(
         protected array $messages,
-        protected string $systemPrompt
+        protected array $systemPrompts
     ) {
-        if ($systemPrompt !== '' && $systemPrompt !== '0') {
-            $this->messages = array_merge(
-                [new SystemMessage($systemPrompt)],
-                $this->messages
-            );
-        }
+        $this->messages = array_merge(
+            $this->systemPrompts,
+            $this->messages
+        );
     }
 
     /**

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -63,7 +63,7 @@ class Text
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens ?? 2048,
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -64,7 +64,7 @@ class Text
             array_merge([
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                'max_tokens' => $request->maxTokens ?? 2048,
+                'max_tokens' => $request->maxTokens() ?? 2048,
             ], array_filter([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),

--- a/src/Providers/Mistral/Maps/MessageMap.php
+++ b/src/Providers/Mistral/Maps/MessageMap.php
@@ -20,17 +20,16 @@ class MessageMap
 
     /**
      * @param  array<int, Message>  $messages
+     * @param  SystemMessage[]  $systemPrompts
      */
     public function __construct(
         protected array $messages,
-        protected string $systemPrompt
+        protected array $systemPrompts
     ) {
-        if ($systemPrompt !== '' && $systemPrompt !== '0') {
-            $this->messages = array_merge(
-                [new SystemMessage($systemPrompt)],
-                $this->messages
-            );
-        }
+        $this->messages = array_merge(
+            $this->systemPrompts,
+            $this->messages
+        );
     }
 
     /**

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -52,9 +52,13 @@ class Structured
 
     public function sendRequest(Request $request): Response
     {
+        if (count($request->systemPrompts()) > 1) {
+            throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
+        }
+
         return $this->client->post('api/chat', [
             'model' => $request->model(),
-            'system' => $request->systemPrompt(),
+            'system' => data_get($request->systemPrompts(), '0.content', ''),
             'messages' => (new MessageMap($request->messages()))->map(),
             'format' => $request->schema()->toArray(),
             'stream' => false,

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -55,11 +55,15 @@ class Text
 
     public function sendRequest(Request $request): Response
     {
+        if (count($request->systemPrompts()) > 1) {
+            throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
+        }
+
         return $this
             ->client
             ->post('api/chat', [
                 'model' => $request->model(),
-                'system' => $request->systemPrompt(),
+                'system' => data_get($request->systemPrompts(), '0.content', ''),
                 'messages' => (new MessageMap($request->messages()))->map(),
                 'tools' => ToolMap::map($request->tools()),
                 'stream' => false,

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -45,7 +45,7 @@ class Structured
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_completion_tokens' => $request->maxTokens(),
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -63,7 +63,7 @@ class Text
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_completion_tokens' => $request->maxTokens(),
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -20,17 +20,16 @@ class MessageMap
 
     /**
      * @param  array<int, Message>  $messages
+     * @param  SystemMessage[]  $systemPrompts
      */
     public function __construct(
         protected array $messages,
-        protected string $systemPrompt
+        protected array $systemPrompts
     ) {
-        if ($systemPrompt !== '' && $systemPrompt !== '0') {
-            $this->messages = array_merge(
-                [new SystemMessage($systemPrompt)],
-                $this->messages
-            );
-        }
+        $this->messages = array_merge(
+            $this->systemPrompts,
+            $this->messages
+        );
     }
 
     /**

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -63,7 +63,7 @@ class Text
             'chat/completions',
             array_merge([
                 'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompt() ?? ''))(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens ?? 2048,
             ], array_filter([
                 'temperature' => $request->temperature(),

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -64,7 +64,7 @@ class Text
             array_merge([
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                'max_tokens' => $request->maxTokens ?? 2048,
+                'max_tokens' => $request->maxTokens() ?? 2048,
             ], array_filter([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),

--- a/src/Providers/XAI/Maps/MessageMap.php
+++ b/src/Providers/XAI/Maps/MessageMap.php
@@ -20,17 +20,16 @@ class MessageMap
 
     /**
      * @param  array<int, Message>  $messages
+     * @param  SystemMessage[]  $systemPrompts
      */
     public function __construct(
         protected array $messages,
-        protected string $systemPrompt
+        protected array $systemPrompts
     ) {
-        if ($systemPrompt !== '' && $systemPrompt !== '0') {
-            $this->messages = array_merge(
-                [new SystemMessage($systemPrompt)],
-                $this->messages
-            );
-        }
+        $this->messages = array_merge(
+            $this->systemPrompts,
+            $this->messages
+        );
     }
 
     /**

--- a/src/Structured/Generator.php
+++ b/src/Structured/Generator.php
@@ -9,10 +9,14 @@ use EchoLabs\Prism\Contracts\Provider;
 use EchoLabs\Prism\Enums\FinishReason;
 use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\ProviderResponse;
 
 class Generator
 {
+    /** @var SystemMessage[] */
+    protected array $systemPrompts = [];
+
     /** @var Message[] */
     protected array $messages = [];
 
@@ -25,6 +29,7 @@ class Generator
 
     public function generate(Request $request): Response
     {
+        $this->systemPrompts = $request->systemPrompts();
         $this->messages = $request->messages();
 
         $response = $this->sendProviderRequest($request);
@@ -36,6 +41,7 @@ class Generator
             usage: $response->usage,
             responseMeta: $response->responseMeta,
             messages: $this->messages,
+            systemPrompts: $this->systemPrompts,
             additionalContent: $response->additionalContent,
         ));
 

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -13,7 +13,6 @@ use EchoLabs\Prism\Concerns\HasPrompts;
 use EchoLabs\Prism\Concerns\HasProviderMeta;
 use EchoLabs\Prism\Concerns\HasSchema;
 use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ProviderResponse;
 use ReflectionMethod;
@@ -59,10 +58,6 @@ class PendingRequest
 
         $messages = $this->messages;
 
-        if ($this->systemPrompt) {
-            $messages[] = new SystemMessage($this->systemPrompt);
-        }
-
         if ($this->prompt) {
             $messages[] = new UserMessage($this->prompt);
         }
@@ -73,7 +68,7 @@ class PendingRequest
 
         return new Request(
             model: $this->model,
-            systemPrompt: $this->systemPrompt,
+            systemPrompts: $this->systemPrompts,
             prompt: $this->prompt,
             messages: $messages,
             temperature: $this->temperature,

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -50,6 +50,7 @@ class Request implements PrismRequest
         return $this->systemPrompts;
     }
 
+    #[\Override]
     public function model(): string
     {
         return $this->model;

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -19,13 +19,14 @@ class Request implements PrismRequest
     use ChecksSelf, HasProviderMeta;
 
     /**
+     * @param  SystemMessage[]  $systemPrompts
      * @param  array<int, Message>  $messages
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerMeta
      */
     public function __construct(
-        protected ?string $systemPrompt,
+        protected array $systemPrompts,
         protected string $model,
         protected ?string $prompt,
         protected array $messages,
@@ -41,9 +42,12 @@ class Request implements PrismRequest
         $this->providerMeta = $providerMeta;
     }
 
-    public function systemPrompt(): ?string
+    /**
+     * @return SystemMessage[]
+     */
+    public function systemPrompts(): array
     {
-        return $this->systemPrompt;
+        return $this->systemPrompts;
     }
 
     public function model(): string

--- a/src/Structured/Step.php
+++ b/src/Structured/Step.php
@@ -6,6 +6,7 @@ namespace EchoLabs\Prism\Structured;
 
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\FinishReason;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
 use EchoLabs\Prism\ValueObjects\Usage;
 
@@ -14,6 +15,7 @@ readonly class Step
     /**
      * @param  array<mixed>|null  $object
      * @param  Message[]  $messages
+     * @param  SystemMessage[]  $systemPrompts
      * @param  array<string,mixed>  $additionalContent
      */
     public function __construct(
@@ -23,6 +25,7 @@ readonly class Step
         public readonly Usage $usage,
         public readonly ResponseMeta $responseMeta,
         public readonly array $messages,
+        public readonly array $systemPrompts,
         public readonly array $additionalContent = []
     ) {}
 }

--- a/src/Text/Generator.php
+++ b/src/Text/Generator.php
@@ -52,6 +52,7 @@ class Generator
             usage: $response->usage,
             responseMeta: $response->responseMeta,
             messages: $request->messages(),
+            systemPrompts: $request->systemPrompts(),
             additionalContent: $response->additionalContent,
         ));
 

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -14,7 +14,6 @@ use EchoLabs\Prism\Concerns\HasPrompts;
 use EchoLabs\Prism\Concerns\HasProviderMeta;
 use EchoLabs\Prism\Concerns\HasTools;
 use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ProviderResponse;
 use ReflectionMethod;
@@ -61,17 +60,13 @@ class PendingRequest
 
         $messages = $this->messages;
 
-        if ($this->systemPrompt) {
-            $messages[] = new SystemMessage($this->systemPrompt);
-        }
-
         if ($this->prompt) {
             $messages[] = new UserMessage($this->prompt);
         }
 
         return new Request(
             model: $this->model,
-            systemPrompt: $this->systemPrompt,
+            systemPrompts: $this->systemPrompts,
             prompt: $this->prompt,
             messages: $messages,
             temperature: $this->temperature,

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -113,6 +113,7 @@ class Request implements PrismRequest
         return $this->systemPrompts;
     }
 
+    #[\Override]
     public function model(): string
     {
         return $this->model;

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -11,12 +11,14 @@ use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Contracts\PrismRequest;
 use EchoLabs\Prism\Enums\ToolChoice;
 use EchoLabs\Prism\Tool;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
 {
     use ChecksSelf, HasProviderMeta;
 
     /**
+     * @param  SystemMessage[]  $systemPrompts
      * @param  array<int, Message>  $messages
      * @param  array<int, Tool>  $tools
      * @param  array<string, mixed>  $clientOptions
@@ -25,7 +27,7 @@ class Request implements PrismRequest
      */
     public function __construct(
         protected string $model,
-        protected ?string $systemPrompt,
+        protected array $systemPrompts,
         protected ?string $prompt,
         protected array $messages,
         protected int $maxSteps,
@@ -103,9 +105,12 @@ class Request implements PrismRequest
         return $this->prompt;
     }
 
-    public function systemPrompt(): ?string
+    /**
+     * @return SystemMessage[]
+     */
+    public function systemPrompts(): array
     {
-        return $this->systemPrompt;
+        return $this->systemPrompts;
     }
 
     public function model(): string

--- a/src/Text/Step.php
+++ b/src/Text/Step.php
@@ -6,6 +6,7 @@ namespace EchoLabs\Prism\Text;
 
 use EchoLabs\Prism\Contracts\Message;
 use EchoLabs\Prism\Enums\FinishReason;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
 use EchoLabs\Prism\ValueObjects\ToolCall;
 use EchoLabs\Prism\ValueObjects\ToolResult;
@@ -17,6 +18,7 @@ readonly class Step
      * @param  ToolCall[]  $toolCalls
      * @param  ToolResult[]  $toolResults
      * @param  Message[]  $messages
+     * @param  SystemMessage[]  $systemPrompts
      * @param  array<string,mixed>  $additionalContent
      */
     public function __construct(
@@ -27,6 +29,7 @@ readonly class Step
         public readonly Usage $usage,
         public readonly ResponseMeta $responseMeta,
         public readonly array $messages,
+        public readonly array $systemPrompts,
         public readonly array $additionalContent = []
     ) {}
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,15 @@
 */
 
 uses(Tests\TestCase::class)->in(__DIR__);
+uses()->group('providers')->in('Providers');
+uses()->group('anthropic')->in('Providers/Anthropic');
+uses()->group('deepseek')->in('Providers/DeepSeek');
+uses()->group('gemini')->in('Providers/Gemini');
+uses()->group('groq')->in('Providers/Groq');
+uses()->group('mistral')->in('Providers/Mistral');
+uses()->group('ollama')->in('Providers/Ollama');
+uses()->group('openai')->in('Providers/OpenAI');
+uses()->group('xai')->in('Providers/XAI');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -11,7 +11,6 @@ use EchoLabs\Prism\Providers\Anthropic\Handlers\Text;
 use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Http\Client\Request;
@@ -174,7 +173,6 @@ it('can calculate cache usage correctly', function (): void {
     $response = Prism::text()
         ->using('anthropic', 'claude-3-5-sonnet-20240620')
         ->withMessages([
-            (new SystemMessage('Old context'))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
             (new UserMessage('New context'))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
         ])
         ->generate();

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -29,18 +29,6 @@ it('maps user messages', function (): void {
     ]]);
 });
 
-it('filters system messages out when calling map', function (): void {
-    expect(MessageMap::map([
-        new UserMessage('Who are you?'),
-        new SystemMessage('I am Groot.'),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            ['type' => 'text', 'text' => 'Who are you?'],
-        ],
-    ]]);
-});
-
 it('maps user messages with images from path', function (): void {
     $mappedMessage = MessageMap::map([
         new UserMessage('Who are you?', [
@@ -242,17 +230,17 @@ it('maps tool result messages', function (): void {
 });
 
 it('maps system messages', function (): void {
-    expect(MessageMap::mapSystemMessages(
-        [new SystemMessage('Who are you?'), new UserMessage('I am rocket.')],
-        'I am Thanos. Me first.'
-    ))->toBe([
+    expect(MessageMap::mapSystemMessages([
+        new SystemMessage('I am Thanos.'),
+        new SystemMessage('But call me Bob.'),
+    ]))->toBe([
         [
             'type' => 'text',
-            'text' => 'I am Thanos. Me first.',
+            'text' => 'I am Thanos.',
         ],
         [
             'type' => 'text',
-            'text' => 'Who are you?',
+            'text' => 'But call me Bob.',
         ],
     ]);
 });
@@ -350,7 +338,7 @@ it('sets the cache type on an AssistantMessage if cacheType providerMeta is set 
 it('sets the cache type on a SystemMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
     expect(MessageMap::mapSystemMessages([
         (new SystemMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
-    ], null))->toBe([
+    ]))->toBe([
         [
             'type' => 'text',
             'text' => 'Who are you?',

--- a/tests/Providers/DeepSeek/MessageMapTest.php
+++ b/tests/Providers/DeepSeek/MessageMapTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use EchoLabs\Prism\Providers\DeepSeek\Maps\MessageMap;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ToolCall;
@@ -15,7 +16,7 @@ it('maps user messages', function (): void {
         messages: [
             new UserMessage('Who are you?'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -33,7 +34,7 @@ it('maps user messages with images from path', function (): void {
                 Image::fromPath('tests/Fixtures/test-image.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -53,7 +54,7 @@ it('maps user messages with images from base64', function (): void {
                 Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -73,7 +74,7 @@ it('maps user messages with images from url', function (): void {
                 Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -89,7 +90,7 @@ it('maps assistant message', function (): void {
         messages: [
             new AssistantMessage('I am Nyx'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toContain([
@@ -111,7 +112,7 @@ it('maps assistant message with tool calls', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -144,7 +145,7 @@ it('maps tool result messages', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -156,12 +157,27 @@ it('maps tool result messages', function (): void {
 
 it('maps system prompt', function (): void {
     $messageMap = new MessageMap(
-        messages: [],
-        systemPrompt: 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'
+        messages: [new UserMessage('Who are you?')],
+        systemPrompts: [
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'),
+            new SystemMessage('But my friends call me Nyx'),
+        ]
     );
 
-    expect($messageMap())->toContain([
-        'role' => 'system',
-        'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+    expect($messageMap())->toBe([
+        [
+            'role' => 'system',
+            'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+        ],
+        [
+            'role' => 'system',
+            'content' => 'But my friends call me Nyx',
+        ],
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
+            ],
+        ],
     ]);
 });

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -132,7 +132,7 @@ describe('Text generation for Groq', function (): void {
         $this->expectExceptionMessage('Invalid tool choice');
 
         Prism::text()
-            ->using('openai', 'gpt-4')
+            ->using('groq', 'gpt-4')
             ->withPrompt('Who are you?')
             ->withToolChoice(ToolChoice::Any)
             ->generate();

--- a/tests/Providers/Groq/MessageMapTest.php
+++ b/tests/Providers/Groq/MessageMapTest.php
@@ -7,6 +7,7 @@ namespace Tests\Providers\Groq;
 use EchoLabs\Prism\Providers\Groq\Maps\MessageMap;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ToolCall;
@@ -17,7 +18,7 @@ it('maps user messages', function (): void {
         messages: [
             new UserMessage('Who are you?'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -35,7 +36,7 @@ it('maps user messages with images from path', function (): void {
                 Image::fromPath('tests/Fixtures/test-image.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -55,7 +56,7 @@ it('maps user messages with images from base64', function (): void {
                 Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -75,7 +76,7 @@ it('maps user messages with images from url', function (): void {
                 Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -91,7 +92,7 @@ it('maps assistant message', function (): void {
         messages: [
             new AssistantMessage('I am Nyx'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toContain([
@@ -113,7 +114,7 @@ it('maps assistant message with tool calls', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -146,7 +147,7 @@ it('maps tool result messages', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -158,12 +159,27 @@ it('maps tool result messages', function (): void {
 
 it('maps system prompt', function (): void {
     $messageMap = new MessageMap(
-        messages: [],
-        systemPrompt: 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'
+        messages: [new UserMessage('Who are you?')],
+        systemPrompts: [
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'),
+            new SystemMessage('But my friends call me Nyx'),
+        ]
     );
 
-    expect($messageMap())->toContain([
-        'role' => 'system',
-        'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+    expect($messageMap())->toBe([
+        [
+            'role' => 'system',
+            'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+        ],
+        [
+            'role' => 'system',
+            'content' => 'But my friends call me Nyx',
+        ],
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
+            ],
+        ],
     ]);
 });

--- a/tests/Providers/Mistral/MessageMapTest.php
+++ b/tests/Providers/Mistral/MessageMapTest.php
@@ -7,6 +7,7 @@ namespace Tests\Providers\Mistral;
 use EchoLabs\Prism\Providers\Mistral\Maps\MessageMap;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ToolCall;
@@ -17,7 +18,7 @@ it('maps user messages', function (): void {
         messages: [
             new UserMessage('Who are you?'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -35,7 +36,7 @@ it('maps user messages with images', function (): void {
                 Image::fromPath('tests/Fixtures/test-image.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -53,7 +54,7 @@ it('maps assistant message', function (): void {
         messages: [
             new AssistantMessage('I am Nyx'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toContain([
@@ -75,7 +76,7 @@ it('maps assistant message with tool calls', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -108,7 +109,7 @@ it('maps tool result messages', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -120,12 +121,27 @@ it('maps tool result messages', function (): void {
 
 it('maps system prompt', function (): void {
     $messageMap = new MessageMap(
-        messages: [],
-        systemPrompt: 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'
+        messages: [new UserMessage('Who are you?')],
+        systemPrompts: [
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'),
+            new SystemMessage('But my friends call me Nyx'),
+        ]
     );
 
-    expect($messageMap())->toContain([
-        'role' => 'system',
-        'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+    expect($messageMap())->toBe([
+        [
+            'role' => 'system',
+            'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+        ],
+        [
+            'role' => 'system',
+            'content' => 'But my friends call me Nyx',
+        ],
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
+            ],
+        ],
     ]);
 });

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Providers\Ollama;
 
 use EchoLabs\Prism\Enums\Provider;
+use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Facades\Tool;
 use EchoLabs\Prism\Prism;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
@@ -181,3 +182,17 @@ describe('Image support', function (): void {
         });
     });
 });
+
+it('throws an exception with multiple system prompts', function (): void {
+    Http::preventStrayRequests();
+
+    $response = Prism::text()
+        ->using('ollama', 'qwen2.5:14b')
+        ->withSystemPrompts([
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!'),
+            new SystemMessage('But my friends call my Nyx.'),
+        ])
+        ->withPrompt('Who are you?')
+        ->generate();
+
+})->throws(PrismException::class, 'Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -7,6 +7,7 @@ namespace Tests\Providers\OpenAI;
 use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ToolCall;
@@ -17,7 +18,7 @@ it('maps user messages', function (): void {
         messages: [
             new UserMessage('Who are you?'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -35,7 +36,7 @@ it('maps user messages with images from path', function (): void {
                 Image::fromPath('tests/Fixtures/test-image.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -55,7 +56,7 @@ it('maps user messages with images from base64', function (): void {
                 Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -75,7 +76,7 @@ it('maps user messages with images from url', function (): void {
                 Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     $mappedMessage = $messageMap();
@@ -91,7 +92,7 @@ it('maps assistant message', function (): void {
         messages: [
             new AssistantMessage('I am Nyx'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toContain([
@@ -113,7 +114,7 @@ it('maps assistant message with tool calls', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -146,7 +147,7 @@ it('maps tool result messages', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -158,12 +159,27 @@ it('maps tool result messages', function (): void {
 
 it('maps system prompt', function (): void {
     $messageMap = new MessageMap(
-        messages: [],
-        systemPrompt: 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'
+        messages: [new UserMessage('Who are you?')],
+        systemPrompts: [
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'),
+            new SystemMessage('But my friends call me Nyx'),
+        ]
     );
 
-    expect($messageMap())->toContain([
-        'role' => 'system',
-        'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+    expect($messageMap())->toBe([
+        [
+            'role' => 'system',
+            'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+        ],
+        [
+            'role' => 'system',
+            'content' => 'But my friends call me Nyx',
+        ],
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
+            ],
+        ],
     ]);
 });

--- a/tests/Providers/XAI/MessageMapTest.php
+++ b/tests/Providers/XAI/MessageMapTest.php
@@ -7,6 +7,7 @@ namespace Tests\Providers\XAI;
 use EchoLabs\Prism\Providers\XAI\Maps\MessageMap;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use EchoLabs\Prism\ValueObjects\ToolCall;
@@ -17,7 +18,7 @@ it('maps user messages', function (): void {
         messages: [
             new UserMessage('Who are you?'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -33,7 +34,7 @@ it('maps assistant message', function (): void {
         messages: [
             new AssistantMessage('I am Nyx'),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toContain([
@@ -55,7 +56,7 @@ it('maps assistant message with tool calls', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -88,7 +89,7 @@ it('maps tool result messages', function (): void {
                 ),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -100,13 +101,28 @@ it('maps tool result messages', function (): void {
 
 it('maps system prompt', function (): void {
     $messageMap = new MessageMap(
-        messages: [],
-        systemPrompt: 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'
+        messages: [new UserMessage('Who are you?')],
+        systemPrompts: [
+            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]'),
+            new SystemMessage('But my friends call me Nyx'),
+        ]
     );
 
-    expect($messageMap())->toContain([
-        'role' => 'system',
-        'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+    expect($messageMap())->toBe([
+        [
+            'role' => 'system',
+            'content' => 'MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]',
+        ],
+        [
+            'role' => 'system',
+            'content' => 'But my friends call me Nyx',
+        ],
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
+            ],
+        ],
     ]);
 });
 
@@ -117,7 +133,7 @@ it('maps user messages with images from path', function (): void {
                 Image::fromPath('tests/Fixtures/test-image.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -141,7 +157,7 @@ it('maps user messages with images from base64', function (): void {
                 Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[
@@ -165,7 +181,7 @@ it('maps user messages with images from url', function (): void {
                 Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
             ]),
         ],
-        systemPrompt: ''
+        systemPrompts: []
     );
 
     expect($messageMap())->toBe([[

--- a/tests/Structured/GeneratorTest.php
+++ b/tests/Structured/GeneratorTest.php
@@ -35,7 +35,7 @@ it('generates structured responses', function (): void {
 
     $generator = new Generator($fakeProvider);
     $request = new Request(
-        systemPrompt: 'test prompt',
+        systemPrompts: [],
         model: 'test-model',
         prompt: 'generate data',
         messages: [],
@@ -91,7 +91,7 @@ it('handles invalid JSON responses', function (): void {
 
     $generator = new Generator($fakeProvider);
     $request = new Request(
-        systemPrompt: 'test prompt',
+        systemPrompts: [],
         model: 'test-model',
         prompt: 'generate data',
         messages: [],
@@ -135,7 +135,7 @@ it('tracks provider responses properly', function (): void {
 
     $generator = new Generator($fakeProvider);
     $request = new Request(
-        systemPrompt: 'test prompt',
+        systemPrompts: [],
         model: 'test-model',
         prompt: 'generate data',
         messages: [],
@@ -172,7 +172,7 @@ it('tracks provider responses properly', function (): void {
     });
 });
 
-test('it adds system message user message and assistant message response to first step', function (): void {
+test('it adds user message and assistant message response to first step', function (): void {
     Prism::fake([
         new ProviderResponse(
             text: json_encode(['I am a string']),
@@ -192,27 +192,59 @@ test('it adds system message user message and assistant message response to firs
     $response = $request->generate();
 
     expect($response)->toBeInstanceOf(Response::class);
-    expect($response->steps[0]->messages)->toHaveCount(3);
-
-    /** @var SystemMessage */
-    $system_message = $response->steps[0]->messages[0];
-
-    expect($system_message)->toBeInstanceOf(SystemMessage::class)
-        ->and($system_message->content)
-        ->toBe('System Prompt');
+    expect($response->steps[0]->messages)->toHaveCount(2);
 
     /** @var UserMessage */
-    $user_message = $response->steps[0]->messages[1];
+    $user_message = $response->steps[0]->messages[0];
 
     expect($user_message)->toBeInstanceOf(UserMessage::class)
         ->and($user_message->text())
         ->toBe('User Prompt');
 
     /** @var AssistantMessage */
-    $assistant_message = $response->steps[0]->messages[2];
+    $assistant_message = $response->steps[0]->messages[1];
 
     expect($assistant_message)->toBeInstanceOf(AssistantMessage::class)
         ->and($assistant_message->content)
         ->toBe(json_encode(['I am a string']));
+});
 
+test('it adds system prompts first step', function (): void {
+    Prism::fake([
+        new ProviderResponse(
+            text: json_encode(['I am a string']),
+            toolCalls: [],
+            usage: new Usage(5, 10),
+            finishReason: FinishReason::Stop,
+            responseMeta: new ResponseMeta('fake-1', 'fake-model'),
+        ),
+    ]);
+
+    $request = Prism::structured()
+        ->using(Provider::Anthropic, 'test')
+        ->withSchema(new ArraySchema('test schema', 'testing', new StringSchema('stringy', 'string')))
+        ->withSystemPrompts([
+            new SystemMessage('System Prompt 1'),
+            new SystemMessage('System Prompt 2'),
+        ])
+        ->withPrompt('User Prompt');
+
+    $response = $request->generate();
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->steps[0]->systemPrompts)->toHaveCount(2);
+
+    /** @var SystemMessage */
+    $messageOne = $response->steps[0]->systemPrompts[0];
+
+    expect($messageOne)->toBeInstanceOf(SystemMessage::class)
+        ->and($messageOne->content)
+        ->toBe('System Prompt 1');
+
+    /** @var SystemMessage */
+    $messageTwo = $response->steps[0]->systemPrompts[1];
+
+    expect($messageTwo)->toBeInstanceOf(SystemMessage::class)
+        ->and($messageTwo->content)
+        ->toBe('System Prompt 2');
 });

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -8,6 +8,7 @@ use EchoLabs\Prism\Exceptions\PrismException;
 use EchoLabs\Prism\Schema\StringSchema;
 use EchoLabs\Prism\Structured\PendingRequest;
 use EchoLabs\Prism\Structured\Request;
+use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 
 beforeEach(function (): void {
@@ -53,7 +54,7 @@ test('it generates a proper request object', function (): void {
     $schema = new StringSchema('test', 'test description');
     $model = 'gpt-4';
     $prompt = 'Test prompt';
-    $systemPrompt = 'System prompt';
+    $systemPrompts = [new SystemMessage('Test system prompt')];
     $temperature = 0.7;
     $maxTokens = 100;
     $topP = 0.9;
@@ -65,7 +66,7 @@ test('it generates a proper request object', function (): void {
         ->using(Provider::OpenAI, $model)
         ->withSchema($schema)
         ->withPrompt($prompt)
-        ->withSystemPrompt($systemPrompt)
+        ->withSystemPrompt($systemPrompts[0])
         ->usingTemperature($temperature)
         ->withMaxTokens($maxTokens)
         ->usingTopP($topP)
@@ -77,7 +78,7 @@ test('it generates a proper request object', function (): void {
     expect($request)
         ->toBeInstanceOf(Request::class)
         ->model()->toBe($model)
-        ->systemPrompt()->toBe($systemPrompt)
+        ->systemPrompts()->toBe($systemPrompts)
         ->prompt()->toBe($prompt)
         ->schema()->toBe($schema)
         ->temperature()->toBe($temperature)

--- a/tests/Structured/ResponseBuilderTest.php
+++ b/tests/Structured/ResponseBuilderTest.php
@@ -14,6 +14,7 @@ test('throws a PrismStructuredDecodingException if the response is not valid jso
 
     $builder->addStep(new Step(
         text: 'This is not valid json',
+        systemPrompts: [],
         object: null,
         finishReason: FinishReason::Stop,
         usage: new Usage(

--- a/tests/Text/GeneratorTest.php
+++ b/tests/Text/GeneratorTest.php
@@ -307,7 +307,7 @@ test('it correctly builds message chain with tools', function (): void {
         );
 });
 
-test('it adds the system message user message and assistant response to first step', function (): void {
+test('it adds the user message and assistant response to first step', function (): void {
     $request = (new PendingRequest)
         ->using('test-provider', 'test-model')
         ->withSystemPrompt('System Prompt')
@@ -317,24 +317,46 @@ test('it adds the system message user message and assistant response to first st
 
     expect($response)->toBeInstanceOf(Response::class);
 
-    /** @var SystemMessage */
-    $system_message = $response->steps[0]->messages[0];
-
-    expect($system_message)->toBeInstanceOf(SystemMessage::class)
-        ->and($system_message->content)
-        ->toBe('System Prompt');
-
     /** @var UserMessage */
-    $user_message = $response->steps[0]->messages[1];
+    $user_message = $response->steps[0]->messages[0];
 
     expect($user_message)->toBeInstanceOf(UserMessage::class)
         ->and($user_message->text())
         ->toBe('User Prompt');
 
     /** @var AssistantMessage */
-    $assistant_message = $response->steps[0]->messages[2];
+    $assistant_message = $response->steps[0]->messages[1];
 
     expect($assistant_message)->toBeInstanceOf(AssistantMessage::class)
         ->and($assistant_message->content)
         ->toBe("I'm nyx!");
+});
+
+test('it adds system prompts first step', function (): void {
+    $request = (new PendingRequest)
+        ->using('test-provider', 'test-model')
+        ->withSystemPrompts([
+            new SystemMessage('System Prompt 1'),
+            new SystemMessage('System Prompt 2'),
+        ])
+        ->withPrompt('User Prompt');
+
+    $response = $request->generate();
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->steps[0]->systemPrompts)->toHaveCount(2);
+
+    /** @var SystemMessage */
+    $messageOne = $response->steps[0]->systemPrompts[0];
+
+    expect($messageOne)->toBeInstanceOf(SystemMessage::class)
+        ->and($messageOne->content)
+        ->toBe('System Prompt 1');
+
+    /** @var SystemMessage */
+    $messageTwo = $response->steps[0]->systemPrompts[1];
+
+    expect($messageTwo)->toBeInstanceOf(SystemMessage::class)
+        ->and($messageTwo->content)
+        ->toBe('System Prompt 2');
 });

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -274,18 +274,6 @@ test('it can set system prompts', function (): void {
         );
 });
 
-test('throws an exception if using withSystemPrompts with system prompts already set', function (): void {
-    $request = $this->pendingRequest
-        ->using(Provider::OpenAI, 'gpt-4')
-        ->withSystemPrompt('Prompt 1')
-        ->withSystemPrompts([
-            new SystemMessage('Prompt 1'),
-            new SystemMessage('Prompt 2'),
-        ]);
-
-    $generated = $request->toRequest();
-})->throws(PrismException::class, 'System prompts have already been set. Remove previous calls to withSystemPrompt or withSystemPrompts.');
-
 test('it throws exception when using both prompt and messages', function (): void {
     $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')


### PR DESCRIPTION
In preparation for #185, as discussed I have replaced systemPrompt with systemPrompts.

I have done this on top of #188. If that changes, I can rebase this to main once that is merged.

It was a bit fiddley to do, but I think the outcome is worth it. Much less confusing and much more flexible for the providers which will be handy come provider refactor.

It comes with two relatively minor breaking changes:

- Anthropic no longer supports `SystemMessage`s in the `messages` array. The exception instructs users to use `withSystemPrompt` or `withSystemPrompts` instead.
- `SystemMessage`s will no longer appear in `Step->messages`. They will appear in `Step->systemPrompts` instead.

All other providers behavior remains in tact. Where a provider (e.g. Ollama) only accepts one "separate" system instruction, we throw an exception to let the dev know if more than one is provided.

Fixes #158. Relevant to to #160.
