### PR TITLE
Update OpenAI error handling

### DIFF
--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -7,7 +7,6 @@ namespace Prism\Prism\Providers\OpenAI;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Http\Client\Response;
 use Prism\Prism\Audio\AudioResponse as TextToSpeechResponse;
 use Prism\Prism\Audio\SpeechToTextRequest;
 use Prism\Prism\Audio\TextResponse as SpeechToTextResponse;


### PR DESCRIPTION
This tries to parse the OpenAI error, so instead of a 400 invalid request, you get the actual errors.