### PR TITLE
feat(anthropic): extended thinking

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -16,6 +16,10 @@ return [
         'anthropic' => [
             'api_key' => env('ANTHROPIC_API_KEY', ''),
             'version' => env('ANTHROPIC_API_VERSION', '2023-06-01'),
+            'default_thinking_budget' => env('ANTHROPIC_DEFAULT_THINKING_BUDGET', 1024),
+
+            // Include beta strings as a comma separated list.
+            'anthropic_beta' => env('ANTHROPIC_BETA', null),
         ],
         'ollama' => [
             'url' => env('OLLAMA_URL', 'http://localhost:11434'),

--- a/config/prism.php
+++ b/config/prism.php
@@ -17,7 +17,6 @@ return [
             'api_key' => env('ANTHROPIC_API_KEY', ''),
             'version' => env('ANTHROPIC_API_VERSION', '2023-06-01'),
             'default_thinking_budget' => env('ANTHROPIC_DEFAULT_THINKING_BUDGET', 1024),
-
             // Include beta strings as a comma separated list.
             'anthropic_beta' => env('ANTHROPIC_BETA', null),
         ],

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EchoLabs\Prism\Contracts;
 
+use EchoLabs\Prism\Enums\Provider;
+
 interface PrismRequest
 {
     /**
@@ -12,4 +14,11 @@ interface PrismRequest
     public function is(string $classString): bool;
 
     public function model(): string;
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    public function withProviderMeta(string|Provider $provider, array $meta): self;
+
+    public function providerMeta(string|Provider $provider, ?string $valuePath = null): mixed;
 }

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -120,6 +120,7 @@ class PrismManager
         return new Anthropic(
             $config['api_key'],
             $config['version'],
+            $config['anthropic_beta'] ?? null
         );
     }
 

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -113,7 +113,7 @@ abstract class AnthropicHandlerAbstract
             return [];
         }
 
-        $thinking = array_find(
+        $thinking = Arr::first(
             data_get($data, 'content', []),
             fn ($content): bool => data_get($content, 'type') === 'thinking'
         );

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -104,6 +104,27 @@ abstract class AnthropicHandlerAbstract
     }
 
     /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function extractThinking(array $data): array
+    {
+        if ($this->request->providerMeta(Provider::Anthropic, 'thinking.enabled') !== true) {
+            return [];
+        }
+
+        $thinking = array_find(
+            data_get($data, 'content', []),
+            fn ($content): bool => data_get($content, 'type') === 'thinking'
+        );
+
+        return [
+            'thinking' => data_get($thinking, 'thinking'),
+            'thinking_signature' => data_get($thinking, 'signature'),
+        ];
+    }
+
+    /**
      * @return ProviderRateLimit[]
      */
     protected function processRateLimits(): array

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -125,6 +125,14 @@ class MessageMap
 
         $content = [];
 
+        if (isset($message->additionalContent['thinking']) && isset($message->additionalContent['thinking_signature'])) {
+            $content[] = [
+                'type' => 'thinking',
+                'thinking' => $message->additionalContent['thinking'],
+                'signature' => $message->additionalContent['thinking_signature'],
+            ];
+        }
+
         if (isset($message->additionalContent['messagePartsWithCitations'])) {
             foreach ($message->additionalContent['messagePartsWithCitations'] as $part) {
                 $content[] = array_filter([

--- a/tests/Fixtures/anthropic/structured-with-extending-thinking-1.json
+++ b/tests/Fixtures/anthropic/structured-with-extending-thinking-1.json
@@ -1,0 +1,25 @@
+{
+    "id": "msg_01Cdtax5gr8m8EWAfFeb6X6H",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-7-sonnet-20250219",
+    "content": [
+        {
+            "type": "thinking",
+            "thinking": "The question asks about \"the meaning of life, the universe and everything in popular fiction.\" This is a reference to Douglas Adams' \"The Hitchhiker's Guide to the Galaxy\" series, where a supercomputer named Deep Thought calculates that the answer to \"the ultimate question of life, the universe, and everything\" is 42.\n\nI'm being asked to respond with only JSON that matches a specific schema. The schema requires an object with a property called \"text\" that contains a string, and no additional properties are allowed.\n\nSo I should create a JSON object with a \"text\" property that explains that in popular fiction, particularly in \"The Hitchhiker's Guide to the Galaxy,\" the meaning of life, the universe, and everything is famously presented as \"42.\"",
+            "signature": "EuYBCkQYAiJAg+qtLhMXqUgaxagF5ryu2/sYLIpErjJsELoN95UARnscajTu5YXcRzTTEbiH87YC8xd5X6SRRxA5FzEiyPbzZBIMO8q4u82TeKNXUtxmGgzNMkFq/WSx5ByDvjsiMHy61qKH+/fr9bFMAjSR4T9dXYIK2G/j2xQSwi5hocmvqW8zXu8Xc5LLqxvZGXGq4ipQyZTLiVn0nQvLXf5qf5RxnbAvCc+NGHezUbUGFGIZsbiScvW8XMvbHPPCkofZqMbYmXssXpHsDkr7LgAz2gMY7tGD6+0Jwxy+YnmVo1J2bj0="
+        },
+        {
+            "type": "text",
+            "text": "{\n    \"text\": \"In popular fiction, the most famous answer to the meaning of life, the universe, and everything is '42' from Douglas Adams' 'The Hitchhiker's Guide to the Galaxy.' In this science fiction series, a supercomputer called Deep Thought spends 7.5 million years calculating this answer, though unfortunately, no one knows what the actual question was.\"\n}"
+        }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 146,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 265
+    }
+}

--- a/tests/Fixtures/anthropic/text-with-extending-thinking-1.json
+++ b/tests/Fixtures/anthropic/text-with-extending-thinking-1.json
@@ -1,0 +1,25 @@
+{
+    "id": "msg_0172otssgTHygjynfEAohvMx",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-7-sonnet-20250219",
+    "content": [
+        {
+            "type": "thinking",
+            "thinking": "This is a reference to Douglas Adams' popular science fiction series \"The Hitchhiker's Guide to the Galaxy\" where the supercomputer Deep Thought was built to calculate \"the Answer to the Ultimate Question of Life, the Universe, and Everything.\" After 7.5 million years of computation, it famously determined the answer to be \"42\" - a deliberately anticlimactic and absurd response that has become a significant pop culture reference.\n\nBeyond the Hitchhiker's reference, the question of life's meaning appears in many works of fiction across different media, with various philosophical approaches.\n\nI should note this humorous 42 reference while also mentioning how other fictional works have approached this philosophical question.",
+            "signature": "EuYBCkQYAiJAQ7ZOmBu5pa8U03x/RN5+Gs3tyKXFYcruUfnC8X/4AKBpJmB8qX+nQQ9atvYOXLD/mUAClCRZEaxt2fyEvdxnhRIMfFi6CLULECysli0mGgy5JRaOXL06fVJndm8iMD2T+D8dSIFJuctCnVeFKZme2TfIPIH+UMFO33a0ojzUq2VYy8+RzKkH7WYK9+580ipQ4yDVegd/67LKRtfb574HOHqwlPcfEbeiJuFuHrayoqK8KS2ltGYRckVGH6lNH46zUyjGaD2z3nZeti8UjmgnfMWRpjUmv0TWWGtrCKRoHGQ="
+        },
+        {
+            "type": "text",
+            "text": "In popular fiction, the most famous answer to this question comes from Douglas Adams' \"The Hitchhiker's Guide to the Galaxy,\" where a supercomputer named Deep Thought calculates for 7.5 million years and determines that the answer is simply \"42.\" This deliberately absurd response has become an iconic joke about the futility of seeking simple answers to profound existential questions.\n\nBeyond this humorous reference, fiction explores life's meaning in countless ways:\n- Finding purpose through love and human connection (seen in works like \"The Good Place\")\n- The pursuit of knowledge and understanding (as in \"Contact\" by Carl Sagan)\n- Creating your own meaning in an indifferent universe (explored in existentialist fiction)\n- Religious or spiritual fulfillment (depicted in works like \"Life of Pi\")\n\nWhat makes this question compelling in fiction is that there's never a definitive answer - just different perspectives that reflect our own search for meaning."
+        }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 50,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 365
+    }
+}

--- a/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-1.json
+++ b/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-1.json
@@ -1,0 +1,33 @@
+{
+    "id": "msg_01447uK5PArU2QWTv63iMsdx",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-7-sonnet-20250219",
+    "content": [
+        {
+            "type": "thinking",
+            "thinking": "The user is asking about:\n1. The time of the Tigers game today (likely referring to a sports team, probably Detroit Tigers baseball)\n2. Whether they should wear a coat (which relates to weather conditions)\n\nFor the first question, I need to search for the Tigers game schedule for today. For the second question, I need to check the weather in the relevant location.\n\nHowever, I'm missing some information:\n- The user hasn't specified which Tigers team they're referring to (though Detroit Tigers is most likely)\n- The user hasn't specified their location, which I need for the weather check\n\nI'll need to search for the Tigers game information first, and then check the weather in the appropriate location (likely Detroit if it's a home game).",
+            "signature": "EuYBCkQYAiJAY1corUurDaKsURSV32GUvrp4ZySJDYJXGHIBx2aPaphiKr+Kcenv2gTcLxAvkU5zUxek2mX3GGkrp8XlN2qJAhIM7v4WGU9Wwfpn8qu1Ggzd9cK0sZX2z6qEbaciMKAfMsaYMc9zVHF1Y2qY+iC35WGiXAnEAZk+KBNGCo0V+t/U1bzJGhAigvTRKkDKpipQDXkfw+XdPzHh+VGFXut2TIPatMN5UrE1CvR+GtQT1cscbxBnuiXFwgs3B/QPlC2/l2VloajCHeYVaHqY3MIXiTyqe4HAyt51Go1Xt1ydVaY="
+        },
+        {
+            "type": "text",
+            "text": "I need to search for the Tigers game information and check the weather for you to determine if you should wear a coat."
+        },
+        {
+            "type": "tool_use",
+            "id": "toolu_01BNmk7Tacn3t45rgeZimYZV",
+            "name": "search",
+            "input": {
+                "query": "Detroit Tigers baseball game time today"
+            }
+        }
+    ],
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 494,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 249
+    }
+}

--- a/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-2.json
+++ b/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-2.json
@@ -1,0 +1,28 @@
+{
+    "id": "msg_01P1M5c31h5cXaGVW1e33KVP",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-7-sonnet-20250219",
+    "content": [
+        {
+            "type": "text",
+            "text": "Now I'll check the weather in Detroit to help you decide about wearing a coat:"
+        },
+        {
+            "type": "tool_use",
+            "id": "toolu_017jLttKGakC1C768dC1BiWq",
+            "name": "weather",
+            "input": {
+                "city": "Detroit"
+            }
+        }
+    ],
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 764,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 70
+    }
+}

--- a/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-3.json
+++ b/tests/Fixtures/anthropic/text-with-extending-thinking-and-tool-calls-3.json
@@ -1,0 +1,20 @@
+{
+    "id": "msg_016nfnVdmr4Mu8zXqSB1d5xd",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-3-7-sonnet-20250219",
+    "content": [
+        {
+            "type": "text",
+            "text": "The Detroit Tigers game is today at 3pm in Detroit. The weather in Detroit will be 75° and sunny, so you likely won't need a coat. It's a warm, pleasant day - just a light jacket or sweater might be enough if you tend to get cold at outdoor events, but generally, these are comfortable conditions."
+        }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+        "input_tokens": 854,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 74
+    }
+}

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -18,189 +18,221 @@ use EchoLabs\Prism\ValueObjects\ToolCall;
 use EchoLabs\Prism\ValueObjects\ToolResult;
 use InvalidArgumentException;
 
-it('maps user messages', function (): void {
-    expect(MessageMap::map([
-        new UserMessage('Who are you?'),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            ['type' => 'text', 'text' => 'Who are you?'],
-        ],
-    ]]);
-});
+describe('Anthropic user message mapping', function (): void {
 
-it('maps user messages with images from path', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Who are you?', [
-            Image::fromPath('tests/Fixtures/test-image.png'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('image');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('base64');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('image/png');
-});
-
-it('maps user messages with images from base64', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Who are you?', [
-            Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('image');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('base64');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('image/png');
-});
-
-it('maps user messages with PDF documents from path', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Here is the document', [
-            Document::fromPath('tests/Fixtures/test-pdf.pdf'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('document');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('base64');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('application/pdf');
-});
-
-it('maps user messages with PDF documents from base64', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Here is the document', [
-            Document::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')), 'application/pdf'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('document');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('base64');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('application/pdf');
-});
-
-it('maps user messages with txt documents from path', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Here is the document', [
-            Document::fromPath('tests/Fixtures/test-text.txt'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('document');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('text');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(file_get_contents('tests/Fixtures/test-text.txt'));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('text/plain');
-});
-
-it('maps user messages with md documents from path', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Here is the document', [
-            Document::fromPath('tests/Fixtures/test-text.md'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('document');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('text');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain(file_get_contents('tests/Fixtures/test-text.md'));
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('text/plain');
-});
-
-it('maps user messages with txt documents from text string', function (): void {
-    $mappedMessage = MessageMap::map([
-        new UserMessage('Here is the document', [
-            Document::fromText('Hello world!'),
-        ]),
-    ]);
-
-    expect(data_get($mappedMessage, '0.content.1.type'))
-        ->toBe('document');
-    expect(data_get($mappedMessage, '0.content.1.source.type'))
-        ->toBe('text');
-    expect(data_get($mappedMessage, '0.content.1.source.data'))
-        ->toContain('Hello world!');
-    expect(data_get($mappedMessage, '0.content.1.source.media_type'))
-        ->toBe('text/plain');
-});
-
-it('does not maps user messages with images from url', function (): void {
-    $this->expectException(InvalidArgumentException::class);
-    MessageMap::map([
-        new UserMessage('Who are you?', [
-            Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
-        ]),
-    ]);
-});
-
-it('maps assistant message', function (): void {
-    expect(MessageMap::map([
-        new AssistantMessage('I am Nyx'),
-    ]))->toContain([
-        'role' => 'assistant',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'I am Nyx',
+    it('maps user messages', function (): void {
+        expect(MessageMap::map([
+            new UserMessage('Who are you?'),
+        ]))->toBe([[
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'Who are you?'],
             ],
-        ],
-    ]);
+        ]]);
+    });
+
+    it('maps user messages with images from path', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Who are you?', [
+                Image::fromPath('tests/Fixtures/test-image.png'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('image');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('base64');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('image/png');
+    });
+
+    it('maps user messages with images from base64', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Who are you?', [
+                Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-image.png')), 'image/png'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('image');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('base64');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-image.png')));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('image/png');
+    });
+
+    it('does not maps user messages with images from url', function (): void {
+        $this->expectException(InvalidArgumentException::class);
+        MessageMap::map([
+            new UserMessage('Who are you?', [
+                Image::fromUrl('https://storage.echolabs.dev/assets/logo.png'),
+            ]),
+        ]);
+    });
+
+    it('maps user messages with PDF documents from path', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Here is the document', [
+                Document::fromPath('tests/Fixtures/test-pdf.pdf'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('document');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('base64');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('application/pdf');
+    });
+
+    it('maps user messages with PDF documents from base64', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Here is the document', [
+                Document::fromBase64(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')), 'application/pdf'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('document');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('base64');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('application/pdf');
+    });
+
+    it('maps user messages with txt documents from path', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Here is the document', [
+                Document::fromPath('tests/Fixtures/test-text.txt'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('document');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('text');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(file_get_contents('tests/Fixtures/test-text.txt'));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('text/plain');
+    });
+
+    it('maps user messages with md documents from path', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Here is the document', [
+                Document::fromPath('tests/Fixtures/test-text.md'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('document');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('text');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain(file_get_contents('tests/Fixtures/test-text.md'));
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('text/plain');
+    });
+
+    it('maps user messages with txt documents from text string', function (): void {
+        $mappedMessage = MessageMap::map([
+            new UserMessage('Here is the document', [
+                Document::fromText('Hello world!'),
+            ]),
+        ]);
+
+        expect(data_get($mappedMessage, '0.content.1.type'))
+            ->toBe('document');
+        expect(data_get($mappedMessage, '0.content.1.source.type'))
+            ->toBe('text');
+        expect(data_get($mappedMessage, '0.content.1.source.data'))
+            ->toContain('Hello world!');
+        expect(data_get($mappedMessage, '0.content.1.source.media_type'))
+            ->toBe('text/plain');
+    });
 });
 
