### PR TITLE
docs: update OpenAI provider documentation

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -40,7 +40,7 @@ $response = Prism::structured()
 ```php
 $response = Prism::structured()
     ->withProviderOptions([ // [!code focus]
-        'meta' => [ // [!code focus]
+        'metadata' => [ // [!code focus]
             'project_id' => 23 // [!code focus]
         ] // [!code focus]
     ]) // [!code focus]


### PR DESCRIPTION
## Description

Replaces `meta` with `metadata` in the OpenAI provider documentation example to match the Responses API parameter. This fixes visibility in API Platform and aligns the docs with the official spec. Reference: [OpenAI API Documentation](https://platform.openai.com/docs/api-reference/responses/create#responses_create-metadata)

## Breaking Changes
No breaking changes.
