### PR TITLE
fix(openrouter): Extract usage from separate streaming chunk

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -222,7 +222,7 @@ class Stream
             // Extract usage from any chunk that has it
             // OpenRouter sends usage in a separate final chunk when stream_options.include_usage=true
             $usage = $this->extractUsage($data);
-            if ($usage instanceof \Prism\Prism\ValueObjects\Usage) {
+            if ($usage instanceof Usage) {
                 $this->state->addUsage($usage);
             }
         }


### PR DESCRIPTION
## Problem
When using OpenRouter with streaming and `stream_options.include_usage=true`, usage data (token counts) is not captured in the `StreamEndEvent`.

## Root Cause
OpenRouter sends usage data in a **separate final chunk** after the `finish_reason` chunk:

```
Chunk N-1: {"choices": [{"finish_reason": "stop", ...}]}           <- has finish_reason, NO usage
Chunk N:   {"choices": [{"finish_reason": null, ...}], "usage": {...}}  <- has usage, finish_reason is null
```

The current code only extracts usage when `finish_reason !== null`:

```php
if ($rawFinishReason !== null) {
    // ...
    $usage = $this->extractUsage($data);  // Only runs when finish_reason is set
}
```

Since the usage chunk has `finish_reason: null`, usage extraction is skipped.

## Solution
Move usage extraction outside the `finish_reason` check so it runs on every chunk. The `extractUsage()` method already safely returns `null` when there's no usage data.

## Testing
Tested with OpenRouter API (via vLLM endpoint):

**Before fix:**
```
StreamEndEvent: usage = null
```

**After fix:**
```
StreamEndEvent: usage = {promptTokens: 27, completionTokens: 2, ...}
```

## Impact
- No breaking changes
- Fixes streaming usage tracking for OpenRouter and any OpenAI-compatible API that sends usage in a separate chunk
- `extractUsage()` is idempotent and safe to call on every chunk