### PR TITLE
fix(openai): use open ai in exception message

### DIFF
--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -56,7 +56,7 @@ class Text
         return match ($this->mapFinishReason($data)) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request),
             FinishReason::Stop => $this->handleStop($data, $request),
-            default => throw new PrismException('Ollama: unknown finish reason'),
+            default => throw new PrismException('OpenAI: unknown finish reason'),
         };
     }
 


### PR DESCRIPTION
## Description
Noticed that OpenAI was throwing the wrong exception message. I do see that the exception handling will be refactored via https://github.com/echolabsdev/prism/issues/205 but wanted to throw in now anyway.

## Breaking Changes
none

Love the project, appreciate your work!
