### PR TITLE
Add thinkingLevel to Gemini Text Handler

### DIFF
--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -78,10 +78,11 @@ class Text
             'temperature' => $request->temperature(),
             'topP' => $request->topP(),
             'maxOutputTokens' => $request->maxTokens(),
-            'thinkingConfig' => isset($providerOptions['thinkingBudget']) ? [
-                'thinkingBudget' => $providerOptions['thinkingBudget'],
+            'thinkingConfig' => (isset($providerOptions['thinkingBudget']) || isset($providerOptions['thinkingLevel'])) ? Arr::whereNotNull([
+                'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+                'thinkingLevel' => $providerOptions['thinkingLevel'] ?? null,
                 'includeThoughts' => true,
-            ] : null,
+            ]) : null,
         ]);
 
         if ($request->tools() !== [] && $request->providerTools() != []) {


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Adds a `thinkingLevel` option to the `thinkingConfig` of Gemini.

## Breaking Changes
<!-- Put any breaking changes here. Remove this section if there are no breaking changes -->