-it('maps assistant message with tool calls', function (): void {
-    expect(MessageMap::map([
-        new AssistantMessage('I am Nyx', [
-            new ToolCall(
-                'tool_1234',
-                'search',
-                [
-                    'query' => 'Laravel collection methods',
-                ]
-            ),
-        ]),
-    ]))->toBe([
-        [
+describe('Anthropic assistant message mapping', function (): void {
+    it('maps assistant message', function (): void {
+        expect(MessageMap::map([
+            new AssistantMessage('I am Nyx'),
+        ]))->toContain([
             'role' => 'assistant',
             'content' => [
                 [
                     'type' => 'text',
                     'text' => 'I am Nyx',
                 ],
-                [
-                    'type' => 'tool_use',
-                    'id' => 'tool_1234',
-                    'name' => 'search',
-                    'input' => [
+            ],
+        ]);
+    });
+
+    it('maps assistant message with tool calls', function (): void {
+        expect(MessageMap::map([
+            new AssistantMessage('I am Nyx', [
+                new ToolCall(
+                    'tool_1234',
+                    'search',
+                    [
                         'query' => 'Laravel collection methods',
+                    ]
+                ),
+            ]),
+        ]))->toBe([
+            [
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'I am Nyx',
+                    ],
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'tool_1234',
+                        'name' => 'search',
+                        'input' => [
+                            'query' => 'Laravel collection methods',
+                        ],
                     ],
                 ],
             ],
-        ],
-    ]);
+        ]);
+    });
+
+    it('maps assistant message with thinking blocks', function (): void {
+        expect(MessageMap::map([
+            new AssistantMessage(
+                content: 'I am Nyx',
+                additionalContent: [
+                    'thinking' => 'I thought long and hard about who I am deep down.',
+                    'thinking_signature' => 'Signed, Nyx',
+                ]
+            ),
+        ]))->toEqual([
+            [
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'thinking',
+                        'thinking' => 'I thought long and hard about who I am deep down.',
+                        'signature' => 'Signed, Nyx',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => 'I am Nyx',
+                    ],
+                ],
+            ],
+        ]);
+    });
 });
 
 it('maps tool result messages', function (): void {
@@ -245,159 +277,123 @@ it('maps system messages', function (): void {
     ]);
 });
 
