### PR TITLE
fix(stream/anthropic): replace TollResultEvent::toolResult with correct ToolResult instance

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -448,17 +448,10 @@ class Stream
 
                 $toolResults[] = $toolResult;
 
-                $resultObj = new ToolResult(
-                    toolCallId: $toolCall->id,
-                    toolName: $toolCall->name,
-                    args: $toolCall->arguments(),
-                    result: is_array($result) ? $result : ['result' => $result]
-                );
-
                 yield new ToolResultEvent(
                     id: EventID::generate(),
                     timestamp: time(),
-                    toolResult: $resultObj,
+                    toolResult: $toolResult,
                     messageId: $this->state->messageId(),
                     success: true
                 );


### PR DESCRIPTION
## Description
Remove superfluous `ToolResult` construction in `Prism\Prism\Providers\Anthropic\Handlers\Stream::handleToolCalls` and use the already constructed `$toolResult` for the `ToolResultEvent::toolResult` prop.

https://github.com/prism-php/prism/blob/e13276f652c62b4f508c9a85d6221d524a302fd2/src/Providers/Anthropic/Handlers/Stream.php#L442-L464

Resolves #693 
