### PR TITLE
Fix: Handle PrismException during tool execution to allow LLM self-correction

### DIFF
--- a/src/Concerns/CallsTools.php
+++ b/src/Concerns/CallsTools.php
@@ -4,57 +4,111 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Concerns;
 
+use Generator;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Streaming\EventID;
+use Prism\Prism\Streaming\Events\ArtifactEvent;
+use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Tool;
 use Prism\Prism\ValueObjects\ToolCall;
 use Prism\Prism\ValueObjects\ToolOutput;
 use Prism\Prism\ValueObjects\ToolResult;
-use Throwable;
 
 trait CallsTools
 {
     /**
+     * Execute tools and return results (for non-streaming handlers).
+     *
      * @param  Tool[]  $tools
      * @param  ToolCall[]  $toolCalls
      * @return ToolResult[]
      */
     protected function callTools(array $tools, array $toolCalls): array
     {
-        return array_map(
-            function (ToolCall $toolCall) use ($tools): ToolResult {
+        $toolResults = [];
+
+        // Consume generator to execute all tools and collect results
+        foreach ($this->callToolsAndYieldEvents($tools, $toolCalls, EventID::generate(), $toolResults) as $event) {
+            // Events are discarded for non-streaming handlers
+        }
+
+        return $toolResults;
+    }
+
+    /**
+     * Generate tool execution events and collect results (for streaming handlers).
+     *
+     * @param  Tool[]  $tools
+     * @param  ToolCall[]  $toolCalls
+     * @param  ToolResult[]  $toolResults  Results are collected into this array by reference
+     * @return Generator<ToolResultEvent|ArtifactEvent>
+     */
+    protected function callToolsAndYieldEvents(array $tools, array $toolCalls, string $messageId, array &$toolResults): Generator
+    {
+        foreach ($toolCalls as $toolCall) {
+            try {
                 $tool = $this->resolveTool($toolCall->name, $tools);
+                $output = call_user_func_array(
+                    $tool->handle(...),
+                    $toolCall->arguments()
+                );
 
-                try {
-                    $output = call_user_func_array(
-                        $tool->handle(...),
-                        $toolCall->arguments()
-                    );
-
-                    if (is_string($output)) {
-                        $output = new ToolOutput(result: $output);
-                    }
-
-                    return new ToolResult(
-                        toolCallId: $toolCall->id,
-                        toolName: $toolCall->name,
-                        args: $toolCall->arguments(),
-                        result: $output->result,
-                        toolCallResultId: $toolCall->resultId,
-                        artifacts: $output->artifacts,
-                    );
-                } catch (Throwable $e) {
-                    if ($e instanceof PrismException) {
-                        throw $e;
-                    }
-
-                    throw PrismException::toolCallFailed($toolCall, $e);
+                if (is_string($output)) {
+                    $output = new ToolOutput(result: $output);
                 }
 
-            },
-            $toolCalls
-        );
+                $toolResult = new ToolResult(
+                    toolCallId: $toolCall->id,
+                    toolName: $toolCall->name,
+                    args: $toolCall->arguments(),
+                    result: $output->result,
+                    toolCallResultId: $toolCall->resultId,
+                    artifacts: $output->artifacts,
+                );
+
+                $toolResults[] = $toolResult;
+
+                yield new ToolResultEvent(
+                    id: EventID::generate(),
+                    timestamp: time(),
+                    toolResult: $toolResult,
+                    messageId: $messageId,
+                    success: true
+                );
+
+                foreach ($toolResult->artifacts as $artifact) {
+                    yield new ArtifactEvent(
+                        id: EventID::generate(),
+                        timestamp: time(),
+                        artifact: $artifact,
+                        toolCallId: $toolCall->id,
+                        toolName: $toolCall->name,
+                        messageId: $messageId,
+                    );
+                }
+            } catch (PrismException $e) {
+                $toolResult = new ToolResult(
+                    toolCallId: $toolCall->id,
+                    toolName: $toolCall->name,
+                    args: $toolCall->arguments(),
+                    result: $e->getMessage(),
+                    toolCallResultId: $toolCall->resultId,
+                );
+
+                $toolResults[] = $toolResult;
+
+                yield new ToolResultEvent(
+                    id: EventID::generate(),
+                    timestamp: time(),
+                    toolResult: $toolResult,
+                    messageId: $messageId,
+                    success: false,
+                    error: $e->getMessage()
+                );
+            }
+        }
     }
 
     /**

--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -20,7 +20,6 @@ use Prism\Prism\Providers\DeepSeek\Maps\MessageMap;
 use Prism\Prism\Providers\DeepSeek\Maps\ToolChoiceMap;
 use Prism\Prism\Providers\DeepSeek\Maps\ToolMap;
 use Prism\Prism\Streaming\EventID;
-use Prism\Prism\Streaming\Events\ArtifactEvent;
 use Prism\Prism\Streaming\Events\StepFinishEvent;
 use Prism\Prism\Streaming\Events\StepStartEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
@@ -33,7 +32,6 @@ use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
 use Prism\Prism\Streaming\Events\ThinkingEvent;
 use Prism\Prism\Streaming\Events\ThinkingStartEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Streaming\StreamState;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
@@ -373,27 +371,8 @@ class Stream
             );
         }
 
-        $toolResults = $this->callTools($request->tools(), $mappedToolCalls);
-
-        foreach ($toolResults as $result) {
-            yield new ToolResultEvent(
-                id: EventID::generate(),
-                timestamp: time(),
-                toolResult: $result,
-                messageId: $this->state->messageId()
-            );
-
-            foreach ($result->artifacts as $artifact) {
-                yield new ArtifactEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    artifact: $artifact,
-                    toolCallId: $result->toolCallId,
-                    toolName: $result->toolName,
-                    messageId: $this->state->messageId(),
-                );
-            }
-        }
+        $toolResults = [];
+        yield from $this->callToolsAndYieldEvents($request->tools(), $mappedToolCalls, $this->state->messageId(), $toolResults);
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -17,7 +17,6 @@ use Prism\Prism\Providers\Gemini\Maps\MessageMap;
 use Prism\Prism\Providers\Gemini\Maps\ToolChoiceMap;
 use Prism\Prism\Providers\Gemini\Maps\ToolMap;
 use Prism\Prism\Streaming\EventID;
-use Prism\Prism\Streaming\Events\ArtifactEvent;
 use Prism\Prism\Streaming\Events\StepFinishEvent;
 use Prism\Prism\Streaming\Events\StepStartEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
@@ -30,14 +29,11 @@ use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
 use Prism\Prism\Streaming\Events\ThinkingEvent;
 use Prism\Prism\Streaming\Events\ThinkingStartEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Streaming\StreamState;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
 use Prism\Prism\ValueObjects\ToolCall;
-use Prism\Prism\ValueObjects\ToolOutput;
-use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
@@ -313,63 +309,7 @@ class Stream
 
         // Execute tools and emit results
         $toolResults = [];
-        foreach ($mappedToolCalls as $toolCall) {
-            try {
-                $tool = $this->resolveTool($toolCall->name, $request->tools());
-                $output = call_user_func_array($tool->handle(...), $toolCall->arguments());
-
-                if (is_string($output)) {
-                    $output = new ToolOutput(result: $output);
-                }
-
-                $toolResult = new ToolResult(
-                    toolCallId: $toolCall->id,
-                    toolName: $toolCall->name,
-                    args: $toolCall->arguments(),
-                    result: is_array($output->result) ? $output->result : ['result' => $output->result],
-                    artifacts: $output->artifacts,
-                );
-
-                $toolResults[] = $toolResult;
-
-                yield new ToolResultEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    toolResult: $toolResult,
-                    messageId: $this->state->messageId(),
-                    success: true
-                );
-
-                foreach ($toolResult->artifacts as $artifact) {
-                    yield new ArtifactEvent(
-                        id: EventID::generate(),
-                        timestamp: time(),
-                        artifact: $artifact,
-                        toolCallId: $toolCall->id,
-                        toolName: $toolCall->name,
-                        messageId: $this->state->messageId(),
-                    );
-                }
-            } catch (Throwable $e) {
-                $errorResult = new ToolResult(
-                    toolCallId: $toolCall->id,
-                    toolName: $toolCall->name,
-                    args: $toolCall->arguments(),
-                    result: []
-                );
-
-                $toolResults[] = $errorResult;
-
-                yield new ToolResultEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    toolResult: $errorResult,
-                    messageId: $this->state->messageId(),
-                    success: false,
-                    error: $e->getMessage()
-                );
-            }
-        }
+        yield from $this->callToolsAndYieldEvents($request->tools(), $mappedToolCalls, $this->state->messageId(), $toolResults);
 
         if ($toolResults !== []) {
             $request->addMessage(new AssistantMessage($this->state->currentText(), $mappedToolCalls));

--- a/src/Providers/Groq/Handlers/Stream.php
+++ b/src/Providers/Groq/Handlers/Stream.php
@@ -20,7 +20,6 @@ use Prism\Prism\Providers\Groq\Maps\MessageMap;
 use Prism\Prism\Providers\Groq\Maps\ToolChoiceMap;
 use Prism\Prism\Providers\Groq\Maps\ToolMap;
 use Prism\Prism\Streaming\EventID;
-use Prism\Prism\Streaming\Events\ArtifactEvent;
 use Prism\Prism\Streaming\Events\ErrorEvent;
 use Prism\Prism\Streaming\Events\StepFinishEvent;
 use Prism\Prism\Streaming\Events\StepStartEvent;
@@ -31,7 +30,6 @@ use Prism\Prism\Streaming\Events\TextCompleteEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\TextStartEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Streaming\StreamState;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
@@ -268,28 +266,8 @@ class Stream
             );
         }
 
-        $toolResults = $this->callTools($request->tools(), $mappedToolCalls);
-
-        // Emit tool result events
-        foreach ($toolResults as $result) {
-            yield new ToolResultEvent(
-                id: EventID::generate(),
-                timestamp: time(),
-                toolResult: $result,
-                messageId: $this->state->messageId()
-            );
-
-            foreach ($result->artifacts as $artifact) {
-                yield new ArtifactEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    artifact: $artifact,
-                    toolCallId: $result->toolCallId,
-                    toolName: $result->toolName,
-                    messageId: $this->state->messageId(),
-                );
-            }
-        }
+        $toolResults = [];
+        yield from $this->callToolsAndYieldEvents($request->tools(), $mappedToolCalls, $this->state->messageId(), $toolResults);
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));

--- a/src/Providers/Mistral/Handlers/Stream.php
+++ b/src/Providers/Mistral/Handlers/Stream.php
@@ -20,7 +20,6 @@ use Prism\Prism\Providers\Mistral\Maps\MessageMap;
 use Prism\Prism\Providers\Mistral\Maps\ToolChoiceMap;
 use Prism\Prism\Providers\Mistral\Maps\ToolMap;
 use Prism\Prism\Streaming\EventID;
-use Prism\Prism\Streaming\Events\ArtifactEvent;
 use Prism\Prism\Streaming\Events\StepFinishEvent;
 use Prism\Prism\Streaming\Events\StepStartEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
@@ -30,7 +29,6 @@ use Prism\Prism\Streaming\Events\TextCompleteEvent;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\TextStartEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Streaming\StreamState;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
@@ -263,27 +261,8 @@ class Stream
             );
         }
 
-        $toolResults = $this->callTools($request->tools(), $mappedToolCalls);
-
-        foreach ($toolResults as $result) {
-            yield new ToolResultEvent(
-                id: EventID::generate(),
-                timestamp: time(),
-                toolResult: $result,
-                messageId: $this->state->messageId()
-            );
-
-            foreach ($result->artifacts as $artifact) {
-                yield new ArtifactEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    artifact: $artifact,
-                    toolCallId: $result->toolCallId,
-                    toolName: $result->toolName,
-                    messageId: $this->state->messageId(),
-                );
-            }
-        }
+        $toolResults = [];
+        yield from $this->callToolsAndYieldEvents($request->tools(), $mappedToolCalls, $this->state->messageId(), $toolResults);
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));

--- a/src/Providers/XAI/Handlers/Stream.php
+++ b/src/Providers/XAI/Handlers/Stream.php
@@ -20,7 +20,6 @@ use Prism\Prism\Providers\XAI\Maps\MessageMap;
 use Prism\Prism\Providers\XAI\Maps\ToolChoiceMap;
 use Prism\Prism\Providers\XAI\Maps\ToolMap;
 use Prism\Prism\Streaming\EventID;
-use Prism\Prism\Streaming\Events\ArtifactEvent;
 use Prism\Prism\Streaming\Events\StepFinishEvent;
 use Prism\Prism\Streaming\Events\StepStartEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
@@ -33,7 +32,6 @@ use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
 use Prism\Prism\Streaming\Events\ThinkingEvent;
 use Prism\Prism\Streaming\Events\ThinkingStartEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\Streaming\StreamState;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
@@ -360,27 +358,8 @@ class Stream
             );
         }
 
-        $toolResults = $this->callTools($request->tools(), $mappedToolCalls);
-
-        foreach ($toolResults as $result) {
-            yield new ToolResultEvent(
-                id: EventID::generate(),
-                timestamp: time(),
-                toolResult: $result,
-                messageId: $this->state->messageId()
-            );
-
-            foreach ($result->artifacts as $artifact) {
-                yield new ArtifactEvent(
-                    id: EventID::generate(),
-                    timestamp: time(),
-                    artifact: $artifact,
-                    toolCallId: $result->toolCallId,
-                    toolName: $result->toolName,
-                    messageId: $this->state->messageId(),
-                );
-            }
-        }
+        $toolResults = [];
+        yield from $this->callToolsAndYieldEvents($request->tools(), $mappedToolCalls, $this->state->messageId(), $toolResults);
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));

--- a/tests/Concerns/CallsToolsTest.php
+++ b/tests/Concerns/CallsToolsTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Streaming\Events\ArtifactEvent;
+use Prism\Prism\Streaming\Events\ToolResultEvent;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Artifact;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolOutput;
+use Prism\Prism\ValueObjects\ToolResult;
+
+class CallsToolsTestHandler
+{
+    use CallsTools;
+
+    public function execute(array $tools, array $toolCalls): array
+    {
+        return $this->callTools($tools, $toolCalls);
+    }
+
+    public function stream(array $tools, array $toolCalls, string $messageId, array &$toolResults): Generator
+    {
+        return $this->callToolsAndYieldEvents($tools, $toolCalls, $messageId, $toolResults);
+    }
+}
+
+it('executes tools and returns array of ToolResults', function (): void {
+    $tool = (new Tool)
+        ->as('greet')
+        ->for('Greet a person')
+        ->withStringParameter('name', 'Name to greet')
+        ->using(fn (string $name): string => "Hello, {$name}!");
+
+    $toolCall = new ToolCall(
+        id: 'call-123',
+        name: 'greet',
+        arguments: ['name' => 'World'],
+        resultId: 'result-456'
+    );
+
+    $handler = new CallsToolsTestHandler;
+    $results = $handler->execute([$tool], [$toolCall]);
+
+    expect($results)->toBeArray()
+        ->and($results)->toHaveCount(1)
+        ->and($results[0])->toBeInstanceOf(ToolResult::class)
+        ->and($results[0]->toolCallId)->toBe('call-123')
+        ->and($results[0]->toolName)->toBe('greet')
+        ->and($results[0]->result)->toBe('Hello, World!')
+        ->and($results[0]->args)->toBe(['name' => 'World'])
+        ->and($results[0]->toolCallResultId)->toBe('result-456')
+        ->and($results[0]->artifacts)->toBeEmpty();
+});
+
+it('generates tool events for streaming handlers', function (): void {
+    $tool = (new Tool)
+        ->as('calculate')
+        ->for('Add two numbers')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn (int $a, int $b): string => (string) ($a + $b));
+
+    $toolCall = new ToolCall(id: 'call-456', name: 'calculate', arguments: ['a' => 5, 'b' => 3]);
+
+    $handler = new CallsToolsTestHandler;
+    $toolResults = [];
+    $events = [];
+
+    foreach ($handler->stream([$tool], [$toolCall], 'msg-123', $toolResults) as $event) {
+        $events[] = $event;
+    }
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(ToolResultEvent::class)
+        ->and($events[0]->success)->toBeTrue()
+        ->and($events[0]->messageId)->toBe('msg-123')
+        ->and($events[0]->toolResult->result)->toBe('8')
+        ->and($toolResults)->toHaveCount(1)
+        ->and($toolResults[0]->result)->toBe('8');
+});
+
+it('yields artifact events when tool returns artifacts', function (): void {
+    $artifact1 = Artifact::fromRawContent('content 1', 'text/plain', ['name' => 'file1.txt']);
+    $artifact2 = Artifact::fromRawContent('content 2', 'application/json', ['name' => 'data.json']);
+
+    $tool = (new Tool)
+        ->as('create_files')
+        ->for('Create files')
+        ->using(fn (): ToolOutput => new ToolOutput(
+            result: 'Files created',
+            artifacts: [$artifact1, $artifact2]
+        ));
+
+    $toolCall = new ToolCall(id: 'call-789', name: 'create_files', arguments: []);
+
+    $handler = new CallsToolsTestHandler;
+    $toolResults = [];
+    $events = [];
+
+    foreach ($handler->stream([$tool], [$toolCall], 'msg-123', $toolResults) as $event) {
+        $events[] = $event;
+    }
+
+    expect($events)->toHaveCount(3)
+        ->and($events[0])->toBeInstanceOf(ToolResultEvent::class)
+        ->and($events[1])->toBeInstanceOf(ArtifactEvent::class)
+        ->and($events[2])->toBeInstanceOf(ArtifactEvent::class)
+        ->and($events[1]->artifact)->toBe($artifact1)
+        ->and($events[1]->toolCallId)->toBe('call-789')
+        ->and($events[1]->toolName)->toBe('create_files')
+        ->and($events[2]->artifact)->toBe($artifact2);
+});
+
+it('yields failed ToolResultEvent when tool is not found', function (): void {
+    $tool = (new Tool)
+        ->as('existing_tool')
+        ->for('An existing tool')
+        ->using(fn (): string => 'result');
+
+    $toolCall = new ToolCall(id: 'call-123', name: 'nonexistent_tool', arguments: []);
+
+    $handler = new CallsToolsTestHandler;
+    $toolResults = [];
+    $events = [];
+
+    foreach ($handler->stream([$tool], [$toolCall], 'msg-123', $toolResults) as $event) {
+        $events[] = $event;
+    }
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(ToolResultEvent::class)
+        ->and($events[0]->success)->toBeFalse()
+        ->and($events[0]->error)->toContain('not found')
+        ->and($events[0]->toolResult->result)->toContain('not found')
+        ->and($toolResults)->toHaveCount(1);
+});
+
+it('yields failed ToolResultEvent when multiple tools with same name exist', function (): void {
+    $tool1 = (new Tool)->as('duplicate')->for('First')->using(fn (): string => 'result 1');
+    $tool2 = (new Tool)->as('duplicate')->for('Second')->using(fn (): string => 'result 2');
+
+    $toolCall = new ToolCall(id: 'call-123', name: 'duplicate', arguments: []);
+
+    $handler = new CallsToolsTestHandler;
+    $toolResults = [];
+    $events = [];
+
+    foreach ($handler->stream([$tool1, $tool2], [$toolCall], 'msg-123', $toolResults) as $event) {
+        $events[] = $event;
+    }
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(ToolResultEvent::class)
+        ->and($events[0]->success)->toBeFalse()
+        ->and($events[0]->error)->toContain('Multiple tools')
+        ->and($toolResults)->toHaveCount(1);
+});
+
+it('continues processing other tool calls when one fails', function (): void {
+    $tool = (new Tool)
+        ->as('valid_tool')
+        ->for('A valid tool')
+        ->using(fn (): string => 'success');
+
+    $toolCalls = [
+        new ToolCall(id: 'call-1', name: 'nonexistent', arguments: []),
+        new ToolCall(id: 'call-2', name: 'valid_tool', arguments: []),
+        new ToolCall(id: 'call-3', name: 'another_nonexistent', arguments: []),
+    ];
+
+    $handler = new CallsToolsTestHandler;
+    $results = $handler->execute([$tool], $toolCalls);
+
+    expect($results)->toHaveCount(3)
+        ->and($results[0]->result)->toContain('not found')
+        ->and($results[1]->result)->toBe('success')
+        ->and($results[2]->result)->toContain('not found');
+});
+
+it('throws non-PrismException errors', function (): void {
+    $tool = (new Tool)
+        ->as('throwing_tool')
+        ->for('A tool that throws')
+        ->using(function (): string {
+            throw new RuntimeException('Unexpected error');
+        })
+        ->withoutErrorHandling();
+
+    $toolCall = new ToolCall(id: 'call-123', name: 'throwing_tool', arguments: []);
+
+    $handler = new CallsToolsTestHandler;
+
+    expect(fn (): array => $handler->execute([$tool], [$toolCall]))
+        ->toThrow(RuntimeException::class, 'Unexpected error');
+});
+
+it('collects results incrementally while yielding events', function (): void {
+    $tool = (new Tool)
+        ->as('echo')
+        ->for('Echo input')
+        ->withStringParameter('input', 'Input')
+        ->using(fn (string $input): string => $input);
+
+    $toolCalls = [
+        new ToolCall(id: 'call-1', name: 'echo', arguments: ['input' => 'first']),
+        new ToolCall(id: 'call-2', name: 'echo', arguments: ['input' => 'second']),
+    ];
+
+    $handler = new CallsToolsTestHandler;
+    $toolResults = [];
+    $toolResultEventCount = 0;
+
+    foreach ($handler->stream([$tool], $toolCalls, 'msg-123', $toolResults) as $event) {
+        if ($event instanceof ToolResultEvent) {
+            $toolResultEventCount++;
+            // Result is already in array before event is yielded
+            expect($toolResults)->toHaveCount($toolResultEventCount)
+                ->and($toolResults[$toolResultEventCount - 1])->toBe($event->toolResult);
+        }
+    }
+
+    expect($toolResultEventCount)->toBe(2)
+        ->and($toolResults[0]->result)->toBe('first')
+        ->and($toolResults[1]->result)->toBe('second');
+});
+
+it('returns empty results when no tool calls provided', function (): void {
+    $tool = (new Tool)->as('test')->for('Test')->using(fn (): string => 'result');
+
+    $handler = new CallsToolsTestHandler;
+
+    // Non-streaming
+    expect($handler->execute([$tool], []))->toBeEmpty();
+
+    // Streaming
+    $toolResults = [];
+    $events = iterator_to_array($handler->stream([$tool], [], 'msg-123', $toolResults));
+
+    expect($events)->toBeEmpty()
+        ->and($toolResults)->toBeEmpty();
+});

--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -185,7 +185,7 @@ it('can generate text stream using tools ', function (): void {
         ->and($toolCalls[0]->reasoningId)->not->toBeNull()
         ->and($toolCalls[0]->reasoningId)->toBe('Eq0ECqoEAdHtim8E9iAxfKwT6QsjWgFpC3mNjNoEc0uf/khdTIkry0wbRzOTpYuw1HdLFm5263kddqUYf+HKlTGq5fbXQb8e+MyBxsft/WzOcmMKTGxbnW1Nx7JPsMhu9TQltjp0w+EIOd7CSJnIcubiZ13tzGR7MOF8OIzTXidrdtNWRRND8kYKIMIBbW2EWuE2CJUzihJFct9JQSQulq/WpJ1ctiI1bl89HcoIGXTuTNK90CncMw/+ink6edobepVG4umPGIdgx2B6bE9uchv+kjKWSwnDsY5hvUP/uSseFZ5fpZbsrhB3IAMVrLBtFTKiLkuvkUh664EQ91rgfYGJ2NTu3SwpEfLy3ftUxqI1d/t84lMWo9X0om5ihM4sFpD//DxGeEKbs3XtAPEJoWawy24aXoVQb59SSt23Yr87epA261b8a2pDPW7QnUCg4GWSquAZ8z39BxO3DJ4fyU72QpRzs9m3G5XYt5iV8+ndMHjJsIxmeXYqqteq3QCNLbAwKCBLbpq4HyYgyu7R4RpnUEx1t8/3seXPfhEUSaP5Prjr9TEwdOB/fgig2BV2eJ4AuAvbw4A7/RkkBhvUQ+0KW3HByDBN5g8X59K5S3fasUhcDRU4QsGQOh9DShH2bi+o71SWpRw5zdKT3AmdDEQqrg5ybVK+plpA6XLSmDIekNl4lqn0YsUzPtzCdvD0rlI1OP85jNnYwQeRS1Dbm8viYbGdZWjTehd+jK1xIxU=')
         ->and($toolResults)->not->toBeEmpty()
-        ->and($toolResults[0]->result)->toBe(['result' => 'The weather will be 75° and sunny in San Francisco'])
+        ->and($toolResults[0]->result)->toBe('The weather will be 75° and sunny in San Francisco')
         ->and($text)->toContain('The current weather in San Francisco is 75°F and sunny. You likely won\'t need a coat, but you might want to bring a light jacket just in case it gets breezy or cools down later.');
 
     $lastEvent = end($events);


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->

## Description

### 🐛 Fix: Handle `PrismException` during tool execution to allow LLM self-correction

#### Problem

When a `PrismException` occurs during tool execution (e.g., tool not found, multiple tools with same name), the exception was thrown and broke the LLM conversation flow. This prevented the model from receiving feedback about the error and self-correcting.

**Example scenario:**
1. LLM calls a tool with a typo in the name: `"get_wether"` instead of `"get_weather"`
2. `resolveTool()` throws `PrismException::toolNotFound()`
3. Exception propagates up and breaks the entire flow
4. User sees an error instead of the LLM correcting itself

#### Solution

Adopted the error handling approach from Anthropic's streaming handler: catch `PrismException` during tool execution and convert it to a failed `ToolResult` with the error message. This allows the LLM to:

* Receive the error as tool output
* Understand what went wrong
* Self-correct on the next turn

```php
// Before: Exception breaks the flow
throw PrismException::toolNotFound($name);

// After: Error returned as tool result, LLM can self-correct
catch (PrismException $e) {
    $toolResult = new ToolResult(
        toolCallId: $toolCall->id,
        toolName: $toolCall->name,
        args: $toolCall->arguments(),
        result: $e->getMessage(),  // "Tool 'get_wether' not found"
    );
    
    yield new ToolResultEvent(
        toolResult: $toolResult,
        success: false,
        error: $e->getMessage()
    );
}
```

#### Refactoring

While implementing this fix, refactored the duplicated tool execution logic into a centralized `callToolsAndYieldEvents()` method in the `CallsTools` trait:

* **Before:** Each of the 8 stream handlers had its own copy of tool execution + event generation.

* **After:** Single `yield from $this->callToolsAndYieldEvents(...)` call in each handler

#### Gemini Stream Handler Fix

The Gemini Stream handler had inconsistent behavior, it wrapped string tool results in an array (`['result' => $output]`) while the Gemini Text/Structured handlers did not. After reviewing the [Gemini API function calling documentation](https://ai.google.dev/gemini-api/docs/function-calling) and the codebase, confirmed that `MessageMap.php` already wraps the tool result in a `content` key and `json_encode()`s tool result when building the API request, so the additional array wrapping in the Stream handler was redundant. The Gemini Stream handler now uses `callToolsAndYieldEvents()` like all other providers, making tool result formatting consistent across all Gemini handlers. 

> **Note for @sixlive:** Please review this Gemini change to confirm the array wrapping removal is correct. All Gemini tests pass & one was updated which checked the tool result was wrapped in result key, but would appreciate a second look.


#### Changes

| File | Change |
|------|--------|
| `src/Concerns/CallsTools.php` | Added `callToolsAndYieldEvents()` with `PrismException` handling; `callTools()` now uses it internally |
| `src/Providers/*/Handlers/Stream.php` | Replaced duplicated logic with single `yield from` call |
| `tests/Concerns/CallsToolsTest.php` | Added comprehensive test coverage |

#### Tests Added

Added `tests/Concerns/CallsToolsTest.php` with 9 tests covering:

* ✅ Basic tool execution (streaming and non-streaming)
* ✅ Artifact event generation
* ✅ `PrismException` handling (tool not found, multiple tools found)
* ✅ Resilience — continues processing after individual tool failures
* ✅ Non-`PrismException` errors are re-thrown
* ✅ Incremental result collection via reference parameter
* ✅ Edge cases (empty tool calls)

#### Breaking Changes

**None.** This is a backward-compatible change:

* `callTools()` method signature unchanged — existing Text/Structured handlers work without modification
* Non-`PrismException` errors still re-thrown as before
* All existing tests pass

#### Result

* ✅ **LLM self-correction enabled**: `PrismException` errors returned as tool results instead of thrown
* ✅ **Consistent behavior**: all handlers now handle tool errors the same way
* ✅ **duplicate tool calling code removed**: duplicated code consolidated into single method
* ✅ **Full test coverage**: new test file for CallsTools tests
* ✅ **No breaking changes**: drop-in replacement for existing behavior

