### PR TITLE
(feat) add support for gemini 3 pro with tool calls

### DIFF
--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Gemini\Maps;
 
 use Exception;
+use Illuminate\Support\Arr;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Media\Audio;
@@ -127,14 +128,15 @@ class MessageMap
         }
 
         foreach ($message->toolCalls as $toolCall) {
-            $parts[] = [
+            $parts[] = Arr::whereNotNull([
                 'functionCall' => [
                     'name' => $toolCall->name,
                     ...count($toolCall->arguments()) ? [
                         'args' => $toolCall->arguments(),
                     ] : [],
                 ],
-            ];
+                'thoughtSignature' => $toolCall->reasoningId,
+            ]);
         }
 
         $this->contents['contents'][] = [

--- a/src/Providers/Gemini/Maps/ToolCallMap.php
+++ b/src/Providers/Gemini/Maps/ToolCallMap.php
@@ -22,6 +22,7 @@ class ToolCallMap
             id: data_get($toolCall, 'functionCall.name'),
             name: data_get($toolCall, 'functionCall.name'),
             arguments: data_get($toolCall, 'functionCall.args'),
+            reasoningId: data_get($toolCall, 'thoughtSignature'),
         ), $toolCalls);
     }
 }

--- a/tests/Providers/Gemini/MessageMapTest.php
+++ b/tests/Providers/Gemini/MessageMapTest.php
@@ -150,7 +150,7 @@ it('maps assistant message with tool calls', function (): void {
                     'search',
                     [
                         'query' => 'Laravel collection methods',
-                    ]
+                    ],
                 ),
             ]),
         ],
@@ -169,6 +169,42 @@ it('maps assistant message with tool calls', function (): void {
                             'query' => 'Laravel collection methods',
                         ],
                     ],
+                ],
+            ],
+        ]],
+    ]);
+});
+
+it('maps assistant message with tool calls with reasoning id', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('I am Nyx', [
+                new ToolCall(
+                    'tool_1234',
+                    'search',
+                    [
+                        'query' => 'Laravel collection methods',
+                    ],
+                    reasoningId: 'reasoning_1234'
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([
+        'contents' => [[
+            'role' => 'model',
+            'parts' => [
+                ['text' => 'I am Nyx'],
+                [
+                    'functionCall' => [
+                        'name' => 'search',
+                        'args' => [
+                            'query' => 'Laravel collection methods',
+                        ],
+                    ],
+                    'thoughtSignature' => 'reasoning_1234',
                 ],
             ],
         ]],


### PR DESCRIPTION
When using Prism with gemini 3 pro and tool calls, the following error happens:

```
HTTP request returned status code 400:
{
"error": {
"code": 400,
"message": "Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance. Additional data, function call `default_api:spider` , position 2. Please refer to https://ai.google.dev/gemini-api/docs/thought-signatures for more details.",
"status": "INVALID_ARGUMENT"
}
}
```

This PR adds the `thoughtSignature` to the functionCall.