### PR TITLE
fix(gemini): stream handler sends empty array for generationConfig

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -285,7 +285,7 @@ class Stream
                         'thinkingConfig' => Arr::whereNotNull([
                             'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
                         ]) ?: null,
-                    ]),
+                    ]) ?: null,
                     'tools' => $tools !== [] ? $tools : null,
                     'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,


### PR DESCRIPTION
``` PHP
Arr::whereNotNull([
    ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
    'cachedContent' => $providerOptions['cachedContentName'] ?? null,
    'generationConfig' => Arr::whereNotNull([
        'temperature' => $request->temperature(),
        'topP' => $request->topP(),
        'maxOutputTokens' => $request->maxTokens(),
        'thinkingConfig' => Arr::whereNotNull([
            'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
        ]) ?: null,
    ]),
    'tools' => $tools !== [] ? $tools : null,
    'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
    'safetySettings' => $providerOptions['safetySettings'] ?? null,
])
```
Should be removed when `generationConfig` is empty