### PR TITLE
fix(xai): stream handling with 0 value mid stream

### DIFF
--- a/src/Providers/XAI/Handlers/Stream.php
+++ b/src/Providers/XAI/Handlers/Stream.php
@@ -144,7 +144,7 @@ class Stream
      */
     protected function isInitialChunk(array $data): bool
     {
-        return isset($data['id']) && isset($data['model']) && ! data_get($data, 'choices.0.delta.content');
+        return isset($data['id']) && isset($data['model']) && data_get($data, 'choices.0.delta.content') === null;
     }
 
     /**

--- a/tests/Fixtures/xai/stream-basic-text-responses-with-zeros-1.json
+++ b/tests/Fixtures/xai/stream-basic-text-responses-with-zeros-1.json
@@ -1,0 +1,15 @@
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355095,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":"Thinking... ","role":"assistant"}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355097,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":"Thinking... "}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355098,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":"Thinking... "}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355099,"model":"grok-4","choices":[{"index":0,"delta":{"content":"410"}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355099,"model":"grok-4","choices":[{"index":0,"delta":{"content":"0"}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355099,"model":"grok-4","choices":[{"index":0,"delta":{"content":"50"}}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355102,"model":"grok-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"system_fingerprint":"fp_acdceb26fb"}
+
+data: [DONE]


### PR DESCRIPTION
## Description

When using XAI (grok-4) and having a stream in which a single `0` is returned within a chunk, it will turn that chunk into an initial chunk instead of a text chunk.

example:

```
data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355099,"model":"grok-4","choices":[{"index":0,"delta":{"content":"410"}}],"system_fingerprint":"fp_acdceb26fb"}

data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1752355099,"model":"grok-4","choices":[{"index":0,"delta":{"content":"0"}}],"system_fingerprint":"fp_acdceb26fb"}
```

returns `410` instead of `4100`

## Breaking Changes

-
