### PR TITLE
feat(gemini): add urlContextMetadata support

### DIFF
--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -201,6 +201,7 @@ class Text
                 'citations' => CitationMapper::mapFromGemini(data_get($data, 'candidates.0', [])) ?: null,
                 'searchEntryPoint' => data_get($data, 'candidates.0.groundingMetadata.searchEntryPoint'),
                 'searchQueries' => data_get($data, 'candidates.0.groundingMetadata.webSearchQueries'),
+                'urlMetadata' => data_get($data, 'candidates.0.urlContextMetadata.urlMetadata'),
                 'thoughtSummaries' => $thoughtSummaries !== [] ? $thoughtSummaries : null,
             ]),
         ));


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
The change adds support for getting URL metadata from the Gemini provider response when using the [url_context](https://ai.google.dev/gemini-api/docs/url-context) tool with Gemini.