### PR TITLE
Allow passing files as additional content in withPrompt() for images

### DIFF
--- a/src/Images/PendingRequest.php
+++ b/src/Images/PendingRequest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Images;
 
-use Illuminate\Contracts\View\View;
 use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
 
 class PendingRequest
@@ -16,16 +16,8 @@ class PendingRequest
     use ConfiguresClient;
     use ConfiguresModels;
     use ConfiguresProviders;
+    use HasPrompts;
     use HasProviderOptions;
-
-    protected string $prompt = '';
-
-    public function withPrompt(string|View $prompt): self
-    {
-        $this->prompt = is_string($prompt) ? $prompt : $prompt->render();
-
-        return $this;
-    }
 
     public function generate(): Response
     {
@@ -43,10 +35,11 @@ class PendingRequest
         return new Request(
             model: $this->model,
             providerKey: $this->providerKey(),
-            prompt: $this->prompt,
+            prompt: $this->prompt ?? '',
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             providerOptions: $this->providerOptions,
+            files: $this->additionalContent,
         );
     }
 }

--- a/src/Images/Request.php
+++ b/src/Images/Request.php
@@ -17,6 +17,7 @@ class Request implements PrismRequest
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerOptions
+     * @param  array<int, mixed>  $files
      */
     public function __construct(
         protected string $model,
@@ -25,6 +26,7 @@ class Request implements PrismRequest
         protected array $clientOptions,
         protected array $clientRetry,
         array $providerOptions = [],
+        protected array $files = [],
     ) {
         $this->providerOptions = $providerOptions;
     }
@@ -43,6 +45,14 @@ class Request implements PrismRequest
     public function clientOptions(): array
     {
         return $this->clientOptions;
+    }
+
+    /**
+     * @return array<int, \Prism\Prism\ValueObjects\Media\Media> $files
+     */
+    public function files(): array
+    {
+        return $this->files;
     }
 
     public function prompt(): string


### PR DESCRIPTION
## Description

Implementation for https://github.com/prism-php/prism/issues/531

Files can now be passed as second parameter to withPrompt() for image requests like for text requests. Next step will be to adapt the providers to use that files.

## Breaking Changes

None.