### PR TITLE
bug(anthropic): improve structured shim

### DIFF
--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -118,7 +118,7 @@ class Structured extends AnthropicHandlerAbstract
     protected function appendMessageForJsonMode(): void
     {
         $this->request->addMessage(new UserMessage(sprintf(
-            "Respond with ONLY JSON that matches the following schema: \n %s %s",
+            "Respond with ONLY JSON (i.e. not in backticks or a code block, with NO CONTENT outside the JSON) that matches the following schema: \n %s %s",
             json_encode($this->request->schema()->toArray(), JSON_PRETTY_PRINT),
             ($this->request->providerMeta(Provider::Anthropic)['citations'] ?? false)
                 ? "\n\n Return the JSON as a single text block with a single set of citations."


### PR DESCRIPTION
## Description
Not really a bug as such, but we've notice Sonnet 3.7 is more prone to including content outside of the JSON, particularly backticks or code blocks.

We'll continue to monitor - if this doesn't do it we could resort to string manipulation for common fail cases.