### PR TITLE
fix(openai): correct usage field path for reasoning tokens

### DIFF
--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -74,7 +74,7 @@ class Structured
                 promptTokens: data_get($data, 'usage.input_tokens', 0) - data_get($data, 'usage.input_tokens_details.cached_tokens', 0),
                 completionTokens: data_get($data, 'usage.output_tokens'),
                 cacheReadInputTokens: data_get($data, 'usage.input_tokens_details.cached_tokens'),
-                thoughtTokens: data_get($data, 'usage.output_token_details.reasoning_tokens'),
+                thoughtTokens: data_get($data, 'usage.output_tokens_details.reasoning_tokens'),
             ),
             meta: new Meta(
                 id: data_get($data, 'id'),

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -160,7 +160,7 @@ class Text
                 promptTokens: data_get($data, 'usage.input_tokens', 0) - data_get($data, 'usage.input_tokens_details.cached_tokens', 0),
                 completionTokens: data_get($data, 'usage.output_tokens'),
                 cacheReadInputTokens: data_get($data, 'usage.input_tokens_details.cached_tokens'),
-                thoughtTokens: data_get($data, 'usage.output_token_details.reasoning_tokens'),
+                thoughtTokens: data_get($data, 'usage.output_tokens_details.reasoning_tokens'),
             ),
             meta: new Meta(
                 id: data_get($data, 'id'),


### PR DESCRIPTION
Fixes #706

## Summary
- Fixed typo in `Text.php` and `Structured.php` handlers
- Changed `output_token_details` → `output_tokens_details` to match OpenAI API spec
- Reasoning tokens now correctly extracted for non-streaming requests

## Changes
- `src/Providers/OpenAI/Handlers/Text.php:163`
- `src/Providers/OpenAI/Handlers/Structured.php:77`