### PR TITLE
Support has schema type contract on gemini provider

### DIFF
--- a/src/Contracts/HasSchemaType.php
+++ b/src/Contracts/HasSchemaType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Contracts;
+
+interface HasSchemaType
+{
+    public function schemaType(): string;
+}

--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -2,6 +2,7 @@
 
 namespace Prism\Prism\Providers\Gemini\Maps;
 
+use Prism\Prism\Contracts\HasSchemaType;
 use Prism\Prism\Contracts\Schema;
 use Prism\Prism\Schema\AnyOfSchema;
 use Prism\Prism\Schema\ArraySchema;
@@ -87,6 +88,9 @@ class SchemaMap
         }
         if ($this->schema instanceof ObjectSchema) {
             return 'object';
+        }
+        if ($this->schema instanceof HasSchemaType) {
+            return $this->schema->schemaType();
         }
 
         return 'string';


### PR DESCRIPTION
This let's custom schema which implement the Schema contract to also provide their own Schema type to the Gemini provider. Otherwise it falls back to `string`.