-it('sets the cache type on a UserMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
-    expect(MessageMap::map([
-        (new UserMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'Who are you?',
-                'cache_control' => ['type' => 'ephemeral'],
-            ],
-        ],
-    ]]);
-})->with([
-    'ephemeral',
-    AnthropicCacheType::Ephemeral,
-]);
-
-it('sets the cache type on a UserMessage image if cacheType providerMeta is set on message', function (): void {
-    expect(MessageMap::map([
-        (new UserMessage(
-            content: 'Who are you?',
-            additionalContent: [Image::fromPath('tests/Fixtures/test-image.png')]
-        ))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'Who are you?',
-                'cache_control' => ['type' => 'ephemeral'],
-            ],
-            [
-                'type' => 'image',
-                'source' => [
-                    'type' => 'base64',
-                    'media_type' => 'image/png',
-                    'data' => base64_encode(file_get_contents('tests/Fixtures/test-image.png')),
+describe('Anthropic cache mapping', function (): void {
+    it('sets the cache type on a UserMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
+        expect(MessageMap::map([
+            (new UserMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        ]))->toBe([[
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'Who are you?',
+                    'cache_control' => ['type' => 'ephemeral'],
                 ],
-                'cache_control' => ['type' => 'ephemeral'],
             ],
-        ],
-    ]]);
-});
+        ]]);
+    })->with([
+        'ephemeral',
+        AnthropicCacheType::Ephemeral,
+    ]);
 
