### PR TITLE
fix(openai) - text verbosity openai + add text verbosity to openai st…

### DIFF
--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -526,6 +526,9 @@ class Stream
                     'parallel_tool_calls' => $request->providerOptions('parallel_tool_calls'),
                     'previous_response_id' => $request->providerOptions('previous_response_id'),
                     'service_tier' => $request->providerOptions('service_tier'),
+                    'text' => $request->providerOptions('text_verbosity') ? [
+                        'verbosity' => $request->providerOptions('text_verbosity'),
+                    ] : null,
                     'truncation' => $request->providerOptions('truncation'),
                     'reasoning' => $request->providerOptions('reasoning'),
                 ]))

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -135,7 +135,9 @@ class Text
                 'parallel_tool_calls' => $request->providerOptions('parallel_tool_calls'),
                 'previous_response_id' => $request->providerOptions('previous_response_id'),
                 'service_tier' => $request->providerOptions('service_tier'),
-                'text_verbosity' => $request->providerOptions('text_verbosity'),
+                'text' => $request->providerOptions('text_verbosity') ? [
+                    'verbosity' => $request->providerOptions('text_verbosity'),
+                ] : null,
                 'truncation' => $request->providerOptions('truncation'),
                 'reasoning' => $request->providerOptions('reasoning'),
             ]))

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -453,7 +453,7 @@ it('uses meta to set text_verbosity', function (): void {
     Http::assertSent(function (Request $request) use ($textVerbosity): true {
         $body = json_decode($request->body(), true);
 
-        expect(data_get($body, 'text_verbosity'))->toBe($textVerbosity);
+        expect(data_get($body, 'text.verbosity'))->toBe($textVerbosity);
 
         return true;
     });
@@ -476,7 +476,7 @@ it('filters text_verbosity if null', function (): void {
     Http::assertSent(function (Request $request): true {
         $body = json_decode($request->body(), true);
 
-        expect($body)->not()->toHaveKey('text_verbosity');
+        expect($body)->not()->toHaveKey('text.verbosity');
 
         return true;
     });


### PR DESCRIPTION
According to https://platform.openai.com/docs/api-reference/responses/create#responses-create-text-verbosity there's no `text_verbosity` setting in the API. When using the feature I get the following error:

```
{
  "error": {
    "message": "Unknown parameter: 'text_verbosity'.",
    "type": "invalid_request_error",
    "param": "text_verbosity",
    "code": "unknown_parameter"
  }
}
```

This PR passes the the setting as `text.verbosity` while keeping the `text_verbosity` setting, if you want it differently let me know.

I've also added it to the stream handler.