### PR TITLE
(fix) gemini message map: duplicated image attachments

### DIFF
--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -108,8 +108,8 @@ class MessageMap
             $this->mapDocuments($message->documents()),
             $parts,
             $this->mapImages($message->images()),
-            $this->mapVideo($message->media()),
-            $this->mapAudio($message->media()),
+            $this->mapVideo($message->videos()),
+            $this->mapAudio($message->audios()),
         );
 
         $this->contents['contents'][] = [

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -39,6 +39,8 @@ describe('Anthropic user message mapping', function (): void {
             ]),
         ]);
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('image');
         expect(data_get($mappedMessage, '0.content.1.source.type'))
@@ -55,6 +57,8 @@ describe('Anthropic user message mapping', function (): void {
                 Image::fromBase64(base64_encode(file_get_contents('tests/Fixtures/diamond.png')), 'image/png'),
             ]),
         ]);
+
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('image');
@@ -73,6 +77,8 @@ describe('Anthropic user message mapping', function (): void {
             ]),
         ]);
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('image');
         expect(data_get($mappedMessage, '0.content.1.source.type'))
@@ -88,6 +94,8 @@ describe('Anthropic user message mapping', function (): void {
             ]),
         ]);
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');
         expect(data_get($mappedMessage, '0.content.1.source.type'))
@@ -102,6 +110,8 @@ describe('Anthropic user message mapping', function (): void {
                 Document::fromLocalPath('tests/Fixtures/test-pdf.pdf'),
             ]),
         ]);
+
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');
@@ -120,6 +130,8 @@ describe('Anthropic user message mapping', function (): void {
             ]),
         ]);
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');
         expect(data_get($mappedMessage, '0.content.1.source.type'))
@@ -136,6 +148,8 @@ describe('Anthropic user message mapping', function (): void {
                 Document::fromLocalPath('tests/Fixtures/test-text.txt'),
             ]),
         ]);
+
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');
@@ -154,6 +168,8 @@ describe('Anthropic user message mapping', function (): void {
             ]),
         ]);
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');
         expect(data_get($mappedMessage, '0.content.1.source.type'))
@@ -170,6 +186,8 @@ describe('Anthropic user message mapping', function (): void {
                 Document::fromText('Hello world!'),
             ]),
         ]);
+
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('document');

