### PR TITLE
fix(gemini): add default empty string for modelVersion

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -221,7 +221,7 @@ class Structured
                 ),
                 meta: new Meta(
                     id: data_get($data, 'id', ''),
-                    model: data_get($data, 'modelVersion'),
+                    model: data_get($data, 'modelVersion', ''),
                 ),
                 messages: $request->messages(),
                 systemPrompts: $request->systemPrompts(),

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -180,7 +180,7 @@ class Text
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),
-                model: data_get($data, 'modelVersion'),
+                model: data_get($data, 'modelVersion', ''),
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Fixes TypeError in Gemini handlers when modelVersion is not present in API response (happens in like 2-3% of responses).