-it('sets the cache type on a UserMessage document if cacheType providerMeta is set on message', function (): void {
-    expect(MessageMap::map([
-        (new UserMessage(
-            content: 'Who are you?',
-            additionalContent: [Document::fromPath('tests/Fixtures/test-pdf.pdf')]
-        ))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'Who are you?',
-                'cache_control' => ['type' => 'ephemeral'],
-            ],
-            [
-                'type' => 'document',
-                'source' => [
-                    'type' => 'base64',
-                    'media_type' => 'application/pdf',
-                    'data' => base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')),
+    it('sets the cache type on a UserMessage image if cacheType providerMeta is set on message', function (): void {
+        expect(MessageMap::map([
+            (new UserMessage(
+                content: 'Who are you?',
+                additionalContent: [Image::fromPath('tests/Fixtures/test-image.png')]
+            ))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
+        ]))->toBe([[
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'Who are you?',
+                    'cache_control' => ['type' => 'ephemeral'],
                 ],
-                'cache_control' => ['type' => 'ephemeral'],
+                [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => 'image/png',
+                        'data' => base64_encode(file_get_contents('tests/Fixtures/test-image.png')),
+                    ],
+                    'cache_control' => ['type' => 'ephemeral'],
+                ],
             ],
-        ],
-    ]]);
-});
+        ]]);
+    });
 
