### PR TITLE
feat(api): Optional model parameter

### DIFF
--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -19,7 +19,7 @@ trait ConfiguresProviders
     /**
      * @param  array<string, mixed>  $providerConfig
      */
-    public function using(string|ProviderEnum $provider, string $model, array $providerConfig = []): self
+    public function using(string|ProviderEnum $provider, string $model = '', array $providerConfig = []): self
     {
         $this->providerKey = is_string($provider) ? $provider : $provider->value;
 


### PR DESCRIPTION
## Description

The using() method currently requires the provider and a model name but there are providers which won't allow you to select the model or choose the current default model if no value is provided. This PR makes the $model parameter in using() optional and uses and empty string if no model name is passed.

## Breaking Changes

None