### PR TITLE
fix(gemini): adding fallbacks to Gemini Streaming

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -91,8 +91,8 @@ class Stream
                 finishReason: $finishReason !== FinishReason::Unknown ? $finishReason : null,
                 // gemini writes metadata in each chunk
                 meta: new Meta(
-                    id: data_get($data, 'responseId'),
-                    model: data_get($data, 'modelVersion'),
+                    id: data_get($data, 'responseId', 'null'),
+                    model: data_get($data, 'modelVersion', 'null'),
                 ),
                 usage: $this->extractUsage($data, $request),
             );
@@ -160,8 +160,8 @@ class Stream
             text: '',
             toolCalls: $toolCalls,
             meta: new Meta(
-                id: data_get($data, 'responseId'),
-                model: data_get($data, 'modelVersion'),
+                id: data_get($data, 'responseId', 'null'),
+                model: data_get($data, 'modelVersion', 'null'),
             ),
             chunkType: ChunkType::ToolCall,
             usage: $this->extractUsage($data, $request),
@@ -173,8 +173,8 @@ class Stream
             text: '',
             toolResults: $toolResults,
             meta: new Meta(
-                id: data_get($data, 'responseId'),
-                model: data_get($data, 'modelVersion'),
+                id: data_get($data, 'responseId', 'null'),
+                model: data_get($data, 'modelVersion', 'null'),
             ),
             chunkType: ChunkType::ToolResult,
             usage: $this->extractUsage($data, $request),
@@ -198,8 +198,8 @@ class Stream
         return collect($toolCalls)
             ->map(fn ($toolCall): ToolCall => new ToolCall(
                 empty($toolCall['id']) ? 'gm-'.Str::random(20) : $toolCall['id'],
-                data_get($toolCall, 'name'),
-                data_get($toolCall, 'arguments'),
+                data_get($toolCall, 'name', 'null'),
+                data_get($toolCall, 'arguments', []),
             ))
             ->toArray();
     }


### PR DESCRIPTION
## Description
When streaming responses with Gemini, occasionally Google will omit or send a NULL responseId.  Our call to create a  Meta value object then fails, as it is expecting a string.

the streaming completely fails and prism throws ->
`Prism\Prism\ValueObjects\Meta::__construct(): Argument #1 ($id) must be of type string, null given, called in /var/www/html/vendor/prism-php/prism/src/Providers/Gemini/Handlers/Stream.php on line 93`

my changes simply populate a fallback to 'null' as a string if the data_get value cannot find a responseId from google. These IDs seem purely for debugging or logging purposes so I would rather see the response stream without error than fail because of an inconsistency on google's part