### PR TITLE
fix: [ OpenRouter -> Stream ] Check if tool_calls is not empty instead of isset in hasToolCalls

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -256,7 +256,7 @@ class Stream
      */
     protected function hasToolCalls(array $data): bool
     {
-        return !empty($data['choices'][0]['delta']['tool_calls']);
+        return ! empty($data['choices'][0]['delta']['tool_calls']);
     }
 
     /**


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

### 🐛 Fix: Ignore empty `tool_calls` deltas to allow text streaming

#### Problem

Some models (e.g. **DeepSeek**) return streaming deltas that include an **empty `tool_calls` array** alongside regular `content`:

```json
{
  "delta": {
    "content": "Hello",
    "tool_calls": []
  }
}
```

The current streaming logic treats the presence of the `tool_calls` key as a signal to enter the tool-call handling block. This causes two issues:

* The `hasToolCalls()` check is triggered even when `tool_calls` is empty
* The parser enters the tool-call block and `continue`s early
* As a result, the `content` delta is never processed and no `TextDeltaEvent` is emitted

This breaks text streaming for models that include empty `tool_calls` by default.

#### Root Cause

`hasToolCalls()` only checks for the **existence** of the `tool_calls` key, not whether it actually contains any tool calls.

#### Solution

Update `hasToolCalls()` to return `true` **only when `tool_calls` is non-empty**:

```php
protected function hasToolCalls(array $data): bool
{
    return !empty($data['choices'][0]['delta']['tool_calls']);
}
```

This ensures:

* Empty `tool_calls: []` are ignored
* Normal text streaming continues as expected
* Tool-call handling is only triggered when actual tool calls are present

#### Result

* ✅ Fixes missing text output for DeepSeek and similar models
* ✅ No breaking changes for existing tool-call flows
