### PR TITLE
feat(openai): add search queries to additional content

### DIFF
--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -187,6 +187,13 @@ class Text
             systemPrompts: $request->systemPrompts(),
             additionalContent: Arr::whereNotNull([
                 'citations' => $this->citations,
+                'searchQueries' => collect($output)
+                    ->filter(fn (array $item): bool => ($item['type'] ?? null) === 'web_search_call')
+                    ->map(fn (array $item): ?string => data_get($item, 'action.query'))
+                    ->filter()
+                    ->unique()
+                    ->values()
+                    ->toArray(),
                 'reasoningSummaries' => collect($output)
                     ->filter(fn (array $output): bool => $output['type'] === 'reasoning')
                     ->flatMap(fn (array $output): array => Arr::pluck($output['summary'] ?? [], 'text'))

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -605,6 +605,9 @@ describe('provider tool results', function (): void {
         expect($providerTool->data)->toHaveKey('action');
         expect($providerTool->data['action']['type'])->toBe('search');
         expect($providerTool->data['action']['query'])->toContain('London weather');
+
+        expect($response->steps[0]->additionalContent)->toHaveKey('searchQueries');
+        expect($response->steps[0]->additionalContent['searchQueries'])->toBe(['London weather forecast today']);
     });
 
     it('captures code interpreter provider tool in providerToolCalls', function (): void {


### PR DESCRIPTION
## Description
This pull request adds the handling and testing of search queries extracted from OpenAI tool outputs and ensuring they are correctly included in the response's additional content.