### PR TITLE
feat(gemini): Add media_resolution provider option for images, videos, documents, and audio.

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -492,7 +492,36 @@ For complete streaming documentation, see [Streaming Output](/core-concepts/stre
 
 ## Media Support
 
-Gemini has robust support for processing multimedia content:
+Gemini has robust support for processing multimedia content.
+
+### Media Resolution
+
+Gemini 3 models support the `mediaResolution` provider option to control the quality vs token usage tradeoff for images, videos, documents, and audio. Higher resolutions improve fine detail recognition but increase token consumption.
+
+| Resolution | Image Tokens | Video Tokens (per frame) | PDF Tokens |
+|------------|--------------|--------------------------|------------|
+| `MEDIA_RESOLUTION_LOW` | 280 | 70 | 280 + text |
+| `MEDIA_RESOLUTION_MEDIUM` | 560 | 70 | 560 + text |
+| `MEDIA_RESOLUTION_HIGH` | 1120 | 280 | 1120 + text |
+
+```php
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Media\Image;
+use Prism\Prism\Enums\Provider;
+
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-3-flash-preview')
+    ->withMessages([
+        new UserMessage(
+            'Read the fine print in this document.',
+            additionalContent: [
+                Image::fromLocalPath('/path/to/document.png')
+                    ->withProviderOptions(['mediaResolution' => 'MEDIA_RESOLUTION_HIGH']),
+            ],
+        ),
+    ])
+    ->asText();
+```
 
 ### Video Analysis
 

--- a/src/Providers/Gemini/Maps/AudioVideoMapper.php
+++ b/src/Providers/Gemini/Maps/AudioVideoMapper.php
@@ -22,19 +22,25 @@ class AudioVideoMapper extends ProviderMediaMapper
         $url = $this->media->url();
 
         if ($this->media->isUrl() && $url !== null && MediaUrlDetector::shouldPassAsFileUri($url)) {
-            return [
+            $payload = [
                 'file_data' => [
                     'file_uri' => $url,
                 ],
             ];
+        } else {
+            $payload = [
+                'inline_data' => [
+                    'mime_type' => $this->media->mimeType(),
+                    'data' => $this->media->base64(),
+                ],
+            ];
         }
 
-        return [
-            'inline_data' => [
-                'mime_type' => $this->media->mimeType(),
-                'data' => $this->media->base64(),
-            ],
-        ];
+        if ($mediaResolution = $this->media->providerOptions('mediaResolution')) {
+            $payload['media_resolution'] = ['level' => $mediaResolution];
+        }
+
+        return $payload;
     }
 
     protected function provider(): string|Provider

--- a/src/Providers/Gemini/Maps/DocumentMapper.php
+++ b/src/Providers/Gemini/Maps/DocumentMapper.php
@@ -22,19 +22,25 @@ class DocumentMapper extends ProviderMediaMapper
         $url = $this->media->url();
 
         if ($this->media->isUrl() && $url !== null && MediaUrlDetector::shouldPassAsFileUri($url)) {
-            return [
+            $payload = [
                 'file_data' => [
                     'file_uri' => $url,
                 ],
             ];
+        } else {
+            $payload = [
+                'inline_data' => [
+                    'mime_type' => $this->media->mimeType(),
+                    'data' => $this->media->base64(),
+                ],
+            ];
         }
 
-        return [
-            'inline_data' => [
-                'mime_type' => $this->media->mimeType(),
-                'data' => $this->media->base64(),
-            ],
-        ];
+        if ($mediaResolution = $this->media->providerOptions('mediaResolution')) {
+            $payload['media_resolution'] = ['level' => $mediaResolution];
+        }
+
+        return $payload;
     }
 
     protected function provider(): string|Provider

--- a/src/Providers/Gemini/Maps/ImageMapper.php
+++ b/src/Providers/Gemini/Maps/ImageMapper.php
@@ -22,19 +22,25 @@ class ImageMapper extends ProviderMediaMapper
         $url = $this->media->url();
 
         if ($this->media->isUrl() && $url !== null && MediaUrlDetector::shouldPassAsFileUri($url)) {
-            return [
+            $payload = [
                 'file_data' => [
                     'file_uri' => $url,
                 ],
             ];
+        } else {
+            $payload = [
+                'inline_data' => [
+                    'mime_type' => $this->media->mimeType(),
+                    'data' => $this->media->base64(),
+                ],
+            ];
         }
 
-        return [
-            'inline_data' => [
-                'mime_type' => $this->media->mimeType(),
-                'data' => $this->media->base64(),
-            ],
-        ];
+        if ($mediaResolution = $this->media->providerOptions('mediaResolution')) {
+            $payload['media_resolution'] = ['level' => $mediaResolution];
+        }
+
+        return $payload;
     }
 
     protected function provider(): string|Provider

--- a/tests/Providers/Gemini/MediaMapperTest.php
+++ b/tests/Providers/Gemini/MediaMapperTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Providers\Gemini\Maps\AudioVideoMapper;
+use Prism\Prism\Providers\Gemini\Maps\DocumentMapper;
+use Prism\Prism\Providers\Gemini\Maps\ImageMapper;
+use Prism\Prism\ValueObjects\Media\Audio;
+use Prism\Prism\ValueObjects\Media\Document;
+use Prism\Prism\ValueObjects\Media\Image;
+use Prism\Prism\ValueObjects\Media\Video;
+
+describe('ImageMapper', function (): void {
+    it('maps images from base64', function (): void {
+        $image = Image::fromBase64(base64_encode('image-content'), 'image/png');
+
+        $payload = (new ImageMapper($image))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'image/png',
+                'data' => base64_encode('image-content'),
+            ],
+        ]);
+    });
+
+    it('includes media_resolution when provider option is set', function (): void {
+        $image = Image::fromBase64(base64_encode('image-content'), 'image/png')
+            ->withProviderOptions(['mediaResolution' => 'MEDIA_RESOLUTION_HIGH']);
+
+        $payload = (new ImageMapper($image))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'image/png',
+                'data' => base64_encode('image-content'),
+            ],
+            'media_resolution' => [
+                'level' => 'MEDIA_RESOLUTION_HIGH',
+            ],
+        ]);
+    });
+
+    it('does not include media_resolution when provider option is not set', function (): void {
+        $image = Image::fromBase64(base64_encode('image-content'), 'image/png');
+
+        $payload = (new ImageMapper($image))->toPayload();
+
+        expect($payload)->not->toHaveKey('media_resolution');
+    });
+});
+
+describe('DocumentMapper', function (): void {
+    it('maps documents from base64', function (): void {
+        $document = Document::fromBase64(base64_encode('pdf-content'), 'application/pdf', 'test.pdf');
+
+        $payload = (new DocumentMapper($document))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'application/pdf',
+                'data' => base64_encode('pdf-content'),
+            ],
+        ]);
+    });
+
+    it('includes media_resolution when provider option is set', function (): void {
+        $document = Document::fromBase64(base64_encode('pdf-content'), 'application/pdf', 'test.pdf')
+            ->withProviderOptions(['mediaResolution' => 'MEDIA_RESOLUTION_MEDIUM']);
+
+        $payload = (new DocumentMapper($document))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'application/pdf',
+                'data' => base64_encode('pdf-content'),
+            ],
+            'media_resolution' => [
+                'level' => 'MEDIA_RESOLUTION_MEDIUM',
+            ],
+        ]);
+    });
+});
+
+describe('AudioVideoMapper', function (): void {
+    it('maps video from base64', function (): void {
+        $video = Video::fromBase64(base64_encode('video-content'), 'video/mp4');
+
+        $payload = (new AudioVideoMapper($video))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'video/mp4',
+                'data' => base64_encode('video-content'),
+            ],
+        ]);
+    });
+
+    it('maps audio from base64', function (): void {
+        $audio = Audio::fromBase64(base64_encode('audio-content'), 'audio/wav');
+
+        $payload = (new AudioVideoMapper($audio))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'audio/wav',
+                'data' => base64_encode('audio-content'),
+            ],
+        ]);
+    });
+
+    it('includes media_resolution when provider option is set', function (): void {
+        $video = Video::fromBase64(base64_encode('video-content'), 'video/mp4')
+            ->withProviderOptions(['mediaResolution' => 'MEDIA_RESOLUTION_LOW']);
+
+        $payload = (new AudioVideoMapper($video))->toPayload();
+
+        expect($payload)->toBe([
+            'inline_data' => [
+                'mime_type' => 'video/mp4',
+                'data' => base64_encode('video-content'),
+            ],
+            'media_resolution' => [
+                'level' => 'MEDIA_RESOLUTION_LOW',
+            ],
+        ]);
+    });
+});


### PR DESCRIPTION
Gemini 3 introduced the [`media_resolution` parameter](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/get-started-with-gemini-3#media-resolution) to control the quality vs token usage tradeoff for multimodal inputs. This PR adds support for setting it via `withProviderOptions()` on media objects.

Works on `Image`, `Document`, `Video`, and `Audio` objects. I've added documentation and tests.