-it('sets the cache type on an AssistantMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
-    expect(MessageMap::map([
-        (new AssistantMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
-    ]))->toBe([[
-        'role' => 'assistant',
-        'content' => [
+    it('sets the cache type on a UserMessage document if cacheType providerMeta is set on message', function (): void {
+        expect(MessageMap::map([
+            (new UserMessage(
+                content: 'Who are you?',
+                additionalContent: [Document::fromPath('tests/Fixtures/test-pdf.pdf')]
+            ))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
+        ]))->toBe([[
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'Who are you?',
+                    'cache_control' => ['type' => 'ephemeral'],
+                ],
+                [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => 'application/pdf',
+                        'data' => base64_encode(file_get_contents('tests/Fixtures/test-pdf.pdf')),
+                    ],
+                    'cache_control' => ['type' => 'ephemeral'],
+                ],
+            ],
+        ]]);
+    });
+
+    it('sets the cache type on an AssistantMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
+        expect(MessageMap::map([
+            (new AssistantMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        ]))->toBe([[
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'Who are you?',
+                    'cache_control' => ['type' => AnthropicCacheType::Ephemeral->value],
+                ],
+            ],
+        ]]);
+    })->with([
+        'ephemeral',
+        AnthropicCacheType::Ephemeral,
+    ]);
+
+    it('sets the cache type on a SystemMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
+        expect(MessageMap::mapSystemMessages([
+            (new SystemMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
+        ]))->toBe([
             [
                 'type' => 'text',
                 'text' => 'Who are you?',
                 'cache_control' => ['type' => AnthropicCacheType::Ephemeral->value],
             ],
-        ],
-    ]]);
-})->with([
-    'ephemeral',
-    AnthropicCacheType::Ephemeral,
-]);
-
-it('sets the cache type on a SystemMessage if cacheType providerMeta is set on message', function (mixed $cacheType): void {
-    expect(MessageMap::mapSystemMessages([
-        (new SystemMessage(content: 'Who are you?'))->withProviderMeta(Provider::Anthropic, ['cacheType' => $cacheType]),
-    ]))->toBe([
-        [
-            'type' => 'text',
-            'text' => 'Who are you?',
-            'cache_control' => ['type' => AnthropicCacheType::Ephemeral->value],
-        ],
+        ]);
+    })->with([
+        'ephemeral',
+        AnthropicCacheType::Ephemeral,
     ]);
-})->with([
-    'ephemeral',
-    AnthropicCacheType::Ephemeral,
-]);
-
-it('sets citiations to true on a UserMessage Document if citations providerMeta is true', function (): void {
-    expect(MessageMap::map([
-        (new UserMessage(
-            content: 'What color is the grass and sky?',
-            additionalContent: [
-                Document::fromText('The grass is green. The sky is blue.')->withProviderMeta(Provider::Anthropic, ['citations' => true]),
-            ]
-        )),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'What color is the grass and sky?',
-            ],
-            [
-                'type' => 'document',
-                'source' => [
-                    'type' => 'text',
-                    'media_type' => 'text/plain',
-                    'data' => 'The grass is green. The sky is blue.',
-                ],
-                'citations' => ['enabled' => true],
-            ],
-        ],
-    ]]);
 });
 
