### PR TITLE
fix: pass thinking along tool call

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -487,7 +487,7 @@ class Stream
         if ($toolResults !== []) {
             $request->addMessage(new AssistantMessage(
                 content: $this->state->currentText(),
-                additionalContent: !empty($this->state->currentThinking()) ? [
+                additionalContent: ! empty($this->state->currentThinking()) ? [
                     'thinking' => $this->state->currentThinking(),
                     'thinking_signature' => $this->state->currentThinkingSignature(),
                 ] : [],


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

I noticed that it was not possible to use thinking (i.e. `->withProviderOptions(['thinking' => ['enabled' => true]])`) in combination with tool calls because the following error occurs:
```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"me
    ssages.1.content.0.type: Expected `thinking` or `redacted_thinking`, but found
    `text`. When `thinking` is enabled, a final `assistant` message must start with a
    thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks).
     We recommend you include thinking blocks from previous turns. To avoid this
    requirement, disable `thinking`. Please consult our documentation at
    https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking"}}
```

It seems that the thinking must be part of the subsequent request so it works correctly.

## Breaking Changes
<!-- Put any breaking changes here. Remove this section if there are no breaking changes -->
