### PR TITLE
(feat) gemini: add support for new thinkingLevel

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -449,6 +449,22 @@ class Stream
             $tools = ['function_declarations' => ToolMap::map($request->tools())];
         }
 
+        $thinkingConfig = $providerOptions['thinkingConfig'] ?? null;
+
+        if (isset($providerOptions['thinkingBudget'])) {
+            $thinkingConfig = [
+                'thinkingBudget' => $providerOptions['thinkingBudget'],
+                'includeThoughts' => true,
+            ];
+        }
+
+        if (isset($providerOptions['thinkingLevel'])) {
+            $thinkingConfig = [
+                'thinkingLevel' => $providerOptions['thinkingLevel'],
+                'includeThoughts' => true,
+            ];
+        }
+
         return $this->client
             ->withOptions(['stream' => true])
             ->post(
@@ -460,10 +476,7 @@ class Stream
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
-                        'thinkingConfig' => Arr::whereNotNull([
-                            'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                            'includeThoughts' => true,
-                        ]) ?: null,
+                        'thinkingConfig' => $thinkingConfig,
                     ]) ?: null,
                     'tools' => $tools !== [] ? $tools : null,
                     'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -102,6 +102,20 @@ class Structured
             ];
         }
 
+        $thinkingConfig = $providerOptions['thinkingConfig'] ?? null;
+
+        if (isset($providerOptions['thinkingBudget'])) {
+            $thinkingConfig = [
+                'thinkingBudget' => $providerOptions['thinkingBudget'],
+            ];
+        }
+
+        if (isset($providerOptions['thinkingLevel'])) {
+            $thinkingConfig = [
+                'thinkingLevel' => $providerOptions['thinkingLevel'],
+            ];
+        }
+
         $response = $this->client->post(
             "{$request->model()}:generateContent",
             Arr::whereNotNull([
@@ -113,9 +127,7 @@ class Structured
                     'temperature' => $request->temperature(),
                     'topP' => $request->topP(),
                     'maxOutputTokens' => $request->maxTokens(),
-                    'thinkingConfig' => Arr::whereNotNull([
-                        'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                    ]) ?: null,
+                    'thinkingConfig' => $thinkingConfig,
                 ]),
                 'tools' => $tools !== [] ? $tools : null,
                 'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -74,14 +74,27 @@ class Text
     {
         $providerOptions = $request->providerOptions();
 
+        $thinkingConfig = $providerOptions['thinkingConfig'] ?? null;
+
+        if (isset($providerOptions['thinkingBudget'])) {
+            $thinkingConfig = [
+                'thinkingBudget' => $providerOptions['thinkingBudget'],
+                'includeThoughts' => true,
+            ];
+        }
+
+        if (isset($providerOptions['thinkingLevel'])) {
+            $thinkingConfig = [
+                'thinkingLevel' => $providerOptions['thinkingLevel'],
+                'includeThoughts' => true,
+            ];
+        }
+
         $generationConfig = Arr::whereNotNull([
             'temperature' => $request->temperature(),
             'topP' => $request->topP(),
             'maxOutputTokens' => $request->maxTokens(),
-            'thinkingConfig' => isset($providerOptions['thinkingBudget']) ? [
-                'thinkingBudget' => $providerOptions['thinkingBudget'],
-                'includeThoughts' => true,
-            ] : null,
+            'thinkingConfig' => $thinkingConfig,
         ]);
 
         if ($request->tools() !== [] && $request->providerTools() != []) {

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -553,4 +553,58 @@ describe('Thinking Mode for Gemini', function (): void {
         });
 
     });
+
+    it('can use thinking level with 3.0-pro', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-thinking-budget');
+
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-3.0-pro')
+            ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
+            ->withProviderOptions(['thinkingLevel' => 'low'])
+            ->asText();
+
+        expect($response->usage->thoughtTokens)->toBe(1209);
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['generationConfig'])
+                ->toHaveKey('thinkingConfig')
+                ->and($data['generationConfig']['thinkingConfig'])->toMatchArray([
+                    'thinkingLevel' => 'low',
+                ]);
+
+            return true;
+        });
+    });
+
+    it('configure pass a thinking config', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-thinking-budget');
+
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-3.0-pro')
+            ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
+            ->withProviderOptions([
+                'thinkingConfig' => [
+                    'thinkingLevel' => 'low',
+                    'includeThoughts' => false,
+                ],
+            ])
+            ->asText();
+
+        expect($response->usage->thoughtTokens)->toBe(1209);
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['generationConfig'])
+                ->toHaveKey('thinkingConfig')
+                ->and($data['generationConfig']['thinkingConfig'])->toMatchArray([
+                    'thinkingLevel' => 'low',
+                    'includeThoughts' => false,
+                ]);
+
+            return true;
+        });
+    });
 });


### PR DESCRIPTION
Gemini 3 pro introduced a new `thinkingLevel` config to replace the thinking budget: https://ai.google.dev/gemini-api/docs/thinking#thinking-levels

I've also added support for a complete `thinkingConfig` so we can also disable thought summaries, keeping the original `thinkingBudget` backwards compatible. 

`thinkingBudget` is also compatible with 3.0-pro, but they don't recommend using it.
