### PR TITLE
fix(anthropic): set default max tokens

### DIFF
--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -98,7 +98,7 @@ class Structured
                         : config('prism.anthropic.default_thinking_budget', 1024),
                 ]
                 : null,
-            'max_tokens' => $request->maxTokens(),
+            'max_tokens' => $request->maxTokens() ?? 64000,
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'mcp_servers' => $request->providerOptions('mcp_servers'),

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -90,7 +90,7 @@ class Text
                         : config('prism.anthropic.default_thinking_budget', 1024),
                 ]
                 : null,
-            'max_tokens' => $request->maxTokens(),
+            'max_tokens' => $request->maxTokens() ?? 64000,
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'tools' => static::buildTools($request) ?: null,

--- a/tests/Providers/Anthropic/AnthropicTextRequestTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextRequestTest.php
@@ -241,6 +241,26 @@ it('omits null values from payload', function (): void {
     });
 });
 
+it('always includes max_tokens in payload because it is required by anthropic', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-haiku-latest')
+        ->withMessages([new UserMessage('Test')])
+        ->asText();
+
+    Http::assertSent(function (Request $request): bool {
+        $payload = $request->data();
+
+        // Anthropic API requires max_tokens - it should always be present
+        expect($payload)->toHaveKey('max_tokens');
+        expect($payload['max_tokens'])->toBeInt();
+        expect($payload['max_tokens'])->toBeGreaterThan(0);
+
+        return true;
+    });
+});
+
 it('can send images from file', function (): void {
     FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-image');
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Anthropic requires max tokens to be set. The PR adds a default value (maximum max tokens for all, current, Anthropic models) for max tokens.