### PR TITLE
fix: gemini tool call fails if thought is included

### DIFF
--- a/src/Providers/Gemini/Maps/ToolCallMap.php
+++ b/src/Providers/Gemini/Maps/ToolCallMap.php
@@ -18,7 +18,7 @@ class ToolCallMap
             return [];
         }
 
-        $filteredToolCalls = array_filter($toolCalls, fn(array $item): bool => isset($item['functionCall']));
+        $filteredToolCalls = array_filter($toolCalls, fn (array $item): bool => isset($item['functionCall']));
 
         return array_map(fn (array $toolCall): ToolCall => new ToolCall(
             id: data_get($toolCall, 'functionCall.name'),


### PR DESCRIPTION
Gemini tool call fails if you set thinking budget greater than 0, this set the inlclude thoughts to be true, now when prism what to process the tool call and create a tool call map some of the array items are not of function call but of text that has the thoughts of the model.

Fix filter out all element that the key is not functionCall
