### PR TITLE
feat(anthropic): implement cache TTL support for messages and tools

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -12,7 +12,7 @@
 ```
 ## Prompt caching
 
-Anthropic's prompt caching feature allows you to drastically reduce latency and your API bill when repeatedly re-using blocks of content within five minutes of each other.
+Anthropic's prompt caching feature allows you to drastically reduce latency and your API bill when repeatedly re-using blocks of content within five minutes or one hour of each other, depending on the Anthropic compatible TTL option you provide.
 
 We support Anthropic prompt caching on:
 
@@ -34,7 +34,7 @@ Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
     ->withSystemPrompt(
         (new SystemMessage('I am a long re-usable system message.'))
-            ->withProviderOptions(['cacheType' => 'ephemeral'])
+            ->withProviderOptions(['cacheType' => 'ephemeral', 'cacheTtl' => '1h'])
     )
     ->withMessages([
         (new UserMessage('I am a long re-usable user message.'))
@@ -63,6 +63,7 @@ use Prism\Prism\ValueObjects\Media\Document;
 - Tools use `withTools()`
 - All message types support caching via `withProviderOptions(['cacheType' => 'ephemeral'])`
 - You cannot use `withPrompt()` for caching as it doesn't allow adding provider options to individual messages
+- Anthropic supports two TTL options: `5m` (default) or `1h`. You can leave the `cacheTtl` unset and Anthropic will use the default TTL of `5m`.
 
 ### Tool result caching
 

--- a/src/Providers/Anthropic/Concerns/NormalizesCacheControl.php
+++ b/src/Providers/Anthropic/Concerns/NormalizesCacheControl.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Anthropic\Concerns;
+
+use BackedEnum;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+trait NormalizesCacheControl
+{
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected static function normalizeCacheControl(AssistantMessage|SystemMessage|Tool|ToolResultMessage|UserMessage $message): ?array
+    {
+        $cacheType = $message->providerOptions('cacheType');
+        $cacheTtl = $message->providerOptions('cacheTtl');
+
+        if (! $cacheType) {
+            return null;
+        }
+
+        $value = $cacheType instanceof BackedEnum ? $cacheType->value : $cacheType;
+
+        return $cacheTtl ? ['type' => $value, 'ttl' => $cacheTtl] : ['type' => $value];
+    }
+}

--- a/src/Providers/Anthropic/Maps/ToolMap.php
+++ b/src/Providers/Anthropic/Maps/ToolMap.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Anthropic\Maps;
 
+use Prism\Prism\Providers\Anthropic\Concerns\NormalizesCacheControl;
 use Prism\Prism\Tool as PrismTool;
-use UnitEnum;
 
 class ToolMap
 {
+    use NormalizesCacheControl;
+
     /**
      * @param  PrismTool[]  $tools
      * @return array<string, mixed>
@@ -16,7 +18,6 @@ class ToolMap
     public static function map(array $tools): array
     {
         return array_map(function (PrismTool $tool): array {
-            $cacheType = $tool->providerOptions('cacheType');
             $properties = $tool->parametersAsArray();
 
             return array_filter([
@@ -27,7 +28,7 @@ class ToolMap
                     'properties' => $properties === [] ? new \stdClass : $properties,
                     'required' => $tool->requiredParameters(),
                 ],
-                'cache_control' => $cacheType ? ['type' => $cacheType instanceof UnitEnum ? $cacheType->name : $cacheType] : null,
+                'cache_control' => self::normalizeCacheControl($tool),
                 'strict' => (bool) $tool->providerOptions('strict'),
             ]);
         }, $tools);

--- a/tests/Providers/Anthropic/ToolMapTest.php
+++ b/tests/Providers/Anthropic/ToolMapTest.php
@@ -37,7 +37,7 @@ it('sets the cache typeif cacheType providerOptions is set on tool', function (m
         ->for('Searching the web')
         ->withStringParameter('query', 'the detailed search query')
         ->using(fn (): string => '[Search results]')
-        ->withProviderOptions(['cacheType' => $cacheType]);
+        ->withProviderOptions(['cacheType' => $cacheType, 'cacheTtl' => '1h']);
 
     expect(ToolMap::map([$tool]))->toBe([[
         'name' => 'search',
@@ -52,7 +52,7 @@ it('sets the cache typeif cacheType providerOptions is set on tool', function (m
             ],
             'required' => ['query'],
         ],
-        'cache_control' => ['type' => 'ephemeral'],
+        'cache_control' => ['type' => 'ephemeral', 'ttl' => '1h'],
     ]]);
 })->with([
     'ephemeral',


### PR DESCRIPTION
## Description
This PR implements user configurable Anthropic cache TTL options in `withProviderOptions()` including `5m` (default) and `1h`. Tests and and documentation also provided.