### PR TITLE
fix: Multiple stream start and end events in gemini and anthropic stream handlers

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -114,7 +114,7 @@ class Stream
     /**
      * @param  array<string, mixed>  $event
      */
-    protected function handleMessageStart(array $event): StreamStartEvent
+    protected function handleMessageStart(array $event): ?StreamStartEvent
     {
         $message = $event['message'] ?? [];
         $this->state->withMessageId($message['id'] ?? EventID::generate());
@@ -128,6 +128,13 @@ class Stream
                 cacheReadInputTokens: $usageData['cache_read_input_tokens'] ?? null
             ));
         }
+
+        // Only emit StreamStartEvent once per streaming session
+        if (! $this->state->shouldEmitStreamStart()) {
+            return null;
+        }
+
+        $this->state->markStreamStarted();
 
         return new StreamStartEvent(
             id: EventID::generate(),

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -121,6 +121,8 @@ class Stream
                 // Check if this is the final part of the tool calls
                 if ($this->mapFinishReason($data) === FinishReason::ToolCalls) {
                     yield from $this->handleToolCalls($request, $depth, $data);
+
+                    return;
                 }
 
                 continue;

--- a/tests/Providers/Anthropic/StreamTest.php
+++ b/tests/Providers/Anthropic/StreamTest.php
@@ -19,6 +19,7 @@ use Prism\Prism\Streaming\Events\CitationEvent;
 use Prism\Prism\Streaming\Events\ProviderToolEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
 use Prism\Prism\Streaming\Events\StreamEvent;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
 use Prism\Prism\Streaming\Events\ThinkingEvent;
@@ -163,6 +164,12 @@ describe('tools', function (): void {
         $lastEvent = end($events);
         expect($lastEvent)->toBeInstanceOf(StreamEndEvent::class);
         expect($lastEvent->finishReason)->toBe(FinishReason::Stop);
+
+        // Verify only one StreamStartEvent and one StreamEndEvent
+        $streamStartEvents = array_filter($events, fn (StreamEvent $event): bool => $event instanceof StreamStartEvent);
+        $streamEndEvents = array_filter($events, fn (StreamEvent $event): bool => $event instanceof StreamEndEvent);
+        expect($streamStartEvents)->toHaveCount(1);
+        expect($streamEndEvents)->toHaveCount(1);
 
         // Verify the HTTP request
         Http::assertSent(function (Request $request): bool {

--- a/tests/Providers/DeepSeek/StreamTest.php
+++ b/tests/Providers/DeepSeek/StreamTest.php
@@ -11,6 +11,7 @@ use Prism\Prism\Enums\Provider;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\ThinkingEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
@@ -114,6 +115,12 @@ it('can generate text using tools with streaming', function (): void {
     expect($events)->not->toBeEmpty();
     expect($toolCallEvents)->not->toBeEmpty();
     expect($toolResultEvents)->not->toBeEmpty();
+
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 
     // Verify the HTTP request
     Http::assertSent(function (Request $request): bool {

--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -268,9 +268,15 @@ it('yields ToolCall events before ToolResult events', function (): void {
 
     $toolCallEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof ToolCallEvent);
     $toolResultEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof ToolResultEvent);
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
 
     expect($toolCallEvents)->not->toBeEmpty();
     expect($toolResultEvents)->not->toBeEmpty();
+
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 
     $firstToolCallEvent = array_values($toolCallEvents)[0];
     expect($firstToolCallEvent->toolCall)->not->toBeNull();

--- a/tests/Providers/Groq/StreamTest.php
+++ b/tests/Providers/Groq/StreamTest.php
@@ -12,6 +12,7 @@ use Prism\Prism\Exceptions\PrismStreamDecodeException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
 use Prism\Prism\Streaming\Events\ToolResultEvent;
@@ -111,6 +112,12 @@ it('can generate text using tools with streaming', function (): void {
     expect($text)->not->toBeEmpty();
     expect($toolCallEvents)->not->toBeEmpty();
     expect($toolResultEvents)->not->toBeEmpty();
+
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 });
 
 it('handles maximum tool call depth exceeded', function (): void {

--- a/tests/Providers/Mistral/StreamTest.php
+++ b/tests/Providers/Mistral/StreamTest.php
@@ -12,6 +12,7 @@ use Prism\Prism\Exceptions\PrismStreamDecodeException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
 use Prism\Prism\Streaming\Events\ToolResultEvent;
@@ -110,6 +111,12 @@ it('can generate text using tools with streaming', function (): void {
     expect($events)->not->toBeEmpty();
     expect($toolCallEvents)->not->toBeEmpty();
     expect($toolResultEvents)->not->toBeEmpty();
+
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 });
 
 it('handles maximum tool call depth exceeded', function (): void {

--- a/tests/Providers/Ollama/StreamTest.php
+++ b/tests/Providers/Ollama/StreamTest.php
@@ -115,6 +115,12 @@ it('can generate text using tools with streaming', function (): void {
 
     // For the basic tools test, validate completion state
     expect($finishReasonFound)->toBeTrue();
+
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 });
 
 it('throws a PrismRateLimitedException with a 429 response code', function (): void {

--- a/tests/Providers/OpenAI/StreamTest.php
+++ b/tests/Providers/OpenAI/StreamTest.php
@@ -116,6 +116,12 @@ it('can generate text using tools with streaming', function (): void {
     expect($toolResults)->toHaveCount(2);
     expect($providerToolEvents)->toBeEmpty();
 
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
+
     // Verify the HTTP request
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);

--- a/tests/Providers/OpenRouter/StreamTest.php
+++ b/tests/Providers/OpenRouter/StreamTest.php
@@ -187,9 +187,11 @@ it('can stream text with tool calls', function (): void {
     // Verify text from first response
     expect($text)->toContain("I'll help you get the weather for you.");
 
-    // Check for StreamEndEvent with usage
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $e): bool => $e instanceof StreamStartEvent);
     $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $e): bool => $e instanceof StreamEndEvent);
-    expect($streamEndEvents)->not->toBeEmpty();
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
 
     $lastStreamEnd = array_values($streamEndEvents)[array_key_last(array_values($streamEndEvents))];
     expect($lastStreamEnd->usage)->not->toBeNull();

--- a/tests/Providers/XAI/StreamTest.php
+++ b/tests/Providers/XAI/StreamTest.php
@@ -113,6 +113,12 @@ it('can generate text using tools with streaming', function (): void {
         ->and($toolCallEvents)->toHaveCount(2)
         ->and($toolResultEvents)->toHaveCount(2);
 
+    // Verify only one StreamStartEvent and one StreamEndEvent
+    $streamStartEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamStartEvent);
+    $streamEndEvents = array_filter($events, fn (\Prism\Prism\Streaming\Events\StreamEvent $event): bool => $event instanceof StreamEndEvent);
+    expect($streamStartEvents)->toHaveCount(1);
+    expect($streamEndEvents)->toHaveCount(1);
+
     // Verify the HTTP request
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);


### PR DESCRIPTION
## Description

Fixes providers emitting duplicate stream events during multi-turn tool conversations. While PR #815 addressed this issue for most providers, two issues remained:

1. **Anthropic**: `handleMessageStart` was unconditionally returning a `StreamStartEvent` on each API call, resulting in multiple start events during tool call loops
2. **Gemini**: After handling tool calls recursively, execution would fall through and emit an additional `StreamEndEvent`

**Changes:**

* Modified `handleMessageStart()` in Anthropic Stream handler to check `shouldEmitStreamStart()` before emitting and call `markStreamStarted()` to track state
* Added early `return` in Gemini Stream handler after `handleToolCalls()` to prevent falling through to emit duplicate `StreamEndEvent`
* Added test assertions across all 9 providers to verify exactly one `StreamStartEvent` and one `StreamEndEvent` in stream-with-tools tests

**Before:**

```
StreamStartEvent (turn 1)
ToolCallEvent
ToolResultEvent
StreamStartEvent (turn 2)    <- Duplicate!
StreamEndEvent (turn 2)      <- Premature!
StreamStartEvent (turn 3)    <- Duplicate!
StreamEndEvent (turn 3)
```

**After:**

```
StreamStartEvent (once)
ToolCallEvent
ToolResultEvent
StreamEndEvent (once at true end)
```

## Related

Follow-up to #815 - ensures all providers follow the same streaming event contract.
