### PR TITLE
docs(openrouter): Improve documentation for OpenRouter provider options and model routing

### DIFF
--- a/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
+++ b/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
@@ -20,38 +20,20 @@ trait BuildsRequestOptions
      */
     protected function buildRequestOptions(TextRequest|StructuredRequest $request, array $additional = []): array
     {
-        // Pass through every documented OpenRouter option so callers can use https://openrouter.ai/docs/api-reference/overview
-        $options = array_merge($request->providerOptions() ?? [], [
+        // Keep OpenRouter option surface flexible; reference https://openrouter.ai/docs/api-reference/parameters for supported keys.
+        $options = $request->providerOptions() ?? [];
+
+        $options = array_merge($options, Arr::whereNotNull([
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
-            'stop' => $request->providerOptions('stop'),
-            'seed' => $request->providerOptions('seed'),
-            'top_k' => $request->providerOptions('top_k'),
-            'frequency_penalty' => $request->providerOptions('frequency_penalty'),
-            'presence_penalty' => $request->providerOptions('presence_penalty'),
-            'repetition_penalty' => $request->providerOptions('repetition_penalty'),
-            'min_p' => $request->providerOptions('min_p'),
-            'top_a' => $request->providerOptions('top_a'),
-            'logit_bias' => $request->providerOptions('logit_bias'),
-            'logprobs' => $request->providerOptions('logprobs'),
-            'top_logprobs' => $request->providerOptions('top_logprobs'),
-            'response_format' => $request->providerOptions('response_format'),
-            'prediction' => $request->providerOptions('prediction'),
-            'transforms' => $request->providerOptions('transforms'),
-            'models' => $request->providerOptions('models'),
-            'route' => $request->providerOptions('route'),
-            'provider' => $request->providerOptions('provider'),
-            'user' => $request->providerOptions('user'),
-            'reasoning' => $request->providerOptions('reasoning'),
-            'verbosity' => $request->providerOptions('verbosity'),
-        ]);
+            'max_tokens' => $request->maxTokens(),
+        ]));
 
         if ($request instanceof TextRequest) {
-            $options = array_merge($options, [
+            $options = array_merge($options, Arr::whereNotNull([
                 'tools' => ToolMap::map($request->tools()),
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                'parallel_tool_calls' => $request->providerOptions('parallel_tool_calls'),
-            ]);
+            ]));
         }
 
         return Arr::whereNotNull(array_merge($options, $additional));


### PR DESCRIPTION
The previous PR included too many manual option bindings since OpenRouter often changes its parameters. So I changed all the options to flexible options and simplified the code.

Also, added detailed documentation about `model` and `models`. I thought some people would be confused about how `models` work when they already have a `model`.

Added the missed max token too.