### PR TITLE
fix(anthropic): tool choice must be object

### DIFF
--- a/src/Providers/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Providers/Anthropic/Maps/ToolChoiceMap.php
@@ -25,14 +25,16 @@ class ToolChoiceMap
             ];
         }
 
-        if (! in_array($toolChoice, [ToolChoice::Auto, ToolChoice::Any])) {
+        if (! in_array($toolChoice, [ToolChoice::Auto, ToolChoice::Any, ToolChoice::None])) {
             throw new InvalidArgumentException('Invalid tool choice');
         }
 
-        return match ($toolChoice) {
-            ToolChoice::Auto => 'auto',
-            ToolChoice::Any => 'any',
-        };
-
+        return [
+            'type' => match ($toolChoice) {
+                ToolChoice::Auto => 'auto',
+                ToolChoice::Any => 'any',
+                ToolChoice::None => 'none',
+            },
+        ];
     }
 }


### PR DESCRIPTION
For Anthropic all tool choices (not just named tools) must be returned in an object with a `type` key (https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#example-simple-tool-definition).

This PR fixes that, and also adds a mapping for `ToolChoice::None`