### PR TITLE
fix(Groq): empty response data

### DIFF
--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -46,7 +46,7 @@ class Text
         $data = $response->json();
 
         $responseMessage = new AssistantMessage(
-            data_get($data, 'message.content') ?? '',
+            data_get($data, 'choices.0.message.content') ?? '',
             $this->mapToolCalls(data_get($data, 'choices.0.message.tool_calls', []) ?? []),
         );
 

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -31,13 +31,16 @@ describe('Text generation for Groq', function (): void {
             ->withPrompt('Who are you?')
             ->generate();
 
-        expect($response->usage->promptTokens)->toBe(13);
-        expect($response->usage->completionTokens)->toBe(208);
-        expect($response->meta->id)->toBe('chatcmpl-ea37c181-ed35-4bd4-af20-c1fcf203e0d8');
-        expect($response->meta->model)->toBe('llama3-8b-8192');
-        expect($response->text)->toBe(
-            'I am LLaMA, an AI assistant developed by Meta AI.'
-        );
+        expect($response->usage->promptTokens)->toBe(13)
+            ->and($response->usage->completionTokens)->toBe(208)
+            ->and($response->meta->id)->toBe('chatcmpl-ea37c181-ed35-4bd4-af20-c1fcf203e0d8')
+            ->and($response->meta->model)->toBe('llama3-8b-8192')
+            ->and($response->text)->toBe(
+                'I am LLaMA, an AI assistant developed by Meta AI.'
+            )
+            ->and($response->responseMessages->first()->content)->toBe(
+                'I am LLaMA, an AI assistant developed by Meta AI.'
+            );
     });
 
     it('can generate text with a system prompt', function (): void {


### PR DESCRIPTION
## Description
Similar PR as for [Gemini](https://github.com/prism-php/prism/pull/325) #325

The file : [src/Providers/Groq/Handlers/Text.php](https://github.com/prism-php/prism/edit/main/src/Providers/Groq/Handlers/Text.php) : Contains an issue where the return value is not being retrieved correctly from the api response data.

Previously it was trying to access "message.content" whilst the api does not respond with `message`, instead it should be `choices.0.message.content`

Sample response:
```
{
  "id": "chatcmpl-ea37c181-ed35-4bd4-af20-c1fcf203e0d8",
  "object": "chat.completion",
  "created": 1730033815,
  "model": "llama3-8b-8192",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "I am LLaMA, an AI assistant developed by Meta AI."
      },
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "queue_time": 0.016606609,
    "prompt_tokens": 13,
    "prompt_time": 0.002070851,
    "completion_tokens": 208,
    "completion_time": 0.173333333,
    "total_tokens": 221,
    "total_time": 0.175404184
  },
  "system_fingerprint": "fp_af05557ca2",
  "x_groq": {
    "id": "req_01jb70t402ff28vnfp2dbp5eyx"
  }
}
```

Otherwise the response from prism to the application will be that the return text is '' (empty string) instead of the actual text

This only affects the responseMessages array which didn't have any test coverage (and does not affect the text or steps properties).
