### PR TITLE
feat(openaI): Add response ID to stream end event

### DIFF
--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -206,7 +206,10 @@ class Stream
                         completionTokens: data_get($data, 'response.usage.output_tokens'),
                         cacheReadInputTokens: data_get($data, 'response.usage.input_tokens_details.cached_tokens'),
                         thoughtTokens: data_get($data, 'response.usage.output_tokens_details.reasoning_tokens')
-                    )
+                    ),
+                    additionalContent: Arr::whereNotNull([
+                        'response_id' => data_get($data, 'response.id'),
+                    ])
                 );
             }
         }

--- a/src/Streaming/Events/StreamEndEvent.php
+++ b/src/Streaming/Events/StreamEndEvent.php
@@ -14,13 +14,15 @@ readonly class StreamEndEvent extends StreamEvent
 {
     /**
      * @param  array<MessagePartWithCitations>|null  $citations
+     * @param  array<string,mixed>  $additionalContent
      */
     public function __construct(
         string $id,
         int $timestamp,
         public FinishReason $finishReason,  // Why stream ended
         public ?Usage $usage = null,        // Token usage information
-        public ?array $citations = null     // Citations collected during stream
+        public ?array $citations = null,    // Citations collected during stream
+        public array $additionalContent = []
     ) {
         parent::__construct($id, $timestamp);
     }
@@ -36,6 +38,7 @@ readonly class StreamEndEvent extends StreamEvent
     public function toArray(): array
     {
         return [
+            ...$this->additionalContent,
             'id' => $this->id,
             'timestamp' => $this->timestamp,
             'finish_reason' => $this->finishReason->name,

--- a/tests/Unit/Streaming/Events/StreamEndEventTest.php
+++ b/tests/Unit/Streaming/Events/StreamEndEventTest.php
@@ -148,3 +148,61 @@ it('handles all finish reason types', function (FinishReason $reason): void {
     FinishReason::Other,
     FinishReason::Unknown,
 ]);
+
+it('constructs with additional content', function (): void {
+    $event = new StreamEndEvent(
+        id: 'event-123',
+        timestamp: 1640995200,
+        finishReason: FinishReason::Stop,
+        additionalContent: [
+            'response_id' => 'resp_abc123',
+            'custom_field' => 'custom_value',
+        ]
+    );
+
+    expect($event->additionalContent)->toBe([
+        'response_id' => 'resp_abc123',
+        'custom_field' => 'custom_value',
+    ]);
+});
+
+it('includes additional content in array output', function (): void {
+    $event = new StreamEndEvent(
+        id: 'event-123',
+        timestamp: 1640995200,
+        finishReason: FinishReason::Stop,
+        additionalContent: [
+            'response_id' => 'resp_abc123',
+            'provider_field' => 'value',
+        ]
+    );
+
+    $array = $event->toArray();
+
+    expect($array)->toHaveKey('response_id')
+        ->and($array['response_id'])->toBe('resp_abc123')
+        ->and($array)->toHaveKey('provider_field')
+        ->and($array['provider_field'])->toBe('value')
+        ->and($array)->toHaveKey('id')
+        ->and($array['id'])->toBe('event-123');
+});
+
+it('defaults to empty additional content', function (): void {
+    $event = new StreamEndEvent(
+        id: 'event-123',
+        timestamp: 1640995200,
+        finishReason: FinishReason::Stop
+    );
+
+    expect($event->additionalContent)->toBe([]);
+
+    $array = $event->toArray();
+
+    expect($array)->toBe([
+        'id' => 'event-123',
+        'timestamp' => 1640995200,
+        'finish_reason' => 'Stop',
+        'usage' => null,
+        'citations' => null,
+    ]);
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes #679

Add `additionalContent` to the `StreamEndEvent` and exposes OpenAI response ID