--- a/tests/Providers/DeepSeek/MessageMapTest.php
+++ b/tests/Providers/DeepSeek/MessageMapTest.php
@@ -39,6 +39,8 @@ it('maps user messages with images from path', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -59,6 +61,8 @@ it('maps user messages with images from base64', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -78,6 +82,8 @@ it('maps user messages with images from url', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');

--- a/tests/Providers/Gemini/MessageMapTest.php
+++ b/tests/Providers/Gemini/MessageMapTest.php
@@ -45,6 +45,8 @@ it('maps user messages with images from path', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, 'contents.0.parts'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, 'contents.0.parts.1.inline_data.mime_type'))
         ->toBe('image/png');
     expect(data_get($mappedMessage, 'contents.0.parts.1.inline_data.data'))
@@ -62,6 +64,8 @@ it('maps user messages with images from base64', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, 'contents.0.parts'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, 'contents.0.parts.1.inline_data.mime_type'))
         ->toBe('image/png');
@@ -81,6 +85,8 @@ describe('documents', function (): void {
         );
 
         $mappedMessage = $messageMap();
+
+        expect(data_get($mappedMessage, 'contents.0.parts'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, 'contents.0.parts.1.text'))
             ->toBe('Here is the document');
@@ -103,6 +109,8 @@ describe('documents', function (): void {
         );
 
         $mappedMessage = $messageMap();
+
+        expect(data_get($mappedMessage, 'contents.0.parts'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, 'contents.0.parts.1.text'))
             ->toBe('Here is the document');

--- a/tests/Providers/Groq/MessageMapTest.php
+++ b/tests/Providers/Groq/MessageMapTest.php
@@ -41,6 +41,8 @@ it('maps user messages with images from path', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -61,6 +63,8 @@ it('maps user messages with images from base64', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -80,6 +84,8 @@ it('maps user messages with images from url', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');

--- a/tests/Providers/Mistral/MessageMapTest.php
+++ b/tests/Providers/Mistral/MessageMapTest.php
@@ -43,6 +43,8 @@ it('maps user messages with images', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -159,6 +161,8 @@ it('maps user messages with documents from a url', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))->toBe('document_url');
 

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -59,6 +59,8 @@ it('maps user messages with images from path', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('input_image');
     expect(data_get($mappedMessage, '0.content.1.image_url'))
@@ -78,6 +80,8 @@ it('maps user messages with images from base64', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('input_image');
@@ -99,6 +103,8 @@ it('maps user messages with images from url', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('input_image');
     expect(data_get($mappedMessage, '0.content.1.image_url'))
@@ -116,6 +122,8 @@ it('maps user messages with images from file id', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('input_image');
@@ -246,6 +254,8 @@ describe('documents', function (): void {
 
         $mappedMessage = $messageMap();
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('input_file')
             ->and(data_get($mappedMessage, '0.content.1.file_data'))
@@ -264,6 +274,8 @@ describe('documents', function (): void {
 
         $mappedMessage = $messageMap();
 
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('input_file')
             ->and(data_get($mappedMessage, '0.content.1.file_url'))
@@ -281,6 +293,8 @@ describe('documents', function (): void {
         );
 
         $mappedMessage = $messageMap();
+
+        expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
         expect(data_get($mappedMessage, '0.content.1.type'))
             ->toBe('input_file')

--- a/tests/Providers/OpenRouter/MessageMapTest.php
+++ b/tests/Providers/OpenRouter/MessageMapTest.php
@@ -41,6 +41,8 @@ it('maps user messages with images from path', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -60,6 +62,8 @@ it('maps user messages with images from base64', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
@@ -81,6 +85,8 @@ it('maps user messages with images from url', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))
         ->toBe('image_url');
     expect(data_get($mappedMessage, '0.content.1.image_url.url'))
@@ -99,6 +105,8 @@ it('maps user messages with audio input', function (): void {
 
     $mappedMessage = $messageMap();
 
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
+
     expect(data_get($mappedMessage, '0.content.1.type'))->toBe('input_audio');
     expect(data_get($mappedMessage, '0.content.1.input_audio.format'))->toBe('wav');
     expect(data_get($mappedMessage, '0.content.1.input_audio.data'))->toBe(base64_encode('audio-content'));
@@ -115,6 +123,8 @@ it('maps user messages with video input', function (): void {
     );
 
     $mappedMessage = $messageMap();
+
+    expect(data_get($mappedMessage, '0.content'))->toHaveCount(2);
 
     expect(data_get($mappedMessage, '0.content.1.type'))->toBe('input_video');
     expect(data_get($mappedMessage, '0.content.1.input_video.format'))->toBe('mp4');


### PR DESCRIPTION
When using Gemini with input modalities, the image gets attached 3 times. This is due to images being handled as video and audio too (see fix).

I've added the same assertions I did for Gemini to all other MessageMap tests, so that a similar issue in the future would get detected by the test suite.

**Reproduction:**

```
$response = Prism::text()
    ->using(Provider::Gemini, 'gemini-2.5-flash')
    ->withPrompt(
        "What's in this image?",
        [Image::fromUrl(url: 'https://example.com/diagram.png')]
    )
    ->asText();
```

```
{
    "contents": [
        {
            "role": "user",
            "parts": [
                {
                    "text": "What's in this image?"
                },
                {
                    "inline_data": {
                        "mime_type": "image\/jpeg",
                        "data": "[TRUNCATED_BASE64_DATA]"
                    }
                },
                {
                    "inline_data": {
                        "mime_type": "image\/jpeg",
                        "data": "[TRUNCATED_BASE64_DATA]"
                    }
                },
                {
                    "inline_data": {
                        "mime_type": "image\/jpeg",
                        "data": "[TRUNCATED_BASE64_DATA]"
                    }
                }
            ]
        }
    ]
}
```