### PR TITLE
feat(gemini): add full support for gemini-2.5-flash-image

### DIFF
--- a/src/Providers/Gemini/Maps/ImageRequestMap.php
+++ b/src/Providers/Gemini/Maps/ImageRequestMap.php
@@ -47,7 +47,7 @@ class ImageRequestMap
                 ],
             ],
             'generationConfig' => [
-                'responseModalities' => ['TEXT', 'IMAGE'],
+                'responseModalities' => $providerOptions['response_modalities'] ?? ['TEXT', 'IMAGE'],
                 'imageConfig' => [
                     'aspectRatio' => $providerOptions['aspect_ratio'] ?? null,
                 ],


### PR DESCRIPTION
## Description

This PR adds full support for `gemini-2.5-flash-image` and fixes issues with Gemini image generation that were causing `"finishReason": "IMAGE_OTHER"` errors (HTTP 200 but no image generated) when performing complex image editing operations.

> **Note:** The models `gemini-2.0-flash-preview-image-generation` and `gemini-2.5-flash-image-preview` will be deprecated on **October 31, 2025** ([reference](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image?hl=fr)). This PR ensures Prism is ready for `gemini-2.5-flash-image`, which is the recommended model going forward.

### Background

While working with `gemini-2.5-flash-image` for large-scale image transformations (e.g., complex face editing, background replacements), I encountered consistent failures returning HTTP 200 with `"finishReason": "IMAGE_OTHER"` instead of generating images. After extensive testing in Node.js comparing different parameter configurations, I identified several API specification deviations in Prism's implementation that were preventing proper usage of this model.

These fixes ensure full compatibility with `gemini-2.5-flash-image` and enable advanced configuration options for image generation.

### Changes Overview

This PR addresses four key issues through four atomic commits:

#### 1. **Fix: Send images before text in multimodal prompts** (`dad8f21`)

**Problem:** Images were sent AFTER the text prompt, violating Gemini's best practices for multimodal prompts.

**Solution:** Reordered the `parts` array to place `inline_data` (images) before `text` prompt.

**Impact:** Without this ordering, complex prompts requesting significant image modifications can fail with `IMAGE_OTHER` and no output.

**Reference:** [Gemini Multimodal Best Practices](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding#best-practices)

```php
// Before
$parts = [
    ['text' => $prompt],
    ['inline_data' => ...], // images
];

// After
$parts = [
    ['inline_data' => ...], // images FIRST
    ['text' => $prompt],
];
```

#### 2. **Fix: Use camelCase for image data fields per API spec** (`5c23f9b`)

**Problem:** Fields used snake_case (`inline_data`, `mime_type`) instead of the official camelCase format.

**Solution:** Converted to camelCase as specified in the REST API documentation:
- `inline_data` → `inlineData`
- `mime_type` → `mimeType`

**Impact:** This change ensures conformity with the official REST API specification. While snake_case appeared to work in basic scenarios, it also seems to increase the likelihood of `IMAGE_OTHER` errors during complex image transformations.

**Reference:** [Gemini Content API Reference](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/Content)

#### 3. **Feat: Add `safety_settings` support** (`0e54d06`)

**Problem:** No way to configure content filtering thresholds for image generation.

**Solution:** Added support for configurable safety settings via provider options.

**Usage:**
```php
Prism::image()
    ->using(Provider::Gemini, 'gemini-2.5-flash-image')
    ->withPrompt('Edit this image', [$image])
    ->withProviderOptions([
        'safety_settings' => [
            ['category' => 'HARM_CATEGORY_HARASSMENT', 'threshold' => 'BLOCK_ONLY_HIGH'],
            ['category' => 'HARM_CATEGORY_HATE_SPEECH', 'threshold' => 'BLOCK_ONLY_HIGH'],
            ['category' => 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'threshold' => 'BLOCK_ONLY_HIGH'],
            ['category' => 'HARM_CATEGORY_DANGEROUS_CONTENT', 'threshold' => 'BLOCK_ONLY_HIGH'],
        ],
    ])
    ->generate();
```

**Reference:** [Gemini SafetySetting API](https://ai.google.dev/api/generate-content?hl=fr#v1beta.SafetySetting)

#### 4. **Feat: Add configurable `responseModalities`** (`27e2a87`)

**Problem:** `responseModalities` was hardcoded to `['TEXT', 'IMAGE']`.

**Solution:** Made it configurable while maintaining the default behavior.

**Usage:**
```php
// Only return image, no text
->withProviderOptions([
    'response_modalities' => ['IMAGE'],
])

// Default behavior (if not specified)
// responseModalities: ['TEXT', 'IMAGE']
```

**Reference:** [Gemini GenerationConfig API](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/GenerationConfig)

### Testing

- All existing tests pass
- Added 4 new comprehensive tests:
  - Image ordering verification
  - camelCase field format verification
  - `safety_settings` configuration
  - `responseModalities` default and override behavior
- Code formatted with Laravel Pint + Rector
- PHPStan level 8 passes with 0 errors

### Files Changed

- `src/Providers/Gemini/Maps/ImageRequestMap.php` (+15 lines)
- `tests/Providers/Gemini/ImagesTest.php` (+57 lines, 4 new tests)

## Breaking Changes

None. All changes are backward compatible:
- Default behavior remains unchanged
- New options are opt-in via `withProviderOptions()`
- Existing code continues to work without modifications

## Next Steps ?
I can handle these improvements in follow-up PRs if you want :

**Update tests for gemini-2.5-flash-image:**
- Replace `gemini-2.0-flash-preview-image-generation` references
- Update test fixtures

**Update documentation:**
- Add `safety_settings` and `response_modalities` examples
- Document model migration (2.0 → 2.5)
- Best practices for complex image editing

---

## Acknowledgments

Thank you to @sixlive and all the contributors for creating and maintaining this excellent library. 🫶

