### PR TITLE
fix(DeepSeek|OpenRouter): Fix exceptions during tool conversion without parameters

### DIFF
--- a/src/Providers/DeepSeek/Maps/ToolMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolMap.php
@@ -19,11 +19,13 @@ class ToolMap
             'function' => [
                 'name' => $tool->name(),
                 'description' => $tool->description(),
-                'parameters' => [
-                    'type' => 'object',
-                    'properties' => $tool->parametersAsArray(),
-                    'required' => $tool->requiredParameters(),
-                ],
+                ...$tool->hasParameters() ? [
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => $tool->parametersAsArray(),
+                        'required' => $tool->requiredParameters(),
+                    ],
+                ] : [],
             ],
             'strict' => $tool->providerOptions('strict'),
         ]), $tools);

--- a/src/Providers/OpenRouter/Maps/ToolMap.php
+++ b/src/Providers/OpenRouter/Maps/ToolMap.php
@@ -19,11 +19,13 @@ class ToolMap
             'function' => [
                 'name' => $tool->name(),
                 'description' => $tool->description(),
-                'parameters' => [
-                    'type' => 'object',
-                    'properties' => $tool->parametersAsArray(),
-                    'required' => $tool->requiredParameters(),
-                ],
+                ...$tool->hasParameters() ? [
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => $tool->parametersAsArray(),
+                        'required' => $tool->requiredParameters(),
+                    ],
+                ] : [],
             ],
             'strict' => $tool->providerOptions('strict'),
         ]), $tools);


### PR DESCRIPTION
Tools without parameters were previously converted to:
``` JSON
{"type":"function","function":{"name":"tool name","description":"tool description","parameters":{"type":"object","properties":[],"required":[]}}}
```
Providers `DeepSeek` and `OpenRouter` would report an error because `properties` is empty.