### PR TITLE
fix(gemini): fix multiple provider tools calls

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -431,14 +431,12 @@ class Stream
         $tools = [];
 
         if ($request->providerTools() !== []) {
-            $tools = [
-                Arr::mapWithKeys(
-                    $request->providerTools(),
-                    fn ($providerTool): array => [
-                        $providerTool->type => $providerTool->options !== [] ? $providerTool->options : (object) [],
-                    ]
-                ),
-            ];
+            $tools = array_map(
+                fn ($providerTool): array => [
+                    $providerTool->type => $providerTool->options !== [] ? $providerTool->options : (object) [],
+                ],
+                $request->providerTools()
+            );
         } elseif ($providerOptions['searchGrounding'] ?? false) {
             $tools = [
                 [

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -91,14 +91,12 @@ class Text
         $tools = [];
 
         if ($request->providerTools() !== []) {
-            $tools = [
-                Arr::mapWithKeys(
-                    $request->providerTools(),
-                    fn (ProviderTool $providerTool): array => [
-                        $providerTool->type => $providerTool->options !== [] ? $providerTool->options : (object) [],
-                    ]
-                ),
-            ];
+            $tools = array_map(
+                fn (ProviderTool $providerTool): array => [
+                    $providerTool->type => $providerTool->options !== [] ? $providerTool->options : (object) [],
+                ],
+                $request->providerTools()
+            );
         }
 
         if ($request->tools() !== []) {


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

When using multiple provider tools (e.g., google_search and url_context), the previous implementation incorrectly merged them into a single object:

```
  {
    "tools": [
      {
        "google_search": {},
        "url_context": {}
      }
    ]
  }

```
This caused the error: "tools[0].tool_type: one_of 'tool_type' has more than one field" because Gemini expects each tool to be a separate object:

```
  {
    "tools": [
      {"google_search": {}},
      {"url_context": {}}
    ]
  }

```
Changed from using Arr::mapWithKeys() wrapped in an array to using array_map() directly, which creates separate array elements for each provider tool as required by the [Gemini API specification](https://ai.google.dev/gemini-api/docs/url-context#rest_1).

Fixes both Text and Stream handlers.