### PR TITLE
Fix: Unhandled `null` value in OpenRouter's response

### DIFF
--- a/src/Providers/OpenRouter/Concerns/MapsFinishReason.php
+++ b/src/Providers/OpenRouter/Concerns/MapsFinishReason.php
@@ -14,6 +14,8 @@ trait MapsFinishReason
      */
     protected function mapFinishReason(array $data): FinishReason
     {
-        return FinishReasonMap::map(data_get($data, 'choices.0.finish_reason', ''));
+        $finishReason = data_get($data, 'choices.0.finish_reason', '');
+
+        return FinishReasonMap::map($finishReason ?? '');
     }
 }


### PR DESCRIPTION
Fix: Unchecked `null` on response data (`choices.0.finish_reason`).

When using `google/gemma-3-27b-it:free`, the returned response does not have `choices.0.finish_reason` attribute causing an exception instead of rerturning a default `''` string.

Solution: a simple `null` check is added to handle such situation.

```php
/**
 * @param  array<string, mixed>  $data
 */
protected function mapFinishReason(array $data): FinishReason
{
    $finishReason = data_get($data, 'choices.0.finish_reason', '');

    return FinishReasonMap::map($finishReason ?? '');
}
```