### PR TITLE
fix(Anthropic MessageMap): ensure empty toolCall arguments dictionary not array

### DIFF
--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -164,7 +164,7 @@ class MessageMap
                 'type' => 'tool_use',
                 'id' => $toolCall->id,
                 'name' => $toolCall->name,
-                'input' => $toolCall->arguments(),
+                'input' => $toolCall->arguments() === [] ? new \stdClass : $toolCall->arguments(),
             ], $message->toolCalls)
             : [];
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the Anthropic provider’s `MessageMap` mapped `ToolCall` arguments that were empty (`[]`) as a JSON array instead of a JSON object (`{}`).

Anthropic’s API requires the input field for tool_use messages to always be a dictionary/object, even when empty.

Previously, if a `ToolCall` had no arguments, Prism would serialize:

```json
"input": []
```

which caused Anthropic to return:

```
messages.#.content.#.tool_use.input: Input should be a valid dictionary
```

This change normalizes empty or list-style argument arrays to an empty object (`{}`) within the Anthropic `MessageMap`, ensuring schema compliance and preventing the error.

It is scoped only to the Anthropic provider and does not affect other integrations (e.g., OpenAI, Gemini).

Resolves #659 