### PR TITLE
Fix: Add output-buffer existence check before calling ob_flush()

### DIFF
--- a/src/Http/Controllers/PrismChatController.php
+++ b/src/Http/Controllers/PrismChatController.php
@@ -67,12 +67,16 @@ class PrismChatController
                 ];
 
                 echo 'data: '.json_encode($data)."\n\n";
-                ob_flush();
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
                 flush();
             }
 
             echo "data: [DONE]\n";
-            ob_flush();
+            if (ob_get_level() > 0) {
+                ob_flush();
+            }
             flush();
         }, 200, [
             'Content-Type' => 'text/event-stream',

--- a/src/Streaming/Adapters/DataProtocolAdapter.php
+++ b/src/Streaming/Adapters/DataProtocolAdapter.php
@@ -35,7 +35,9 @@ class DataProtocolAdapter
 
                 echo "data: {$data}\n\n";
 
-                ob_flush();
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
                 flush();
             }
 

--- a/src/Streaming/Adapters/SSEAdapter.php
+++ b/src/Streaming/Adapters/SSEAdapter.php
@@ -22,7 +22,9 @@ class SSEAdapter
                     json_encode($event->toArray()),
                 ]);
 
-                ob_flush();
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
                 flush();
             }
         }, 200, [

--- a/tests/Providers/OpenAI/StreamTest.php
+++ b/tests/Providers/OpenAI/StreamTest.php
@@ -434,7 +434,9 @@ it('can accept falsy parameters', function (): void {
         ->asStream();
 
     foreach ($response as $chunk) {
-        ob_flush();
+        if (ob_get_level() > 0) {
+            ob_flush();
+        }
         flush();
     }
 })->throwsNoExceptions();


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

This PR addresses and fixes the error reported in #760  by ensuring ob_flush() is only called when an output buffer is actually active.
