### PR TITLE
feat(api) Pass additional files to text request

### DIFF
--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -156,6 +156,7 @@ class PendingRequest
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
+            additionalContent: $this->additionalContent,
             providerOptions: $this->providerOptions,
             providerTools: $this->providerTools,
         );

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -11,6 +11,7 @@ use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Enums\ToolChoice;
 use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Media\Media;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\ProviderTool;
 
@@ -25,6 +26,7 @@ class Request implements PrismRequest
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerOptions
+     * @param  Media[]  $additionalContent
      * @param  array<int, ProviderTool>  $providerTools
      */
     public function __construct(
@@ -41,6 +43,7 @@ class Request implements PrismRequest
         protected array $clientOptions,
         protected array $clientRetry,
         protected string|ToolChoice|null $toolChoice,
+        protected array $additionalContent,
         array $providerOptions = [],
         protected array $providerTools = [],
     ) {
@@ -141,5 +144,13 @@ class Request implements PrismRequest
         $this->messages = array_merge($this->messages, [$message]);
 
         return $this;
+    }
+
+    /**
+     * @return Media[]
+     */
+    public function additionalContent(): array
+    {
+        return $this->additionalContent;
     }
 }


### PR DESCRIPTION
## Description

Additional files are passed to text requests like for other requests (e.g. images). Currently, files in text requests are special handled by passing them in Message objects. This PR streamlines the behaviour and passes file as additionalContent so providers can use them directly or as part of Message objects.

## Breaking Changes

None for the user but the text request constructor requires an additional parameter now