### PR TITLE
feat: Add an interface for the ability to process speech-to-text asynchronously

### DIFF
--- a/src/Audio/ProviderIdResponse.php
+++ b/src/Audio/ProviderIdResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Audio;
+
+use Prism\Prism\ValueObjects\Usage;
+
+readonly class ProviderIdResponse
+{
+    public function __construct(
+        public string|int $id,
+        public ?Usage $usage = null,
+        /** @var array<string,mixed> */
+        public array $additionalContent = []
+    ) {}
+}

--- a/src/Audio/SpeechToTextAsyncRequest.php
+++ b/src/Audio/SpeechToTextAsyncRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Audio;
+
+use Closure;
+use Prism\Prism\Concerns\ChecksSelf;
+use Prism\Prism\Concerns\HasProviderOptions;
+use Prism\Prism\Contracts\PrismRequest;
+
+class SpeechToTextAsyncRequest implements PrismRequest
+{
+    use ChecksSelf, HasProviderOptions;
+
+    /**
+     * @param  array<string, mixed>  $clientOptions
+     * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
+     * @param  array<string, mixed>  $providerOptions
+     */
+    public function __construct(
+        protected string $model,
+        protected string $providerKey,
+        protected string|int $input,
+        protected array $clientOptions,
+        protected array $clientRetry,
+        array $providerOptions = [],
+    ) {
+        $this->providerOptions = $providerOptions;
+    }
+
+    /**
+     * @return array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}
+     */
+    public function clientRetry(): array
+    {
+        return $this->clientRetry;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function clientOptions(): array
+    {
+        return $this->clientOptions;
+    }
+
+    public function input(): string|int
+    {
+        return $this->input;
+    }
+
+    public function model(): string
+    {
+        return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
+    }
+}

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -7,6 +7,8 @@ namespace Prism\Prism\Providers;
 use Generator;
 use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Audio\AudioResponse as TextToSpeechResponse;
+use Prism\Prism\Audio\ProviderIdResponse;
+use Prism\Prism\Audio\SpeechToTextAsyncRequest;
 use Prism\Prism\Audio\SpeechToTextRequest;
 use Prism\Prism\Audio\TextResponse as SpeechToTextResponse;
 use Prism\Prism\Audio\TextToSpeechRequest;
@@ -54,6 +56,16 @@ abstract class Provider
     public function speechToText(SpeechToTextRequest $request): SpeechToTextResponse
     {
         throw PrismException::unsupportedProviderAction('speechToText', class_basename($this));
+    }
+
+    public function speechToTextProviderId(SpeechToTextRequest $request): ProviderIdResponse
+    {
+        throw PrismException::unsupportedProviderAction('speechToTextProviderId', class_basename($this));
+    }
+
+    public function speechToTextAsync(SpeechToTextAsyncRequest $request): SpeechToTextResponse
+    {
+        throw PrismException::unsupportedProviderAction('speechToTextAsync', class_basename($this));
     }
 
     /**

--- a/tests/Audio/PendingRequestTest.php
+++ b/tests/Audio/PendingRequestTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Audio\PendingRequest;
+use Prism\Prism\Audio\ProviderIdResponse;
+use Prism\Prism\Audio\SpeechToTextAsyncRequest;
+use Prism\Prism\Audio\SpeechToTextRequest;
+use Prism\Prism\Providers\Provider as ProviderContract;
+use Prism\Prism\ValueObjects\Media\Audio;
+use Tests\TestDoubles\TestProvider;
+
+beforeEach(function (): void {
+    $this->pendingRequest = new PendingRequest;
+});
+
+test('it generates a provider id response for speech to text', function (): void {
+    resolve('prism-manager')->extend('test-provider', fn ($config): ProviderContract => new TestProvider);
+
+    $audio = Audio::fromUrl('https://example.com/audio.mp3', 'audio/mpeg');
+
+    $response = $this->pendingRequest
+        ->using('test-provider', 'test-model')
+        ->withInput($audio)
+        ->asTextProviderId();
+
+    $provider = $this->pendingRequest->provider();
+
+    expect($response)
+        ->toBeInstanceOf(ProviderIdResponse::class)
+        ->and($response->id)->toBe('provider-id')
+        ->and($provider->request)->toBeInstanceOf(SpeechToTextRequest::class)
+        ->and($provider->request->input())->toBe($audio);
+});
+
+test('it generates a response for async speech to text', function (): void {
+    resolve('prism-manager')->extend('test-provider', fn ($config): ProviderContract => new TestProvider);
+
+    $providerId = 'provider-id-123';
+
+    $response = $this->pendingRequest
+        ->using('test-provider', 'test-model')
+        ->withInput($providerId)
+        ->asTextAsync();
+
+    $provider = $this->pendingRequest->provider();
+
+    expect($response->text)->toBe('Async transcript')
+        ->and($provider->request)->toBeInstanceOf(SpeechToTextAsyncRequest::class)
+        ->and($provider->request->model())->toBe('test-model')
+        ->and($provider->request->input())->toBe($providerId);
+});

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Tests\TestDoubles;
 
 use Generator;
+use Prism\Prism\Audio\ProviderIdResponse;
+use Prism\Prism\Audio\SpeechToTextAsyncRequest;
+use Prism\Prism\Audio\SpeechToTextRequest;
+use Prism\Prism\Audio\TextResponse as AudioTextResponse;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
 use Prism\Prism\Enums\FinishReason;
@@ -24,7 +28,7 @@ use Prism\Prism\ValueObjects\Usage;
 
 class TestProvider extends Provider
 {
-    public StructuredRequest|TextRequest|EmbeddingRequest|ImageRequest $request;
+    public StructuredRequest|TextRequest|EmbeddingRequest|ImageRequest|SpeechToTextRequest|SpeechToTextAsyncRequest $request;
 
     /** @var array<string, mixed> */
     public array $clientOptions;
@@ -32,7 +36,7 @@ class TestProvider extends Provider
     /** @var array<mixed> */
     public array $clientRetry;
 
-    /** @var array<int, StructuredResponse|TextResponse|EmbeddingResponse|ImageResponse> */
+    /** @var array<int, StructuredResponse|TextResponse|EmbeddingResponse|ImageResponse|AudioTextResponse|ProviderIdResponse> */
     public array $responses = [];
 
     public $callCount = 0;
@@ -115,7 +119,27 @@ class TestProvider extends Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    public function withResponse(StructuredResponse|TextResponse $response): Provider
+    #[\Override]
+    public function speechToTextProviderId(SpeechToTextRequest $request): ProviderIdResponse
+    {
+        $this->callCount++;
+
+        $this->request = $request;
+
+        return $this->responses[$this->callCount - 1] ?? new ProviderIdResponse('provider-id');
+    }
+
+    #[\Override]
+    public function speechToTextAsync(SpeechToTextAsyncRequest $request): AudioTextResponse
+    {
+        $this->callCount++;
+
+        $this->request = $request;
+
+        return $this->responses[$this->callCount - 1] ?? new AudioTextResponse('Async transcript');
+    }
+
+    public function withResponse(StructuredResponse|TextResponse|EmbeddingResponse|ImageResponse|AudioTextResponse|ProviderIdResponse $response): Provider
     {
         $this->responses[] = $response;
 


### PR DESCRIPTION
## Description

This adds the ability to be able to send a request to a provider to create a transcript where the provider will give you an id and then send a webhook to you in the future when the job is done with that id. This is just supplying the interface that a provider can utilize in the future. 

We are hoping to utilize this functionality with a custom provider in the near future but I thought if there were other providers that have similar functionality, this could be useful.
