### PR TITLE
fix(openrouter): Handle null id/model in API responses.

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -99,8 +99,8 @@ class Structured
                 data_get($data, 'usage.completion_tokens'),
             ),
             meta: new Meta(
-                id: data_get($data, 'id'),
-                model: data_get($data, 'model'),
+                id: data_get($data, 'id', ''),
+                model: data_get($data, 'model', $request->model()),
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -129,8 +129,8 @@ class Text
                 data_get($data, 'usage.completion_tokens'),
             ),
             meta: new Meta(
-                id: data_get($data, 'id'),
-                model: data_get($data, 'model'),
+                id: data_get($data, 'id', ''),
+                model: data_get($data, 'model', $request->model()),
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),

--- a/tests/Fixtures/openrouter/generate-text-with-missing-meta-1.json
+++ b/tests/Fixtures/openrouter/generate-text-with-missing-meta-1.json
@@ -1,0 +1,1 @@
+{"object":"chat.completion","created":1737243487,"choices":[{"index":0,"message":{"role":"assistant","content":"Hello! I'm an AI assistant powered by OpenRouter. How can I help you today?"},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":20,"total_tokens":27}}

--- a/tests/Fixtures/openrouter/structured-with-missing-meta-1.json
+++ b/tests/Fixtures/openrouter/structured-with-missing-meta-1.json
@@ -1,0 +1,1 @@
+{"object":"chat.completion","created":1737243487,"choices":[{"index":0,"message":{"role":"assistant","content":"{\"weather\":\"75º\",\"game_time\":\"3pm\",\"coat_required\":false}"},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":187,"completion_tokens":26,"total_tokens":213}}

--- a/tests/Providers/OpenRouter/TextTest.php
+++ b/tests/Providers/OpenRouter/TextTest.php
@@ -42,6 +42,21 @@ it('can generate text with a prompt', function (): void {
     expect($response->finishReason)->toBe(FinishReason::Stop);
 });
 
+it('handles responses with missing id and model fields', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openrouter/generate-text-with-missing-meta');
+
+    $response = Prism::text()
+        ->using(Provider::OpenRouter, 'openai/gpt-4-turbo')
+        ->withPrompt('Who are you?')
+        ->generate();
+
+    expect($response)->toBeInstanceOf(TextResponse::class);
+    expect($response->meta->id)->toBe('');
+    expect($response->meta->model)->toBe('openai/gpt-4-turbo');
+    expect($response->text)->toContain("Hello! I'm an AI assistant");
+    expect($response->finishReason)->toBe(FinishReason::Stop);
+});
+
 it('can generate text with a system prompt', function (): void {
     FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openrouter/generate-text-with-system-prompt');
 


### PR DESCRIPTION
OpenRouter can sometimes return responses without `id` or `model` fields in the response body. The handlers passed these values directly to `Meta::__construct()` without defaults, causing a TypeError when they were null.

### Before

```
TypeError: Prism\Prism\ValueObjects\Meta::__construct(): Argument #1 ($id) must be of type string, null given
```

### After

The response is handled, with `id` defaulting to an empty string and `model` falling back to the requested model from the original request.
