### PR TITLE
feat(ollama): add support for thinking chunks in streaming responses (gpt-oss)

### DIFF
--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -74,8 +74,15 @@ class Stream
                 return;
             }
 
-            $content = data_get($data, 'message.content', '') ?? '';
-            $text .= $content;
+            $thinking = data_get($data, 'message.thinking', '');
+            $isThinking = $thinking !== '';
+
+            $chunkType = $isThinking ? ChunkType::Thinking : ChunkType::Text;
+            $content = $isThinking ? $thinking : data_get($data, 'message.content', '');
+
+            if (! $isThinking) {
+                $text .= $content;
+            }
 
             $finishReason = (bool) data_get($data, 'done', false)
                 ? FinishReason::Stop
@@ -83,7 +90,8 @@ class Stream
 
             yield new Chunk(
                 text: $content,
-                finishReason: $finishReason !== FinishReason::Unknown ? $finishReason : null
+                finishReason: $finishReason !== FinishReason::Unknown ? $finishReason : null,
+                chunkType: $chunkType,
             );
         }
     }

--- a/tests/Fixtures/ollama/stream-with-thinking-1.sse
+++ b/tests/Fixtures/ollama/stream-with-thinking-1.sse
@@ -1,0 +1,5 @@
+{"model":"gpt-oss:20b","created_at":"2025-08-08T10:00:00Z","message":{"role":"assistant","thinking":"Let me think about that."},"done":false}
+{"model":"gpt-oss:20b","created_at":"2025-08-08T10:00:01Z","message":{"role":"assistant","thinking":"First, I will consider relevant factors."},"done":false}
+{"model":"gpt-oss:20b","created_at":"2025-08-08T10:00:02Z","message":{"role":"assistant","content":"Here is the answer:"},"done":false}
+{"model":"gpt-oss:20b","created_at":"2025-08-08T10:00:03Z","message":{"role":"assistant","content":" You should bring a light jacket."},"done":false}
+{"model":"gpt-oss:20b","created_at":"2025-08-08T10:00:04Z","message":{"role":"assistant","content":" Have a great day!"},"done_reason":"stop","done":true}


### PR DESCRIPTION
## Description
Add thinking support for the [gpt-oss](https://ollama.com/library/gpt-oss) models.

It returns `message.thinking` and `message.content`. 

### Thinking mode:
```php
// Ollama
message[
    thinking => "something",
    content => ""
]

// Prism Chunk
Chunk(
    text: $content, // text from message.thinking 
    chunkType: ChunkType::Thinking,
)
```

### No thinking mode:
```php
// Ollama
message[
    thinking => "",
    content => "something"
]

// Prism Chunk
Chunk(
    text: $content, // text from message.content
    chunkType: ChunkType::Text,
)
```

