### PR TITLE
feat(openai): include service tier in response meta

### DIFF
--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -146,6 +146,7 @@ class Structured
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
                 rateLimits: $this->processRateLimits($clientResponse),
+                serviceTier: data_get($data, 'service_tier'),
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -174,6 +174,7 @@ class Text
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
                 rateLimits: $this->processRateLimits($clientResponse),
+                serviceTier: data_get($data, 'service_tier'),
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),

--- a/src/ValueObjects/Meta.php
+++ b/src/ValueObjects/Meta.php
@@ -13,5 +13,6 @@ readonly class Meta
         public string $id,
         public string $model,
         public array $rateLimits = [],
+        public ?string $serviceTier = null,
     ) {}
 }


### PR DESCRIPTION
This updates the `Meta` object to include `serviceTier` for OpenAI requests.

This resolves #778 