-test('MessageMap applies citations to all documents if requestProviderMeta has citations true', function (): void {
-    $messages = [
-        (new UserMessage(
-            content: 'What color is the grass and sky?',
-            additionalContent: [
-                Document::fromText('The grass is green.', 'All aboout the grass.', 'A novel look into the colour of grass.'),
-                Document::fromText('The sky is blue.'),
-            ]
-        )),
-        (new UserMessage(
-            content: 'What color is sea and earth?',
-            additionalContent: [
-                Document::fromText('The sea is blue'),
-                Document::fromText('The earth is brown.'),
-            ]
-        )),
-    ];
-
-    expect(MessageMap::map($messages, ['citations' => true]))->toBe([
-        [
+describe('Anthropic citation mapping', function (): void {
+    it('sets citiations to true on a UserMessage Document if citations providerMeta is true', function (): void {
+        expect(MessageMap::map([
+            (new UserMessage(
+                content: 'What color is the grass and sky?',
+                additionalContent: [
+                    Document::fromText('The grass is green. The sky is blue.')->withProviderMeta(Provider::Anthropic, ['citations' => true]),
+                ]
+            )),
+        ]))->toBe([[
             'role' => 'user',
             'content' => [
                 [
@@ -409,216 +405,256 @@ test('MessageMap applies citations to all documents if requestProviderMeta has c
                     'source' => [
                         'type' => 'text',
                         'media_type' => 'text/plain',
-                        'data' => 'The grass is green.',
-                    ],
-                    'title' => 'All aboout the grass.',
-                    'context' => 'A novel look into the colour of grass.',
-                    'citations' => ['enabled' => true],
-                ],
-                [
-                    'type' => 'document',
-                    'source' => [
-                        'type' => 'text',
-                        'media_type' => 'text/plain',
-                        'data' => 'The sky is blue.',
+                        'data' => 'The grass is green. The sky is blue.',
                     ],
                     'citations' => ['enabled' => true],
                 ],
             ],
-        ],
-        [
+        ]]);
+    });
+
+    test('MessageMap applies citations to all documents if requestProviderMeta has citations true', function (): void {
+        $messages = [
+            (new UserMessage(
+                content: 'What color is the grass and sky?',
+                additionalContent: [
+                    Document::fromText('The grass is green.', 'All aboout the grass.', 'A novel look into the colour of grass.'),
+                    Document::fromText('The sky is blue.'),
+                ]
+            )),
+            (new UserMessage(
+                content: 'What color is sea and earth?',
+                additionalContent: [
+                    Document::fromText('The sea is blue'),
+                    Document::fromText('The earth is brown.'),
+                ]
+            )),
+        ];
+
+        expect(MessageMap::map($messages, ['citations' => true]))->toBe([
+            [
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'What color is the grass and sky?',
+                    ],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'text',
+                            'media_type' => 'text/plain',
+                            'data' => 'The grass is green.',
+                        ],
+                        'title' => 'All aboout the grass.',
+                        'context' => 'A novel look into the colour of grass.',
+                        'citations' => ['enabled' => true],
+                    ],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'text',
+                            'media_type' => 'text/plain',
+                            'data' => 'The sky is blue.',
+                        ],
+                        'citations' => ['enabled' => true],
+                    ],
+                ],
+            ],
+            [
+                'role' => 'user',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'What color is sea and earth?',
+                    ],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'text',
+                            'media_type' => 'text/plain',
+                            'data' => 'The sea is blue',
+                        ],
+                        'citations' => ['enabled' => true],
+                    ],
+                    [
+                        'type' => 'document',
+                        'source' => [
+                            'type' => 'text',
+                            'media_type' => 'text/plain',
+                            'data' => 'The earth is brown.',
+                        ],
+                        'citations' => ['enabled' => true],
+                    ],
+                ],
+            ],
+        ]);
+    });
+
+    it('maps a chunked document correctly', function (): void {
+        expect(MessageMap::map([
+            (new UserMessage(
+                content: 'What color is the grass and sky?',
+                additionalContent: [
+                    Document::fromChunks(['chunk1', 'chunk2'])->withProviderMeta(Provider::Anthropic, ['citations' => true]),
+                ]
+            )),
+        ]))->toBe([[
             'role' => 'user',
             'content' => [
                 [
                     'type' => 'text',
-                    'text' => 'What color is sea and earth?',
+                    'text' => 'What color is the grass and sky?',
                 ],
                 [
                     'type' => 'document',
                     'source' => [
-                        'type' => 'text',
-                        'media_type' => 'text/plain',
-                        'data' => 'The sea is blue',
+                        'type' => 'content',
+                        'content' => [
+                            ['type' => 'text', 'text' => 'chunk1'],
+                            ['type' => 'text', 'text' => 'chunk2'],
+                        ],
                     ],
                     'citations' => ['enabled' => true],
                 ],
+            ],
+        ]]);
+    });
+
+    it('maps an assistant message with PDF citations back to its original format', function (): void {
+        $block_one = [
+            'type' => 'text',
+            'text' => '.',
+        ];
+
+        $block_two = [
+            'type' => 'text',
+            'text' => 'the grass is green',
+            'citations' => [
                 [
-                    'type' => 'document',
-                    'source' => [
-                        'type' => 'text',
-                        'media_type' => 'text/plain',
-                        'data' => 'The earth is brown.',
+                    'type' => 'page_location',
+                    'cited_text' => 'The grass is green. ',
+                    'document_index' => 0,
+                    'document_title' => 'All aboout the grass and the sky',
+                    'start_page_number' => 1,
+                    'end_page_number' => 2,
+                ],
+            ],
+        ];
+
+        $block_three = [
+            'type' => 'text',
+            'text' => ' and ',
+        ];
+
+        $block_four = [
+            'type' => 'text',
+            'text' => 'the sky is blue',
+            'citations' => [
+                [
+                    'type' => 'page_location',
+                    'cited_text' => 'The sky is blue.',
+                    'document_index' => 0,
+                    'document_title' => 'All aboout the grass and the sky',
+                    'start_page_number' => 1,
+                    'end_page_number' => 2,
+                ],
+            ],
+        ];
+
+        $block_five = [
+            'type' => 'text',
+            'text' => '.',
+        ];
+
+        expect(MessageMap::map([
+            new AssistantMessage(
+                content: 'According to the text, the grass is green and the sky is blue.',
+                additionalContent: [
+                    'messagePartsWithCitations' => [
+                        MessagePartWithCitations::fromContentBlock($block_one),
+                        MessagePartWithCitations::fromContentBlock($block_two),
+                        MessagePartWithCitations::fromContentBlock($block_three),
+                        MessagePartWithCitations::fromContentBlock($block_four),
+                        MessagePartWithCitations::fromContentBlock($block_five),
                     ],
-                    'citations' => ['enabled' => true],
+                ]
+            ),
+        ]))->toBe([[
+            'role' => 'assistant',
+            'content' => [
+                $block_one,
+                $block_two,
+                $block_three,
+                $block_four,
+                $block_five,
+            ],
+        ]]);
+    });
+
+    it('maps an assistant message with text document citations back to its original format', function (): void {
+        $block = [
+            'type' => 'text',
+            'text' => 'the grass is green',
+            'citations' => [
+                [
+                    'type' => 'char_location',
+                    'cited_text' => 'The grass is green. ',
+                    'document_index' => 0,
+                    'document_title' => 'All aboout the grass and the sky',
+                    'start_char_index' => 1,
+                    'end_char_index' => 20,
                 ],
             ],
-        ],
-    ]);
-});
+        ];
 
