### PR TITLE
fix(gemini): only include includeThoughts when explicitly set

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -105,15 +105,17 @@ class Structured
         $thinkingConfig = $providerOptions['thinkingConfig'] ?? null;
 
         if (isset($providerOptions['thinkingBudget'])) {
-            $thinkingConfig = [
+            $thinkingConfig = Arr::whereNotNull([
                 'thinkingBudget' => $providerOptions['thinkingBudget'],
-            ];
+                'includeThoughts' => $providerOptions['includeThoughts'] ?? null,
+            ]);
         }
 
         if (isset($providerOptions['thinkingLevel'])) {
-            $thinkingConfig = [
+            $thinkingConfig = Arr::whereNotNull([
                 'thinkingLevel' => $providerOptions['thinkingLevel'],
-            ];
+                'includeThoughts' => $providerOptions['includeThoughts'] ?? null,
+            ]);
         }
 
         $response = $this->client->post(

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -77,17 +77,17 @@ class Text
         $thinkingConfig = $providerOptions['thinkingConfig'] ?? null;
 
         if (isset($providerOptions['thinkingBudget'])) {
-            $thinkingConfig = [
+            $thinkingConfig = Arr::whereNotNull([
                 'thinkingBudget' => $providerOptions['thinkingBudget'],
-                'includeThoughts' => true,
-            ];
+                'includeThoughts' => $providerOptions['includeThoughts'] ?? null,
+            ]);
         }
 
         if (isset($providerOptions['thinkingLevel'])) {
-            $thinkingConfig = [
+            $thinkingConfig = Arr::whereNotNull([
                 'thinkingLevel' => $providerOptions['thinkingLevel'],
-                'includeThoughts' => true,
-            ];
+                'includeThoughts' => $providerOptions['includeThoughts'] ?? null,
+            ]);
         }
 
         $generationConfig = Arr::whereNotNull([


### PR DESCRIPTION
## Description
After PR #764 setting `thinkingBudget` or `thinkingLevel` would automatically set `includeThoughts` to true. This change makes `includeThoughts` independent from thinking budget/level settings - it will only be included in the API request when explicitly set by the user.