### PR TITLE
Anthropic: Return an empty string for the `message_stop` event instead of the entire response

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -379,7 +379,7 @@ class Stream
         $usage = $this->state->usage();
 
         return new Chunk(
-            text: $this->state->text(),
+            text: '',
             finishReason: FinishReasonMap::map($this->state->stopReason()),
             meta: new Meta(
                 id: $this->state->requestId(),


### PR DESCRIPTION
## Description
This change updates the Anthropic provider's stream handler so that the final chunk for the `message_stop` event yields `text: ''` (an empty string) instead of the entire completed response. This avoids duplicate output when consuming text as chunks.

## Breaking Changes
None. The public API is preserved; only the contents of the final chunk change to match other providers and user expectations.

Resolves: #528 