-it('maps a chunked document correctly', function (): void {
-    expect(MessageMap::map([
-        (new UserMessage(
-            content: 'What color is the grass and sky?',
-            additionalContent: [
-                Document::fromChunks(['chunk1', 'chunk2'])->withProviderMeta(Provider::Anthropic, ['citations' => true]),
-            ]
-        )),
-    ]))->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'What color is the grass and sky?',
-            ],
-            [
-                'type' => 'document',
-                'source' => [
-                    'type' => 'content',
-                    'content' => [
-                        ['type' => 'text', 'text' => 'chunk1'],
-                        ['type' => 'text', 'text' => 'chunk2'],
+        expect(MessageMap::map([
+            new AssistantMessage(
+                content: 'According to the text, the grass is green and the sky is blue.',
+                additionalContent: [
+                    'messagePartsWithCitations' => [
+                        MessagePartWithCitations::fromContentBlock($block),
                     ],
+                ]
+            ),
+        ]))->toBe([[
+            'role' => 'assistant',
+            'content' => [
+                $block,
+            ],
+        ]]);
+    });
+
+    it('maps an assistant message with custom content document citations back to its original format', function (): void {
+        $block = [
+            'type' => 'text',
+            'text' => 'the grass is green',
+            'citations' => [
+                [
+                    'type' => 'content_block_location',
+                    'cited_text' => 'The grass is green. ',
+                    'document_index' => 0,
+                    'document_title' => 'All aboout the grass and the sky',
+                    'start_block_index' => 0,
+                    'end_block_index' => 1,
                 ],
-                'citations' => ['enabled' => true],
             ],
-        ],
-    ]]);
-});
+        ];
 
-it('maps an assistant message with PDF citations back to its original format', function (): void {
-    $block_one = [
-        'type' => 'text',
-        'text' => '.',
-    ];
-
-    $block_two = [
-        'type' => 'text',
-        'text' => 'the grass is green',
-        'citations' => [
-            [
-                'type' => 'page_location',
-                'cited_text' => 'The grass is green. ',
-                'document_index' => 0,
-                'document_title' => 'All aboout the grass and the sky',
-                'start_page_number' => 1,
-                'end_page_number' => 2,
+        expect(MessageMap::map([
+            new AssistantMessage(
+                content: 'According to the text, the grass is green and the sky is blue.',
+                additionalContent: [
+                    'messagePartsWithCitations' => [
+                        MessagePartWithCitations::fromContentBlock($block),
+                    ],
+                ]
+            ),
+        ]))->toBe([[
+            'role' => 'assistant',
+            'content' => [
+                $block,
             ],
-        ],
-    ];
-
-    $block_three = [
-        'type' => 'text',
-        'text' => ' and ',
-    ];
-
-    $block_four = [
-        'type' => 'text',
-        'text' => 'the sky is blue',
-        'citations' => [
-            [
-                'type' => 'page_location',
-                'cited_text' => 'The sky is blue.',
-                'document_index' => 0,
-                'document_title' => 'All aboout the grass and the sky',
-                'start_page_number' => 1,
-                'end_page_number' => 2,
-            ],
-        ],
-    ];
-
-    $block_five = [
-        'type' => 'text',
-        'text' => '.',
-    ];
-
-    expect(MessageMap::map([
-        new AssistantMessage(
-            content: 'According to the text, the grass is green and the sky is blue.',
-            additionalContent: [
-                'messagePartsWithCitations' => [
-                    MessagePartWithCitations::fromContentBlock($block_one),
-                    MessagePartWithCitations::fromContentBlock($block_two),
-                    MessagePartWithCitations::fromContentBlock($block_three),
-                    MessagePartWithCitations::fromContentBlock($block_four),
-                    MessagePartWithCitations::fromContentBlock($block_five),
-                ],
-            ]
-        ),
-    ]))->toBe([[
-        'role' => 'assistant',
-        'content' => [
-            $block_one,
-            $block_two,
-            $block_three,
-            $block_four,
-            $block_five,
-        ],
-    ]]);
-});
-
-it('maps an assistant message with text document citations back to its original format', function (): void {
-    $block = [
-        'type' => 'text',
-        'text' => 'the grass is green',
-        'citations' => [
-            [
-                'type' => 'char_location',
-                'cited_text' => 'The grass is green. ',
-                'document_index' => 0,
-                'document_title' => 'All aboout the grass and the sky',
-                'start_char_index' => 1,
-                'end_char_index' => 20,
-            ],
-        ],
-    ];
-
-    expect(MessageMap::map([
-        new AssistantMessage(
-            content: 'According to the text, the grass is green and the sky is blue.',
-            additionalContent: [
-                'messagePartsWithCitations' => [
-                    MessagePartWithCitations::fromContentBlock($block),
-                ],
-            ]
-        ),
-    ]))->toBe([[
-        'role' => 'assistant',
-        'content' => [
-            $block,
-        ],
-    ]]);
-});
-
-it('maps an assistant message with custom content document citations back to its original format', function (): void {
-    $block = [
-        'type' => 'text',
-        'text' => 'the grass is green',
-        'citations' => [
-            [
-                'type' => 'content_block_location',
-                'cited_text' => 'The grass is green. ',
-                'document_index' => 0,
-                'document_title' => 'All aboout the grass and the sky',
-                'start_block_index' => 0,
-                'end_block_index' => 1,
-            ],
-        ],
-    ];
-
-    expect(MessageMap::map([
-        new AssistantMessage(
-            content: 'According to the text, the grass is green and the sky is blue.',
-            additionalContent: [
-                'messagePartsWithCitations' => [
-                    MessagePartWithCitations::fromContentBlock($block),
-                ],
-            ]
-        ),
-    ]))->toBe([[
-        'role' => 'assistant',
-        'content' => [
-            $block,
-        ],
-    ]]);
+        ]]);
+    });
 });

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -185,3 +185,25 @@ it('saves message parts with citations to additionalContent on response steps an
     expect($response->responseMessages->last()->additionalContent['messagePartsWithCitations'])->toHaveCount(1);
     expect($response->steps[0]->additionalContent['messagePartsWithCitations'][0])->toBeInstanceOf(MessagePartWithCitations::class);
 });
