### PR TITLE
Add 'includeThoughts' provider option for Gemini

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -107,14 +107,30 @@ class Stream
                 text: $content,
                 finishReason: $finishReason !== FinishReason::Unknown ? $finishReason : null,
                 // gemini writes metadata in each chunk
-                meta: new Meta(
-                    id: data_get($data, 'responseId'),
-                    model: data_get($data, 'modelVersion'),
-                ),
+                meta: $this->extractMeta($data),
                 usage: $this->extractUsage($data, $request),
                 chunkType: $isThinking ? ChunkType::Thinking : ChunkType::Text,
             );
         }
+    }
+
+    /**
+     * @return Meta|null
+     */
+    protected function extractMeta(array $data): ?Meta
+    {
+        $meta = null;
+        $responseId = data_get($data, 'responseId');
+        $modelVersion = data_get($data, 'modelVersion');
+
+        if (!empty($responseId) && !empty($modelVersion)) {
+            $meta = new Meta(
+                id: $responseId,
+                model: $modelVersion
+            );
+        }
+
+        return $meta;
     }
 
     /**


### PR DESCRIPTION
Gemini provides the option to include thoughts in the response output ([https://ai.google.dev/api/generate-content#ThinkingConfig]()). 
This commit will include the possibility to have these thoughts in the Gemini streamed response (chunks).
`ChunkType` will be defined as `ChunkType::Thinking` when chunk is a _thought_.
When provider option `includeThoughts` is not explicitly defined as `true`, nothing will change compared to current streaming functionality.