### PR TITLE
doc: use correct model name for provider config in configuration page

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -65,6 +65,7 @@ PROVIDER_API_KEY=your-api-key-here
 PROVIDER_URL=https://custom-endpoint.com
 
 ```
+
 > [!NOTE]
 > Remember to always refer to your chosen provider's documentation pages for the most up-to-date configuration options and requirements specific to that provider.
 
@@ -78,7 +79,7 @@ use Prism\Prism\Enums\Provider;
 
 // Via the third parameter of `using()`
 $response = Prism::text()
-    ->using(Provider::OpenAI, 'claude-3-5-sonnet-20241022', [
+    ->using(Provider::OpenAI, 'gpt-4o', [
         'url' => 'new-base-url'
     ])
     ->withPrompt('Explain quantum computing.')
@@ -86,7 +87,7 @@ $response = Prism::text()
 
 // Or via `usingProviderConfig()` (note that this will re-resolve the provider).
 $response = Prism::text()
-    ->using(Provider::OpenAI, 'claude-3-5-sonnet-20241022')
+    ->using(Provider::OpenAI, 'gpt-4o')
     ->usingProviderConfig([
         'url' => 'new-base-url'
     ])


### PR DESCRIPTION
This PR updates the documentation in the configuration page to use the correct model name for the OpenAI LLM provider. The previous example incorrectly referenced the `claude-3-5-sonnet-20241022` model, which belongs to Anthropic. It has been replaced with the correct OpenAI model name, `gpt-4o`, in all relevant code samples.

This change ensures that users configuring the OpenAI provider have accurate examples that reflect the correct model usage, reducing confusion and improving the clarity and accuracy of the documentation.