### PR TITLE
fix: replace array_filter with Arr::whereNotNull in handlers

### DIFF
--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -60,7 +60,7 @@ abstract class AnthropicHandlerAbstract
      */
     protected function extractCitations(array $data): ?array
     {
-        if (array_filter(data_get($data, 'content.*.citations')) === []) {
+        if (Arr::whereNotNull(data_get($data, 'content.*.citations')) === []) {
             return null;
         }
 

--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -8,8 +8,8 @@ use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use Pest\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\ChunkType;
 use Prism\Prism\Exceptions\PrismChunkDecodeException;
@@ -563,7 +563,7 @@ class Stream
             return $this->client
                 ->withOptions(['stream' => true])
                 ->throw()
-                ->post('messages', array_filter([
+                ->post('messages', Arr::whereNotNull([
                     'stream' => true,
                     ...Text::buildHttpRequestPayload($request),
                 ]));

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Anthropic\Handlers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
@@ -76,7 +77,7 @@ class Structured extends AnthropicHandlerAbstract
             throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
         }
 
-        return array_filter([
+        return Arr::whereNotNull([
             'model' => $request->model(),
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
@@ -115,7 +116,7 @@ class Structured extends AnthropicHandlerAbstract
                 model: data_get($data, 'model'),
                 rateLimits: $this->processRateLimits($this->httpResponse)
             ),
-            additionalContent: array_filter([
+            additionalContent: Arr::whereNotNull([
                 'messagePartsWithCitations' => $this->extractCitations($data),
                 ...$this->extractThinking($data),
             ])

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Anthropic\Handlers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Contracts\PrismRequest;
@@ -81,7 +82,7 @@ class Text extends AnthropicHandlerAbstract
             throw new \InvalidArgumentException('Request must be an instance of '.TextRequest::class);
         }
 
-        return array_filter([
+        return Arr::whereNotNull([
             'model' => $request->model(),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
@@ -170,7 +171,7 @@ class Text extends AnthropicHandlerAbstract
                 model: data_get($data, 'model'),
                 rateLimits: $this->processRateLimits($this->httpResponse)
             ),
-            additionalContent: array_filter([
+            additionalContent: Arr::whereNotNull([
                 'messagePartsWithCitations' => $this->extractCitations($data),
                 ...$this->extractThinking($data),
             ])

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -3,6 +3,7 @@
 namespace Prism\Prism\Providers\DeepSeek\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
 use Prism\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
@@ -56,7 +57,7 @@ class Structured
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_completion_tokens' => $request->maxTokens(),
-            ], array_filter([
+            ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\DeepSeek\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -109,7 +110,7 @@ class Text
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_completion_tokens' => $request->maxTokens(),
-                ], array_filter([
+                ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),

--- a/src/Providers/Gemini/Handlers/Cache.php
+++ b/src/Providers/Gemini/Handlers/Cache.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Providers\Gemini\Maps\MessageMap;
 use Prism\Prism\Providers\Gemini\ValueObjects\GeminiCachedObject;
@@ -40,7 +41,7 @@ class Cache
         try {
             $response = $this->client->post(
                 '/cachedContents',
-                array_filter([
+                Arr::whereNotNull([
                     'model' => 'models/'.$this->model,
                     ...(new MessageMap($this->messages, $this->systemPrompts))(),
                     'ttl' => $this->ttl.'s',

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Prism\Prism\Embeddings\Request;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
@@ -59,7 +60,7 @@ class Embeddings
 
         return $this->client->post(
             "{$request->model()}:embedContent",
-            array_filter([
+            Arr::whereNotNull([
                 'model' => $request->model(),
                 'content' => [
                     'parts' => [

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -7,6 +7,7 @@ namespace Prism\Prism\Providers\Gemini\Handlers;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
@@ -235,16 +236,16 @@ class Stream
                 ->withOptions(['stream' => true])
                 ->post(
                     "{$request->model()}:streamGenerateContent?alt=sse",
-                    array_filter([
+                    Arr::whereNotNull([
                         ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
                         'cachedContent' => $providerOptions['cachedContentName'] ?? null,
-                        'generationConfig' => array_filter([
+                        'generationConfig' => Arr::whereNotNull([
                             'temperature' => $request->temperature(),
                             'topP' => $request->topP(),
                             'maxOutputTokens' => $request->maxTokens(),
-                            'thinkingConfig' => array_filter([
+                            'thinkingConfig' => Arr::whereNotNull([
                                 'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                            ], fn ($v): bool => $v !== null),
+                            ]),
                         ]),
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -3,6 +3,7 @@
 namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Gemini\Concerns\ValidatesResponse;
 use Prism\Prism\Providers\Gemini\Maps\FinishReasonMap;
@@ -55,18 +56,18 @@ class Structured
 
             $response = $this->client->post(
                 "{$request->model()}:generateContent",
-                array_filter([
+                Arr::whereNotNull([
                     ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'cachedContent' => $providerOptions['cachedContentName'] ?? null,
-                    'generationConfig' => array_filter([
+                    'generationConfig' => Arr::whereNotNull([
                         'response_mime_type' => 'application/json',
                         'response_schema' => (new SchemaMap($request->schema()))->toArray(),
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
-                        'thinkingConfig' => array_filter([
+                        'thinkingConfig' => Arr::whereNotNull([
                             'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                        ], fn ($v): bool => $v !== null),
+                        ]),
                     ]),
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
                 ])

--- a/src/Providers/Groq/Concerns/ValidateResponse.php
+++ b/src/Providers/Groq/Concerns/ValidateResponse.php
@@ -41,7 +41,11 @@ trait ValidateResponse
      */
     protected function processRateLimits(Response $response): array
     {
-        $limitHeaders = array_filter($response->getHeaders(), fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'), ARRAY_FILTER_USE_KEY);
+        $limitHeaders = array_filter(
+            $response->getHeaders(),
+            fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'),
+            ARRAY_FILTER_USE_KEY
+        );
 
         $rateLimits = [];
 

--- a/src/Providers/Groq/Handlers/Structured.php
+++ b/src/Providers/Groq/Handlers/Structured.php
@@ -4,6 +4,7 @@ namespace Prism\Prism\Providers\Groq\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Groq\Concerns\ValidateResponse;
 use Prism\Prism\Providers\Groq\Maps\FinishReasonMap;
@@ -54,7 +55,7 @@ class Structured
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens(),
-            ], array_filter([
+            ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Groq\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -68,7 +69,7 @@ class Text
         try {
             return $this->client->post(
                 'chat/completions',
-                array_filter([
+                Arr::whereNotNull([
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_tokens' => $request->maxTokens(),

--- a/src/Providers/Mistral/Handlers/Stream.php
+++ b/src/Providers/Mistral/Handlers/Stream.php
@@ -7,6 +7,7 @@ namespace Prism\Prism\Providers\Mistral\Handlers;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
@@ -211,7 +212,7 @@ class Stream
                         'model' => $request->model(),
                         'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                         'max_tokens' => $request->maxTokens(),
-                    ], array_filter([
+                    ], Arr::whereNotNull([
                         'temperature' => $request->temperature(),
                         'top_p' => $request->topP(),
                         'tools' => ToolMap::map($request->tools()),

--- a/src/Providers/Mistral/Handlers/Structured.php
+++ b/src/Providers/Mistral/Handlers/Structured.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Mistral\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Mistral\Concerns\MapsFinishReason;
 use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
@@ -58,7 +59,7 @@ class Structured
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens(),
-            ], array_filter([
+            ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Mistral\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -138,7 +139,7 @@ class Text
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_tokens' => $request->maxTokens(),
-                ], array_filter([
+                ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Prism\Prism\Embeddings\Request;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
@@ -48,10 +49,10 @@ class Embeddings
     {
         return $this->client->post(
             'api/embed',
-            array_filter([
+            Arr::whereNotNull([
                 'model' => $request->model(),
                 'input' => $request->inputs(),
-                'options' => array_filter($request->providerOptions()),
+                'options' => Arr::whereNotNull($request->providerOptions()),
             ])
         );
     }

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismChunkDecodeException;
@@ -181,7 +182,7 @@ class Stream
                     'messages' => (new MessageMap($request->messages()))->map(),
                     'tools' => ToolMap::map($request->tools()),
                     'stream' => true,
-                    'options' => array_filter(array_merge([
+                    'options' => Arr::whereNotNull(array_merge([
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Ollama\Concerns\MapsFinishReason;
 use Prism\Prism\Providers\Ollama\Concerns\ValidatesResponse;
@@ -87,7 +88,7 @@ class Structured
                 'messages' => (new MessageMap($request->messages()))->map(),
                 'format' => $request->schema()->toArray(),
                 'stream' => false,
-                'options' => array_filter(array_merge([
+                'options' => Arr::whereNotNull(array_merge([
                     'temperature' => $request->temperature(),
                     'num_predict' => $request->maxTokens() ?? 2048,
                     'top_p' => $request->topP(),

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -78,7 +79,7 @@ class Text
                     'messages' => (new MessageMap($request->messages()))->map(),
                     'tools' => ToolMap::map($request->tools()),
                     'stream' => false,
-                    'options' => array_filter(array_merge([
+                    'options' => Arr::whereNotNull(array_merge([
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),

--- a/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
@@ -15,7 +15,11 @@ trait ProcessesRateLimits
      */
     protected function processRateLimits(Response $response): array
     {
-        $limitHeaders = array_filter($response->getHeaders(), fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'), ARRAY_FILTER_USE_KEY);
+        $limitHeaders = array_filter(
+            $response->getHeaders(),
+            fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'),
+            ARRAY_FILTER_USE_KEY
+        );
 
         $rateLimits = [];
 

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
@@ -216,7 +217,7 @@ class Stream
                         'model' => $request->model(),
                         'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                         'max_completion_tokens' => $request->maxTokens(),
-                    ], array_filter([
+                    ], Arr::whereNotNull([
                         'temperature' => $request->temperature(),
                         'top_p' => $request->topP(),
                         'metadata' => (array) $request->providerOptions('metadata'),

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -4,6 +4,7 @@ namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Enums\StructuredMode;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
@@ -98,7 +99,7 @@ class Structured
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_completion_tokens' => $request->maxTokens(),
-                ], array_filter([
+                ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'metadata' => (array) $request->providerOptions('metadata'),
@@ -131,10 +132,10 @@ class Structured
 
         return $this->sendRequest($request, [
             'type' => 'json_schema',
-            'json_schema' => array_filter([
+            'json_schema' => Arr::whereNotNull([
                 'name' => $request->schema()->name(),
                 'schema' => $request->schema()->toArray(),
-                'strict' => (bool) $request->providerOptions('schema.strict'),
+                'strict' => $request->providerOptions('schema.strict') ? true : null,
             ]),
         ]);
     }

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -110,7 +111,7 @@ class Text
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_completion_tokens' => $request->maxTokens(),
-                ], array_filter([
+                ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'metadata' => (array) $request->providerOptions('metadata'),

--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -4,6 +4,7 @@ namespace Prism\Prism\Providers\VoyageAI;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
@@ -47,7 +48,7 @@ class Embeddings
         $providerOptions = $this->request->providerOptions();
 
         try {
-            $this->httpResponse = $this->client->post('embeddings', array_filter([
+            $this->httpResponse = $this->client->post('embeddings', Arr::whereNotNull([
                 'model' => $this->request->model(),
                 'input' => $this->request->inputs(),
                 'input_type' => $providerOptions['inputType'] ?? null,

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\XAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
@@ -108,7 +109,7 @@ class Text
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'max_tokens' => $request->maxTokens() ?? 2048,
-                ], array_filter([
+                ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),


### PR DESCRIPTION
## Description

Replaces array_filter with Arr::whereNotNull in provider handlers to address the issue spotted by a contributor on the [bedrock package](https://github.com/prism-php/bedrock/pull/15).

TL;DR - array_filter is replacing false-y values such as zero when setting e.g. temperature or topP to 0.