### PR TITLE
(fix) gemini support for raw schemas

### DIFF
--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -8,6 +8,7 @@ use Prism\Prism\Schema\ArraySchema;
 use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\NumberSchema;
 use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\RawSchema;
 
 class SchemaMap
 {
@@ -24,6 +25,10 @@ class SchemaMap
 
         // Remove unsupported fields
         unset($schemaArray['additionalProperties'], $schemaArray['description'], $schemaArray['name']);
+
+        if ($this->schema instanceof RawSchema) {
+            return $schemaArray;
+        }
 
         // AnyOfSchema: recursively process nested schemas to remove unsupported fields
         if ($this->schema instanceof AnyOfSchema) {

--- a/tests/Providers/Gemini/SchemaMapTest.php
+++ b/tests/Providers/Gemini/SchemaMapTest.php
@@ -8,6 +8,7 @@ use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\EnumSchema;
 use Prism\Prism\Schema\NumberSchema;
 use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\RawSchema;
 use Prism\Prism\Schema\StringSchema;
 
 it('maps array schema correctly', function (): void {
@@ -110,5 +111,22 @@ it('maps object schema correctly', function (): void {
         ],
         'required' => ['testName'],
         'nullable' => true,
+    ]);
+});
+
+it('does not map a raw schema', function (): void {
+    $map = (new SchemaMap(new RawSchema(
+        'schema',
+        [
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+        ]
+    )))->toArray();
+
+    expect($map)->toBe([
+        'type' => 'array',
+        'items' => [
+            'type' => 'string',
+        ],
     ]);
 });


### PR DESCRIPTION
When using a Raw schema with Gemini it didn't respect the schema but would try to map it.

```
[
            'type' => 'array',
            'items' => ['type' => 'string'],
        ]
```

would be transformed into

```
'type' => 'string',
      'items' => [
          'type' => 'string',
],
```