### PR TITLE
fix(gemini): structured output compatibility issues

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -89,22 +89,34 @@ class Structured
             ));
         }
 
-        // Check for thinking token exhaustion pattern
+        // Check for token exhaustion patterns
         $finishReason = data_get($data, 'candidates.0.finishReason');
         $content = data_get($data, 'candidates.0.content.parts.0.text', '');
         $thoughtTokens = data_get($data, 'usageMetadata.thoughtsTokenCount', 0);
 
-        if ($finishReason === 'MAX_TOKENS' && in_array(trim((string) $content), ['', '0'], true) && $thoughtTokens > 0) {
+        if ($finishReason === 'MAX_TOKENS') {
             $promptTokens = data_get($data, 'usageMetadata.promptTokenCount', 0);
+            $candidatesTokens = data_get($data, 'usageMetadata.candidatesTokenCount', 0);
             $totalTokens = data_get($data, 'usageMetadata.totalTokenCount', 0);
-            $outputTokens = $totalTokens - $promptTokens - $thoughtTokens;
+            $outputTokens = $candidatesTokens - $thoughtTokens;
 
-            throw PrismException::providerResponseError(
-                'Gemini thinking tokens exhausted the token limit. '.
-                "Token usage: {$promptTokens} prompt + {$thoughtTokens} thinking + {$outputTokens} output = {$totalTokens} total. ".
-                'Since thinking tokens consumed most of the allocation, no tokens remained for structured output. '.
-                'Try increasing maxTokens to at least '.($totalTokens + 500).' (suggested: '.($totalTokens * 2).' for comfortable margin).'
-            );
+            // Check if content is empty or likely truncated/invalid JSON
+            $isEmpty = in_array(trim((string) $content), ['', '0'], true);
+            $isInvalidJson = ! empty($content) && json_decode((string) $content) === null;
+            $contentLength = strlen((string) $content);
+
+            if (($isEmpty || $isInvalidJson) && $thoughtTokens > 0) {
+                $errorDetail = $isEmpty
+                    ? 'no tokens remained for structured output'
+                    : "output was truncated at {$contentLength} characters resulting in invalid JSON";
+
+                throw PrismException::providerResponseError(
+                    'Gemini hit token limit with high thinking token usage. '.
+                    "Token usage: {$promptTokens} prompt + {$thoughtTokens} thinking + {$outputTokens} output = {$totalTokens} total. ".
+                    "The {$errorDetail}. ".
+                    'Try increasing maxTokens to at least '.($totalTokens + 1000).' (suggested: '.($totalTokens * 2).' for comfortable margin).'
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Problems

### Issue 1: additionalProperties Schema Compatibility
The Gemini API does not support the `additionalProperties` field in JSON schemas, causing HTTP 400 errors when using ObjectSchema instances with this field.

### Issue 2: Token Exhaustion Detection for Structured Output
Gemini 2.5 Pro and Flash models can fail to generate valid structured output in two scenarios:
1. **Empty output**: Thinking tokens consume all available tokens, leaving none for output
2. **Truncated JSON**: Output is generated but gets cut off mid-stream, resulting in invalid JSON (e.g., infinite text repetition)

Both cases return empty arrays or invalid responses without clear error messages.

## Root Causes

### Schema Compatibility Issue
The `SchemaMap` class was including the `additionalProperties` field from ObjectSchema in API requests, which Gemini rejects with:
```
Invalid JSON payload received. Unknown name "additionalProperties"
```

### Token Exhaustion Issues
When token limits are insufficient, two failure patterns occur:
1. Thinking tokens (10k-65k tokens) consume entire allocation → empty output
2. Long outputs get truncated at MAX_TOKENS → invalid JSON that can't be parsed

## Solutions

### Fix 1: Schema Compatibility
```php
// Remove additionalProperties for Gemini compatibility
$schemaArray = $this->schema->toArray();
unset($schemaArray['additionalProperties']);
```

### Fix 2: Enhanced Token Exhaustion Detection
```php
if ($finishReason === 'MAX_TOKENS') {
    $promptTokens = data_get($data, 'usageMetadata.promptTokenCount', 0);
    $candidatesTokens = data_get($data, 'usageMetadata.candidatesTokenCount', 0);
    $totalTokens = data_get($data, 'usageMetadata.totalTokenCount', 0);
    $outputTokens = $candidatesTokens - $thoughtTokens;
    
    // Check if content is empty or likely truncated/invalid JSON
    $isEmpty = in_array(trim((string) $content), ['', '0'], true);
    $isInvalidJson = !empty($content) && json_decode($content) === null;
    $contentLength = strlen($content);
    
    if (($isEmpty || $isInvalidJson) && $thoughtTokens > 0) {
        $errorDetail = $isEmpty 
            ? 'no tokens remained for structured output' 
            : "output was truncated at {$contentLength} characters resulting in invalid JSON";
        
        throw PrismException::providerResponseError(
            'Gemini hit token limit with high thinking token usage. '.
            "Token usage: {$promptTokens} prompt + {$thoughtTokens} thinking + {$outputTokens} output = {$totalTokens} total. ".
            "The {$errorDetail}. ".
            'Try increasing maxTokens to at least '.($totalTokens + 1000).' (suggested: '.($totalTokens * 2).' for comfortable margin).'
        );
    }
}
```

## Real-World Examples

### Example 1: Empty Output (Thinking Tokens Exhaustion)
```php
// Request with maxTokens: 200
// Response data:
[
    "candidates" => [
        ["content" => ["parts" => [["text" => ""]]], "finishReason" => "MAX_TOKENS"]
    ],
    "usageMetadata" => [
        "promptTokenCount" => 12577,
        "candidatesTokenCount" => 199,
        "thoughtsTokenCount" => 199,
        "totalTokenCount" => 12776
    ]
]

// Error message:
"Gemini hit token limit with high thinking token usage. 
Token usage: 12577 prompt + 199 thinking + 0 output = 12776 total. 
The no tokens remained for structured output. 
Try increasing maxTokens to at least 13776 (suggested: 25552 for comfortable margin)."
```

### Example 2: Truncated JSON (Infinite Repetition)
```php
// Request with insufficient maxTokens
// Response data:
[
    "candidates" => [
        ["content" => ["parts" => [["text" => '{"daily_summary": "...", "primary_language": "ko-KR_Standard_V1_2024-07-23_A1_ko-KR_Standard_V1_2024-07-23_A1_ko-K... (무한반복)']]], 
         "finishReason" => "MAX_TOKENS"]
    ],
    "usageMetadata" => [
        "promptTokenCount" => 12577,
        "candidatesTokenCount" => 55178,
        "thoughtsTokenCount" => 10345,
        "totalTokenCount" => 78100
    ]
]

// Error message:
"Gemini hit token limit with high thinking token usage. 
Token usage: 12577 prompt + 10345 thinking + 44833 output = 78100 total. 
The output was truncated at 77497 characters resulting in invalid JSON. 
Try increasing maxTokens to at least 79100 (suggested: 156200 for comfortable margin)."
```

## Implementation Details

### Comprehensive Error Detection
- **Empty output detection**: Checks for empty or "0" content
- **Invalid JSON detection**: Validates JSON parsing to catch truncated outputs
- **Token breakdown**: Shows exact token distribution (prompt/thinking/output)
- **Character count**: Reports truncation point for debugging
- **Smart recommendations**: Suggests minimum (+1000) and comfortable (×2) token limits

### Schema Processing
- Removes unsupported `additionalProperties` field before API calls
- Maintains full ObjectSchema API compatibility
- Preserves all other schema features

## Impact

This comprehensive fix provides:
- **Schema compatibility**: ObjectSchema with `allowAdditionalProperties` now works
- **Clear diagnostics**: Detailed token usage breakdown and truncation info
- **Actionable guidance**: Specific token recommendations based on actual usage
- **Cost transparency**: No automatic increases, users control their token allocation
- **Better debugging**: Character count and token distribution help identify issues