### PR TITLE
refactor(anthropic): return final Response

### DIFF
--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -49,7 +49,7 @@ readonly class Anthropic implements Provider
             $request
         );
 
-        return $handler->generate();
+        return $handler->handle();
     }
 
     #[\Override]

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -10,8 +10,9 @@ use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
 use EchoLabs\Prism\Providers\Anthropic\Handlers\Structured;
 use EchoLabs\Prism\Providers\Anthropic\Handlers\Text;
 use EchoLabs\Prism\Structured\Request as StructuredRequest;
+use EchoLabs\Prism\Structured\Response as StructuredResponse;
 use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\ValueObjects\ProviderResponse;
+use EchoLabs\Prism\Text\Response;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 
@@ -24,25 +25,31 @@ readonly class Anthropic implements Provider
     ) {}
 
     #[\Override]
-    public function text(TextRequest $request): ProviderResponse
+    public function text(TextRequest $request): Response
     {
-        $handler = new Text($this->client(
-            $request->clientOptions(),
-            $request->clientRetry()
-        ));
+        $handler = new Text(
+            $this->client(
+                $request->clientOptions(),
+                $request->clientRetry()
+            ),
+            $request
+        );
 
-        return $handler->handle($request);
+        return $handler->handle();
     }
 
     #[\Override]