+
+it('can use extending thinking', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-with-extending-thinking');
+
+    $response = Prism::structured()
+        ->using('anthropic', 'claude-3-7-sonnet-latest')
+        ->withSchema(new ObjectSchema('output', 'the output object', [new StringSchema('text', 'the output text')], ['text']))
+        ->withPrompt('What is the meaning of life, the universe and everything in popular fiction?')
+        ->withProviderMeta(Provider::Anthropic, ['thinking' => ['enabled' => true]])
+        ->generate();
+
+    $expected_thinking = "The question asks about \"the meaning of life, the universe and everything in popular fiction.\" This is a reference to Douglas Adams' \"The Hitchhiker's Guide to the Galaxy\" series, where a supercomputer named Deep Thought calculates that the answer to \"the ultimate question of life, the universe, and everything\" is 42.\n\nI'm being asked to respond with only JSON that matches a specific schema. The schema requires an object with a property called \"text\" that contains a string, and no additional properties are allowed.\n\nSo I should create a JSON object with a \"text\" property that explains that in popular fiction, particularly in \"The Hitchhiker's Guide to the Galaxy,\" the meaning of life, the universe, and everything is famously presented as \"42.\"";
+    $expected_signature = 'EuYBCkQYAiJAg+qtLhMXqUgaxagF5ryu2/sYLIpErjJsELoN95UARnscajTu5YXcRzTTEbiH87YC8xd5X6SRRxA5FzEiyPbzZBIMO8q4u82TeKNXUtxmGgzNMkFq/WSx5ByDvjsiMHy61qKH+/fr9bFMAjSR4T9dXYIK2G/j2xQSwi5hocmvqW8zXu8Xc5LLqxvZGXGq4ipQyZTLiVn0nQvLXf5qf5RxnbAvCc+NGHezUbUGFGIZsbiScvW8XMvbHPPCkofZqMbYmXssXpHsDkr7LgAz2gMY7tGD6+0Jwxy+YnmVo1J2bj0=';
+
+    expect($response->structured['text'])->toBe("In popular fiction, the most famous answer to the meaning of life, the universe, and everything is '42' from Douglas Adams' 'The Hitchhiker's Guide to the Galaxy.' In this science fiction series, a supercomputer called Deep Thought spends 7.5 million years calculating this answer, though unfortunately, no one knows what the actual question was.");
+    expect($response->additionalContent['thinking'])->toBe($expected_thinking);
+    expect($response->additionalContent['thinking_signature'])->toBe($expected_signature);
+
+    expect($response->steps->last()->messages[2])
+        ->additionalContent->thinking->toBe($expected_thinking)
+        ->additionalContent->thinking_signature->toBe($expected_signature);
+});


### PR DESCRIPTION
## Description

Implements the new extended thinking mode for Anthropic, which only works with the new Claude Sonnet 3.7.

There are a lot of interplays with other Anthropic functionality like caching, tool use, etc. I decided to not try and address that in Prism as it'll be subject to change and makes the provider more brittle. Ultimately the developer will get exceptions anyway.

There's some config points to note which I will add to the docs:
- Added a config for default thinking budget, which will default to 1024 (the minimum) if not set in config or in provider meta.
- Added a config for the anthropic-beta header, which is currently required for extended output.

