### PR TITLE
Add OpenAI response to PrismException

### DIFF
--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -10,6 +10,27 @@ use Throwable;
 
 class PrismException extends Exception
 {
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null,
+        protected ?array $data = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
+    protected function setData(?array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
     public static function promptOrMessages(): self
     {
         return new self('You can only use `prompt` or `messages`');

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -61,7 +61,7 @@ class Text
         return match ($this->mapFinishReason($data)) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response),
             FinishReason::Stop => $this->handleStop($data, $request, $response),
-            default => throw new PrismException('OpenAI: unknown finish reason'),
+            default => throw new PrismException(message: 'OpenAI: unknown finish reason', data: $data),
         };
     }
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Adds data attribute to the PrismException exception to be able to pass more data based on the provider to allow more control on the user end. The most obvious use case is when OpenAI returns a finish_reason: length, which is valuable information to have on the exception.

## Breaking Changes
None