-    public function structured(StructuredRequest $request): ProviderResponse
+    public function structured(StructuredRequest $request): StructuredResponse
     {
-        $handler = new Structured($this->client(
-            $request->clientOptions(),
-            $request->clientRetry()
-        ));
+        $handler = new Structured(
+            $this->client(
+                $request->clientOptions(),
+                $request->clientRetry()
+            ),
+            $request
+        );
 
-        return $handler->handle($request);
+        return $handler->generate();
     }
 
     #[\Override]

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -55,7 +55,6 @@ class Structured extends AnthropicHandlerAbstract
 
         $this->responseBuilder->addStep(new Step(
             text: $this->tempResponse->text,
-            object: json_decode($this->tempResponse->text, true),
             finishReason: $this->tempResponse->finishReason,
             usage: $this->tempResponse->usage,
             responseMeta: $this->tempResponse->responseMeta,

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -36,7 +36,7 @@ class Structured extends AnthropicHandlerAbstract
         $this->responseBuilder = new ResponseBuilder;
     }
 
-    public function generate(): Response
+    public function handle(): Response
     {
         $this->appendMessageForJsonMode();
 

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -9,11 +9,14 @@ use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
 use EchoLabs\Prism\Structured\Request as StructuredRequest;
+use EchoLabs\Prism\Structured\Response;
+use EchoLabs\Prism\Structured\ResponseBuilder;
+use EchoLabs\Prism\Structured\Step;
+use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ProviderResponse;
 use EchoLabs\Prism\ValueObjects\ResponseMeta;
 use EchoLabs\Prism\ValueObjects\Usage;
-use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Collection;
 
 class Structured extends AnthropicHandlerAbstract
 {
@@ -22,7 +25,47 @@ class Structured extends AnthropicHandlerAbstract
      */
     protected PrismRequest $request; // Redeclared for type hinting
 
-    public function __construct(protected PendingRequest $client) {}
+    protected Response $tempResponse;
+
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(mixed ...$args)
+    {
+        parent::__construct(...$args);
+
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    public function generate(): Response
+    {
+        $this->appendMessageForJsonMode();
+
+        $this->sendRequest();
+
+        $this->prepareTempResponse();
+
+        $responseMessage = new AssistantMessage(
+            $this->tempResponse->text,
+            [],
+            $this->tempResponse->additionalContent
+        );
+
+        $this->request->addMessage($responseMessage);
+        $this->responseBuilder->addResponseMessage($responseMessage);
+
+        $this->responseBuilder->addStep(new Step(
+            text: $this->tempResponse->text,
+            object: json_decode($this->tempResponse->text, true),
+            finishReason: $this->tempResponse->finishReason,
+            usage: $this->tempResponse->usage,
+            responseMeta: $this->tempResponse->responseMeta,
+            messages: $this->request->messages(),
+            systemPrompts: $this->request->systemPrompts(),
+            additionalContent: $this->tempResponse->additionalContent,
+        ));
+
+        return $this->responseBuilder->toResponse();
+    }
 
     /**
      * @param  StructuredRequest  $request
@@ -46,30 +89,22 @@ class Structured extends AnthropicHandlerAbstract
         ]));
     }
 
-    /**
-     * @return StructuredRequest
-     */
-    #[\Override]
-    protected function prepareRequest(): PrismRequest
-    {
-        return $this->appendMessageForJsonMode();
-    }
-
-    #[\Override]
-    protected function buildProviderResponse(): ProviderResponse
+    protected function prepareTempResponse(): void
     {
         $data = $this->httpResponse->json();
 
-        return new ProviderResponse(
+        $this->tempResponse = new Response(
+            steps: new Collection,
+            responseMessages: new Collection,
             text: $this->extractText($data),
-            toolCalls: [],
+            structured: [],
+            finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
             usage: new Usage(
                 promptTokens: data_get($data, 'usage.input_tokens'),
                 completionTokens: data_get($data, 'usage.output_tokens'),
                 cacheWriteInputTokens: data_get($data, 'usage.cache_creation_input_tokens', null),
                 cacheReadInputTokens: data_get($data, 'usage.cache_read_input_tokens', null)
             ),
-            finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
             responseMeta: new ResponseMeta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
@@ -81,12 +116,9 @@ class Structured extends AnthropicHandlerAbstract
         );
     }
 
-    /**
-     * @return StructuredRequest
-     */
-    protected function appendMessageForJsonMode(): PrismRequest
+    protected function appendMessageForJsonMode(): void
     {
-        return $this->request->addMessage(new UserMessage(sprintf(
+        $this->request->addMessage(new UserMessage(sprintf(
             "Respond with ONLY JSON that matches the following schema: \n %s %s",
             json_encode($this->request->schema()->toArray(), JSON_PRETTY_PRINT),
             ($this->request->providerMeta(Provider::Anthropic)['citations'] ?? false)

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -4,25 +4,26 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\Enums\Provider;
-use Illuminate\Support\Collection;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\Usage;
 use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use EchoLabs\Prism\Contracts\PrismRequest;
+use EchoLabs\Prism\Enums\FinishReason;
+use EchoLabs\Prism\Enums\Provider;
 use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\ResponseMeta;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
+use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
+use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
+use EchoLabs\Prism\Text\Request as TextRequest;
+use EchoLabs\Prism\Text\Response;
+use EchoLabs\Prism\Text\ResponseBuilder;
+use EchoLabs\Prism\Text\Step;
 use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
 use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use EchoLabs\Prism\ValueObjects\ResponseMeta;
+use EchoLabs\Prism\ValueObjects\ToolCall;
+use EchoLabs\Prism\ValueObjects\ToolResult;
+use EchoLabs\Prism\ValueObjects\Usage;
+use Illuminate\Support\Collection;
 
 /**
  * @template TRequest of TextRequest
@@ -117,6 +118,9 @@ class Text extends AnthropicHandlerAbstract
         return $this->responseBuilder->toResponse();
     }
 
+    /**
+     * @param  ToolResult[]  $toolResults
+     */
     protected function addStep(array $toolResults = []): void
     {
         $this->responseBuilder->addStep(new Step(
@@ -133,7 +137,7 @@ class Text extends AnthropicHandlerAbstract
     }
 
     protected function shouldContinue(): bool
-    {       
+    {
         return $this->responseBuilder->steps->count() < $this->request->maxSteps();
     }
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -4,23 +4,72 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Contracts\PrismRequest;
+use EchoLabs\Prism\Text\Step;
+use EchoLabs\Prism\Text\Response;
 use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use Illuminate\Support\Collection;
+use EchoLabs\Prism\Enums\FinishReason;
+use EchoLabs\Prism\ValueObjects\Usage;
+use EchoLabs\Prism\Concerns\CallsTools;
+use EchoLabs\Prism\Text\ResponseBuilder;
+use EchoLabs\Prism\ValueObjects\ToolCall;
+use EchoLabs\Prism\Contracts\PrismRequest;
+use EchoLabs\Prism\Exceptions\PrismException;
+use EchoLabs\Prism\ValueObjects\ResponseMeta;
+use EchoLabs\Prism\Text\Request as TextRequest;
+use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
 use EchoLabs\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\ValueObjects\ProviderResponse;
-use EchoLabs\Prism\ValueObjects\ResponseMeta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\Usage;
+use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
+use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
 
 /**
  * @template TRequest of TextRequest
  */
 class Text extends AnthropicHandlerAbstract
 {
+    use CallsTools;
+
+    /**
+     * @var TextRequest
+     */
+    protected PrismRequest $request; // Redeclared for type hinting
+
+    protected Response $tempResponse;
+
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(mixed ...$args)
+    {
+        parent::__construct(...$args);
+
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    public function handle(): Response
+    {
+        $this->sendRequest();
+
+        $this->prepareTempResponse();
+
+        $responseMessage = new AssistantMessage(
+            $this->tempResponse->text,
+            $this->tempResponse->toolCalls,
+            $this->tempResponse->additionalContent,
+        );
+
+        $this->responseBuilder->addResponseMessage($responseMessage);
+
+        $this->request->addMessage($responseMessage);
+
+        return match ($this->tempResponse->finishReason) {
+            FinishReason::ToolCalls => $this->handleToolCalls(),
+            FinishReason::Stop => $this->handleStop(),
+            default => throw new PrismException('Anthropic: unknown finish reason'),
+        };
+    }
+
     /**
      * @param  TextRequest  $request
      * @return array<string, mixed>
@@ -45,27 +94,67 @@ class Text extends AnthropicHandlerAbstract
         ]));
     }
 
-    #[\Override]
-    protected function prepareRequest(): PrismRequest
+    protected function handleToolCalls(): Response
     {
-        return $this->request;
+        $toolResults = $this->callTools($this->request->tools(), $this->tempResponse->toolCalls);
+        $message = new ToolResultMessage($toolResults);
+
+        $this->request->addMessage($message);
+
+        $this->addStep($toolResults);
+
+        if ($this->shouldContinue()) {
+            return $this->handle();
+        }
+
+        return $this->responseBuilder->toResponse();
     }
 
-    #[\Override]
-    protected function buildProviderResponse(): ProviderResponse
+    protected function handleStop(): Response
+    {
+        $this->addStep();
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    protected function addStep(array $toolResults = []): void
+    {
+        $this->responseBuilder->addStep(new Step(
+            text: $this->tempResponse->text,
+            finishReason: $this->tempResponse->finishReason,
+            toolCalls: $this->tempResponse->toolCalls,
+            toolResults: $toolResults,
+            usage: $this->tempResponse->usage,
+            responseMeta: $this->tempResponse->responseMeta,
+            messages: $this->request->messages(),
+            systemPrompts: $this->request->systemPrompts(),
+            additionalContent: $this->tempResponse->additionalContent,
+        ));
+    }
+
+    protected function shouldContinue(): bool
+    {       
+        return $this->responseBuilder->steps->count() < $this->request->maxSteps();
+    }
+
+    protected function prepareTempResponse(): void
     {
         $data = $this->httpResponse->json();
 
-        return new ProviderResponse(
+        $this->tempResponse = new Response(
+            steps: new Collection,
+            responseMessages: new Collection,
+            messages: new Collection,
             text: $this->extractText($data),
+            finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
             toolCalls: $this->extractToolCalls($data),
+            toolResults: [],
             usage: new Usage(
                 promptTokens: data_get($data, 'usage.input_tokens'),
                 completionTokens: data_get($data, 'usage.output_tokens'),
                 cacheWriteInputTokens: data_get($data, 'usage.cache_creation_input_tokens'),
                 cacheReadInputTokens: data_get($data, 'usage.cache_read_input_tokens')
             ),
-            finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
             responseMeta: new ResponseMeta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -66,7 +66,7 @@ class Text extends AnthropicHandlerAbstract
 
         return match ($this->tempResponse->finishReason) {
             FinishReason::ToolCalls => $this->handleToolCalls(),
-            FinishReason::Stop => $this->handleStop(),
+            FinishReason::Stop, FinishReason::Length => $this->handleStop(),
             default => throw new PrismException('Anthropic: unknown finish reason'),
         };
     }


### PR DESCRIPTION
Refactor Anthropic for #185.

Note, I have allowed FinishReason::Length as a valid stop reason. I am not sure what the behaviour is in practice with Ollama and OpenAI (i.e. does it still provide a valid response) - but we may wish to consider adding to those also.