### PR TITLE
Allow `macroable` on base Prism class

### DIFF
--- a/src/Prism.php
+++ b/src/Prism.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prism\Prism;
 
+use Illuminate\Support\Traits\Macroable;
 use Prism\Prism\Audio\PendingRequest as PendingAudioRequest;
 use Prism\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
 use Prism\Prism\Images\PendingRequest as PendingImageRequest;
@@ -13,6 +14,8 @@ use Prism\Prism\Text\PendingRequest as PendingTextRequest;
 
 class Prism
 {
+    use Macroable;
+
     public function text(): PendingTextRequest
     {
         return new PendingTextRequest;


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Allow the base `Prism` class to be macroable, enabling developers to extend it with custom methods such as shared defaults or project-specific helpers.