### PR TITLE
feat(openai): support openai model gpt-4.1 and gpt-4.1-mini model for structured output

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -32,6 +32,9 @@ class StructuredModeResolver
             'chatgpt-4o-latest',
             'o3-mini',
             'o3-mini-2025-01-31',
+            'gpt-4.1',
+            'gpt-4.1-nano',
+            'gpt-4.1-mini',
             'gpt-4.5-preview',
             'gpt-4.5-preview-2025-02-27',
         ]);


### PR DESCRIPTION
## Description

This PR adds support for `gpt-4.1`, `gpt-4.1-nano` and `gpt-4.1-mini` models in Prism's structured output.
![image](https://github.com/user-attachments/assets/1f1f01db-a475-46e8-9b50-f76b3f3acc49)

## Breaking Changes
None
