### PR TITLE
feat(openrouter): Include raw API response context in structured decoding exceptions.

### DIFF
--- a/tests/Fixtures/openrouter/structured-empty-content-1.json
+++ b/tests/Fixtures/openrouter/structured-empty-content-1.json
@@ -1,0 +1,17 @@
+{
+    "id": "gen-structured-empty",
+    "model": "anthropic/claude-3.5-sonnet",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": null
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 100,
+        "completion_tokens": 0
+    }
+}

--- a/tests/Providers/OpenRouter/StructuredTest.php
+++ b/tests/Providers/OpenRouter/StructuredTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismStructuredDecodingException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\ObjectSchema;
@@ -100,4 +101,54 @@ it('forwards provider options for structured requests', function (): void {
             && $payload['user'] === 'structured-user-21'
             && $payload['verbosity'] === 'medium';
     });
+});
+
+it('throws enriched exception when content is empty', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openrouter/structured-empty-content');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('data', 'Some data'),
+        ],
+        ['data']
+    );
+
+    expect(fn () => Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::OpenRouter, 'anthropic/claude-3.5-sonnet')
+        ->withPrompt('Give me some data')
+        ->asStructured()
+    )->toThrow(PrismStructuredDecodingException::class);
+});
+
+it('includes raw response context in decoding exception', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openrouter/structured-empty-content');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('data', 'Some data'),
+        ],
+        ['data']
+    );
+
+    try {
+        Prism::structured()
+            ->withSchema($schema)
+            ->using(Provider::OpenRouter, 'anthropic/claude-3.5-sonnet')
+            ->withPrompt('Give me some data')
+            ->asStructured();
+
+        $this->fail('Expected PrismStructuredDecodingException to be thrown');
+    } catch (PrismStructuredDecodingException $e) {
+        expect($e->getMessage())
+            ->toContain('Structured object could not be decoded')
+            ->toContain('Model: anthropic/claude-3.5-sonnet')
+            ->toContain('Finish reason: stop')
+            ->toContain('Raw choices:')
+            ->toContain('"content": null');
+    }
 });


### PR DESCRIPTION
When structured decoding fails, the exception message was unhelpful; it would show just "Received: " with nothing after it.

By catching the exception in the OpenRouter handler (where we still have access to the raw API response) and re-throwing with context, we can now see exactly what the provider returned.

### Before

> Structured object could not be decoded. Received: 

### After

> Structured object could not be decoded. Received: 
> Model: anthropic/claude-3.5-sonnet
> Finish reason: stop
> Raw choices: [{"message": {"content": null, "role": "assistant"}}]