### PR TITLE
Feat: Evented telemetry 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
     "ext-fileinfo": "*",
     "laravel/framework": "^11.0|^12.0"
   },
+  "suggest": {
+    "open-telemetry/sdk": "Required for OTLP telemetry drivers (Phoenix, Langfuse, etc.)",
+    "open-telemetry/exporter-otlp": "Required for OTLP telemetry drivers",
+    "google/protobuf": "Required for OTLP telemetry export (or ext-protobuf)"
+  },
   "config": {
     "allow-plugins": {
       "php-http/discovery": true,
@@ -45,7 +50,10 @@
     "symplify/rule-doc-generator-contracts": "^11.2",
     "phpstan/phpdoc-parser": "^2.0",
     "spatie/laravel-ray": "^1.39",
-    "laravel/mcp": "^0.3.2"
+    "laravel/mcp": "^0.3.2",
+    "open-telemetry/sdk": "^1.10",
+    "open-telemetry/exporter-otlp": "^1.3",
+    "google/protobuf": "^4.29"
   },
   "autoload-dev": {
     "psr-4": {

--- a/config/prism.php
+++ b/config/prism.php
@@ -62,4 +62,52 @@ return [
             ],
         ],
     ],
+    'telemetry' => [
+        'enabled' => env('PRISM_TELEMETRY_ENABLED', false),
+        'driver' => env('PRISM_TELEMETRY_DRIVER', 'null'),
+
+        // Each named driver config specifies a 'driver' key for the actual driver type.
+        // This allows multiple configs using the same underlying driver (e.g., multiple OTLP endpoints).
+        'drivers' => [
+            'null' => [
+                'driver' => 'null',
+            ],
+
+            'log' => [
+                'driver' => 'log',
+                'channel' => env('PRISM_TELEMETRY_LOG_CHANNEL', 'prism-telemetry'),
+            ],
+
+            // Phoenix Arize - OTLP with OpenInference semantic conventions
+            'phoenix' => [
+                'driver' => 'otlp',
+                'endpoint' => env('PHOENIX_ENDPOINT', 'https://app.phoenix.arize.com/v1/traces'),
+                'api_key' => env('PHOENIX_API_KEY'),
+                'service_name' => env('PHOENIX_SERVICE_NAME', 'prism'),
+                'mapper' => \Prism\Prism\Telemetry\Semantics\OpenInferenceMapper::class,
+                'timeout' => 30.0,
+                // Tags applied to all spans (useful for filtering)
+                'tags' => [
+                    'environment' => env('APP_ENV', 'production'),
+                    'app' => env('APP_NAME', 'laravel'),
+                ],
+            ],
+
+            // Example: Langfuse OTLP backend
+            // 'langfuse' => [
+            //     'driver' => 'otlp',
+            //     'endpoint' => env('LANGFUSE_ENDPOINT', 'https://cloud.langfuse.com/api/public/otel/v1/traces'),
+            //     'api_key' => env('LANGFUSE_API_KEY'),
+            //     'service_name' => env('LANGFUSE_SERVICE_NAME', 'prism'),
+            //     'mapper' => \Prism\Prism\Telemetry\Semantics\PassthroughMapper::class,
+            // ],
+
+            // Example: Custom driver via factory class
+            // 'my-custom' => [
+            //     'driver' => 'custom',
+            //     'via' => App\Telemetry\MyCustomDriverFactory::class,
+            //     // Pass any additional config your factory needs...
+            // ],
+        ],
+    ],
 ];

--- a/src/Concerns/EmitsTelemetry.php
+++ b/src/Concerns/EmitsTelemetry.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Generator;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Events\SpanException;
+
+trait EmitsTelemetry
+{
+    /**
+     * Execute a callable with telemetry tracking.
+     *
+     * @template TResponse
+     *
+     * @param  callable(string, string, ?string): object  $startEventFactory  Factory to create start event (spanId, traceId, parentSpanId) => event
+     * @param  callable(string, string, ?string, TResponse): object  $endEventFactory  Factory to create end event (spanId, traceId, parentSpanId, response) => event
+     * @param  callable(): TResponse  $execute  The operation to execute
+     * @return TResponse
+     */
+    protected function withTelemetry(
+        callable $startEventFactory,
+        callable $endEventFactory,
+        callable $execute,
+    ): mixed {
+        if (! config('prism.telemetry.enabled', false)) {
+            return $execute();
+        }
+
+        // Push telemetry context if HasTelemetryContext trait is used
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (method_exists($this, 'pushTelemetryContext')) {
+            $this->pushTelemetryContext();
+        }
+
+        $spanId = bin2hex(random_bytes(8));
+        $traceId = Context::getHidden('prism.telemetry.trace_id') ?? bin2hex(random_bytes(16));
+        $parentSpanId = Context::getHidden('prism.telemetry.current_span_id');
+
+        // Use hidden context to avoid leaking telemetry IDs into logs
+        Context::addHidden('prism.telemetry.trace_id', $traceId);
+        Context::addHidden('prism.telemetry.current_span_id', $spanId);
+
+        Event::dispatch($startEventFactory($spanId, $traceId, $parentSpanId));
+
+        try {
+            $response = $execute();
+
+            Event::dispatch($endEventFactory($spanId, $traceId, $parentSpanId, $response));
+
+            return $response;
+        } catch (\Throwable $e) {
+            Event::dispatch(new SpanException($spanId, $e));
+
+            throw $e;
+        } finally {
+            Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+            // Shutdown driver to flush any buffered spans
+            app(TelemetryDriver::class)->shutdown();
+        }
+    }
+
+    /**
+     * Execute a generator with telemetry tracking.
+     *
+     * If event types are provided, dispatches telemetry when those events are encountered.
+     * Otherwise, dispatches before/after the entire generator execution.
+     *
+     * @template TYield
+     *
+     * @param  callable(string, string, ?string, mixed): object  $startEventFactory  Factory to create start event
+     * @param  callable(string, string, ?string, mixed): object  $endEventFactory  Factory to create end event
+     * @param  callable(): Generator<TYield>  $execute  The generator to iterate
+     * @param  class-string|null  $startEventType  Stream event type that triggers start telemetry (null = dispatch immediately)
+     * @param  class-string|null  $endEventType  Stream event type that triggers end telemetry (null = dispatch after generator completes)
+     * @return Generator<TYield>
+     */
+    protected function withStreamingTelemetry(
+        callable $startEventFactory,
+        callable $endEventFactory,
+        callable $execute,
+        ?string $startEventType = null,
+        ?string $endEventType = null,
+    ): Generator {
+        if (! config('prism.telemetry.enabled', false)) {
+            yield from $execute();
+
+            return;
+        }
+
+        // Push telemetry context if HasTelemetryContext trait is used
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (method_exists($this, 'pushTelemetryContext')) {
+            $this->pushTelemetryContext();
+        }
+
+        $spanId = bin2hex(random_bytes(8));
+        $traceId = Context::getHidden('prism.telemetry.trace_id') ?? bin2hex(random_bytes(16));
+        $parentSpanId = Context::getHidden('prism.telemetry.current_span_id');
+
+        // Use hidden context to avoid leaking telemetry IDs into logs
+        Context::addHidden('prism.telemetry.trace_id', $traceId);
+        Context::addHidden('prism.telemetry.current_span_id', $spanId);
+
+        // Dispatch start before generator if no event type specified
+        if ($startEventType === null) {
+            Event::dispatch($startEventFactory($spanId, $traceId, $parentSpanId, null));
+        }
+
+        try {
+            foreach ($execute() as $event) {
+                if ($startEventType !== null && $event instanceof $startEventType) {
+                    Event::dispatch($startEventFactory($spanId, $traceId, $parentSpanId, $event));
+                }
+
+                if ($endEventType !== null && $event instanceof $endEventType) {
+                    Event::dispatch($endEventFactory($spanId, $traceId, $parentSpanId, $event));
+                }
+
+                yield $event;
+            }
+
+            // Dispatch end after generator if no event type specified
+            if ($endEventType === null) {
+                Event::dispatch($endEventFactory($spanId, $traceId, $parentSpanId, null));
+            }
+        } catch (\Throwable $e) {
+            Event::dispatch(new SpanException($spanId, $e));
+
+            throw $e;
+        } finally {
+            Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+            // Shutdown driver to flush any buffered spans
+            app(TelemetryDriver::class)->shutdown();
+        }
+    }
+}

--- a/src/Concerns/HasTelemetryContext.php
+++ b/src/Concerns/HasTelemetryContext.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Illuminate\Support\Facades\Context;
+use Prism\Prism\Prism;
+
+trait HasTelemetryContext
+{
+    /** @var array<string, mixed> */
+    protected array $telemetryContext = [];
+
+    /**
+     * Add context metadata for telemetry tracking.
+     *
+     * This metadata is included in telemetry spans and can be used
+     * for filtering, grouping, and analysis in observability platforms.
+     *
+     * Common keys: user_id, user_email, session_id, environment, etc.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function withTelemetryContext(array $context): static
+    {
+        $this->telemetryContext = array_merge($this->telemetryContext, $context);
+
+        return $this;
+    }
+
+    /**
+     * Set user context for telemetry tracking.
+     *
+     * @param  string|int|null  $userId  User identifier
+     * @param  string|null  $email  User email (optional)
+     */
+    public function forUser(string|int|null $userId, ?string $email = null): static
+    {
+        return $this->withTelemetryContext(array_filter([
+            'user_id' => $userId !== null ? (string) $userId : null,
+            'user_email' => $email,
+        ], fn (?string $v): bool => $v !== null));
+    }
+
+    /**
+     * Set conversation/chat session context for telemetry tracking.
+     *
+     * The session ID should represent the logical conversation thread,
+     * NOT the Laravel HTTP session. This allows Phoenix/Arize to group
+     * all messages in a conversation together.
+     *
+     * @param  string|int  $conversationId  The conversation/chat thread ID
+     */
+    public function forConversation(string|int $conversationId): static
+    {
+        return $this->withTelemetryContext([
+            'session_id' => (string) $conversationId,
+        ]);
+    }
+
+    /**
+     * Set the agent/bot identifier for telemetry tracking.
+     *
+     * Use this when you have multiple AI agents in your application
+     * to differentiate and group telemetry by agent type.
+     *
+     * @param  string  $agent  The agent identifier (e.g., "support-bot", "code-assistant")
+     */
+    public function forAgent(string $agent): static
+    {
+        return $this->withTelemetryContext([
+            'agent' => $agent,
+        ]);
+    }
+
+    /**
+     * Set tags for telemetry filtering.
+     *
+     * Tags are key-value pairs useful for filtering and grouping in observability platforms.
+     *
+     * @param  array<string, string>  $tags
+     */
+    public function withTelemetryTags(array $tags): static
+    {
+        return $this->withTelemetryContext(['tags' => $tags]);
+    }
+
+    /**
+     * Push telemetry context to Laravel's Context facade.
+     *
+     * Uses hidden context so telemetry metadata doesn't leak into logs.
+     * This makes the context available to SpanCollector without
+     * needing to pass it through events.
+     */
+    protected function pushTelemetryContext(): void
+    {
+        $context = array_merge(
+            Prism::getDefaultTelemetryContext(),
+            $this->telemetryContext
+        );
+
+        if ($context !== []) {
+            // Use hidden context to avoid leaking telemetry data into logs
+            Context::addHidden('prism.telemetry.metadata', $context);
+        }
+    }
+}

--- a/src/Concerns/InitializesClient.php
+++ b/src/Concerns/InitializesClient.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Concerns;
 
+use Closure;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Prism\Prism\Telemetry\Events\HttpCallCompleted;
+use Prism\Prism\Telemetry\Events\HttpCallStarted;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -19,6 +24,62 @@ trait InitializesClient
             ->withResponseMiddleware(fn (ResponseInterface $response): ResponseInterface => $response)
             ->timeout($timeout)
             ->connectTimeout($timeout)
+            ->when(
+                config('prism.telemetry.enabled', false),
+                fn (PendingRequest $client) => $client->withMiddleware($this->telemetryMiddleware())
+            )
             ->throw();
+    }
+
+    protected function telemetryMiddleware(): Closure
+    {
+        return fn (callable $handler): callable => function ($request, array $options) use ($handler) {
+            $spanId = bin2hex(random_bytes(8));
+            $traceId = Context::getHidden('prism.telemetry.trace_id') ?? bin2hex(random_bytes(16));
+            $parentSpanId = Context::getHidden('prism.telemetry.current_span_id');
+
+            // Use hidden context to avoid leaking telemetry IDs into logs
+            Context::addHidden('prism.telemetry.trace_id', $traceId);
+            Context::addHidden('prism.telemetry.current_span_id', $spanId);
+
+            // Extract details from the PSR-7 request
+            $method = $request->getMethod();
+            $url = (string) $request->getUri();
+            $headers = $request->getHeaders();
+
+            Event::dispatch(new HttpCallStarted(
+                spanId: $spanId,
+                traceId: $traceId,
+                parentSpanId: $parentSpanId,
+                method: $method,
+                url: $url,
+                headers: $headers,
+            ));
+
+            $promise = $handler($request, $options);
+
+            return $promise->then(
+                function ($response) use ($spanId, $traceId, $parentSpanId, $method, $url) {
+                    Event::dispatch(new HttpCallCompleted(
+                        spanId: $spanId,
+                        traceId: $traceId,
+                        parentSpanId: $parentSpanId,
+                        method: $method,
+                        url: $url,
+                        statusCode: $response->getStatusCode(),
+                    ));
+
+                    Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+                    return $response;
+                },
+                function (\Throwable $reason) use ($parentSpanId): void {
+                    // Reset context even on HTTP errors
+                    Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+                    throw $reason;
+                }
+            );
+        };
     }
 }

--- a/src/Contracts/TelemetryDriver.php
+++ b/src/Contracts/TelemetryDriver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Contracts;
+
+use Prism\Prism\Telemetry\SpanData;
+
+interface TelemetryDriver
+{
+    /**
+     * Record a complete span.
+     *
+     * The driver receives fully constructed span data and is responsible
+     * for formatting and exporting it to the appropriate backend.
+     */
+    public function recordSpan(SpanData $span): void;
+
+    /**
+     * Shutdown the driver, flushing any buffered spans.
+     *
+     * Called when a Prism operation completes to ensure all
+     * telemetry data is exported.
+     */
+    public function shutdown(): void;
+}

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -7,15 +7,21 @@ namespace Prism\Prism\Embeddings;
 use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\EmitsTelemetry;
 use Prism\Prism\Concerns\HasProviderOptions;
+use Prism\Prism\Concerns\HasTelemetryContext;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted;
 use Prism\Prism\ValueObjects\Media\Image;
 
 class PendingRequest
 {
     use ConfiguresClient;
     use ConfiguresProviders;
+    use EmitsTelemetry;
     use HasProviderOptions;
+    use HasTelemetryContext;
 
     /** @var array<string> */
     protected array $inputs = [];
@@ -101,7 +107,22 @@ class PendingRequest
         $request = $this->toRequest();
 
         try {
-            return $this->provider->embeddings($request);
+            return $this->withTelemetry(
+                startEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId): \Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted => new EmbeddingGenerationStarted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                ),
+                endEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId, Response $response): \Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted => new EmbeddingGenerationCompleted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                    response: $response,
+                ),
+                execute: fn (): \Prism\Prism\Embeddings\Response => $this->provider->embeddings($request),
+            );
         } catch (RequestException $e) {
             $this->provider->handleRequestException($request->model(), $e);
         }

--- a/src/Prism.php
+++ b/src/Prism.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prism\Prism;
 
+use Closure;
 use Illuminate\Support\Traits\Macroable;
 use Prism\Prism\Audio\PendingRequest as PendingAudioRequest;
 use Prism\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
@@ -15,6 +16,71 @@ use Prism\Prism\Text\PendingRequest as PendingTextRequest;
 class Prism
 {
     use Macroable;
+
+    /**
+     * The callback to resolve default telemetry context.
+     *
+     * @var (Closure(): array<string, mixed>)|null
+     */
+    protected static ?Closure $defaultTelemetryContextResolver = null;
+
+    /**
+     * Set a callback to resolve default telemetry context.
+     *
+     * This context will be automatically added to all Prism requests.
+     * Useful for adding user_id, session_id, etc. globally.
+     *
+     * The callback is invoked lazily per-request, so it's safe to reference
+     * request-scoped services like auth() and session() inside the closure.
+     *
+     * @param  (Closure(): array<string, mixed>)|null  $callback
+     *
+     * @example
+     * ```php
+     * // In AppServiceProvider::boot():
+     * Prism::defaultTelemetryContext(fn () => [
+     *     'user_id' => auth()->id(),        // Resolved fresh each request
+     *     'session_id' => session()->getId(),
+     *     'environment' => app()->environment(),
+     * ]);
+     * ```
+     *
+     * @warning Do NOT capture request-scoped values in the closure:
+     * ```php
+     * // ❌ BAD - $user is captured, will leak between Octane requests
+     * $user = auth()->user();
+     * Prism::defaultTelemetryContext(fn () => ['user_id' => $user->id]);
+     *
+     * // ✅ GOOD - auth() is called fresh each request
+     * Prism::defaultTelemetryContext(fn () => ['user_id' => auth()->id()]);
+     * ```
+     */
+    public static function defaultTelemetryContext(?Closure $callback): void
+    {
+        static::$defaultTelemetryContextResolver = $callback;
+    }
+
+    /**
+     * Get the default telemetry context.
+     *
+     * @return array<string, mixed>
+     */
+    public static function getDefaultTelemetryContext(): array
+    {
+        if (! static::$defaultTelemetryContextResolver instanceof \Closure) {
+            return [];
+        }
+
+        return (static::$defaultTelemetryContextResolver)();
+    }
+
+    /**
+     * Clear the default telemetry context resolver.
+     */
+    public static function flushDefaultTelemetryContext(): void
+    {
+        static::$defaultTelemetryContextResolver = null;
+    }
 
     public function text(): PendingTextRequest
     {

--- a/src/PrismServiceProvider.php
+++ b/src/PrismServiceProvider.php
@@ -4,6 +4,7 @@ namespace Prism\Prism;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Prism\Prism\Telemetry\TelemetryServiceProvider;
 
 class PrismServiceProvider extends ServiceProvider
 {
@@ -48,5 +49,7 @@ class PrismServiceProvider extends ServiceProvider
             'prism-server',
             fn (): PrismServer => new PrismServer
         );
+
+        $this->app->register(TelemetryServiceProvider::class);
     }
 }

--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismStreamDecodeException;
 use Prism\Prism\Providers\Anthropic\Maps\CitationsMapper;
 use Prism\Prism\Providers\Anthropic\ValueObjects\AnthropicStreamState;
@@ -466,6 +467,8 @@ class Stream
 
     /**
      * @return Generator<StreamEvent>
+     *
+     * @throws PrismException
      */
     protected function handleToolCalls(Request $request, int $depth): Generator
     {

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -11,14 +11,18 @@ use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresStructuredOutput;
 use Prism\Prism\Concerns\ConfiguresTools;
+use Prism\Prism\Concerns\EmitsTelemetry;
 use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Concerns\HasProviderTools;
 use Prism\Prism\Concerns\HasSchema;
+use Prism\Prism\Concerns\HasTelemetryContext;
 use Prism\Prism\Concerns\HasTools;
 use Prism\Prism\Contracts\Schema;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Telemetry\Events\StructuredOutputCompleted;
+use Prism\Prism\Telemetry\Events\StructuredOutputStarted;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
@@ -29,11 +33,13 @@ class PendingRequest
     use ConfiguresProviders;
     use ConfiguresStructuredOutput;
     use ConfiguresTools;
+    use EmitsTelemetry;
     use HasMessages;
     use HasPrompts;
     use HasProviderOptions;
     use HasProviderTools;
     use HasSchema;
+    use HasTelemetryContext;
     use HasTools;
 
     /**
@@ -49,7 +55,22 @@ class PendingRequest
         $request = $this->toRequest();
 
         try {
-            return $this->provider->structured($request);
+            return $this->withTelemetry(
+                startEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId): \Prism\Prism\Telemetry\Events\StructuredOutputStarted => new StructuredOutputStarted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                ),
+                endEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId, Response $response): \Prism\Prism\Telemetry\Events\StructuredOutputCompleted => new StructuredOutputCompleted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                    response: $response,
+                ),
+                execute: fn (): \Prism\Prism\Structured\Response => $this->provider->structured($request),
+            );
         } catch (RequestException $e) {
             $this->provider->handleRequestException($request->model(), $e);
         }

--- a/src/Telemetry/Contracts/SemanticMapperInterface.php
+++ b/src/Telemetry/Contracts/SemanticMapperInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Contracts;
+
+/**
+ * Interface for semantic convention mappers.
+ *
+ * Mappers convert generic Prism span attributes to specific semantic conventions
+ * like OpenInference (Phoenix/Arize) or GenAI (Langfuse).
+ */
+interface SemanticMapperInterface
+{
+    /**
+     * Map generic Prism attributes to semantic convention format.
+     *
+     * @param  string  $operation  The operation type (e.g., 'text_generation', 'tool_call')
+     * @param  array<string, mixed>  $attributes  Generic Prism attributes
+     * @return array<string, mixed> Mapped attributes in semantic convention format
+     */
+    public function map(string $operation, array $attributes): array;
+
+    /**
+     * Map events to semantic convention format.
+     *
+     * @param  array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>  $events
+     * @return array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>
+     */
+    public function mapEvents(array $events): array;
+}

--- a/src/Telemetry/Drivers/LogDriver.php
+++ b/src/Telemetry/Drivers/LogDriver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Drivers;
+
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\SpanData;
+use Throwable;
+
+/**
+ * Log telemetry driver.
+ *
+ * Logs generic Prism span attributes directly for debugging and development.
+ * Uses human-readable attribute names (not OpenInference).
+ */
+class LogDriver implements TelemetryDriver
+{
+    /**
+     * @param  string  $channel  Laravel log channel name
+     */
+    public function __construct(
+        protected string $channel = 'default'
+    ) {}
+
+    /**
+     * Log a completed span with readable attributes.
+     */
+    public function recordSpan(SpanData $span): void
+    {
+        Log::channel($this->channel)->info('Span recorded', [
+            'span_id' => $span->spanId,
+            'trace_id' => $span->traceId,
+            'parent_span_id' => $span->parentSpanId,
+            'operation' => $span->operation,
+            'start_time_nano' => $span->startTimeNano,
+            'end_time_nano' => $span->endTimeNano,
+            'duration_ms' => $span->durationMs(),
+            'attributes' => $span->attributes,
+            'events' => $span->events,
+            'has_error' => $span->hasError(),
+            'exception' => $span->exception instanceof Throwable ? [
+                'class' => $span->exception::class,
+                'message' => $span->exception->getMessage(),
+                'file' => $span->exception->getFile(),
+                'line' => $span->exception->getLine(),
+            ] : null,
+            'timestamp' => now()->toISOString(),
+        ]);
+    }
+
+    /**
+     * Shutdown (no-op for log driver - logs immediately).
+     */
+    public function shutdown(): void
+    {
+        // Log driver writes immediately, nothing to flush
+    }
+}

--- a/src/Telemetry/Drivers/NullDriver.php
+++ b/src/Telemetry/Drivers/NullDriver.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Drivers;
+
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\SpanData;
+
+/**
+ * Null telemetry driver.
+ *
+ * Discards all telemetry data. Used when telemetry is disabled.
+ */
+class NullDriver implements TelemetryDriver
+{
+    /**
+     * Record a span (no-op).
+     */
+    public function recordSpan(SpanData $span): void
+    {
+        // Intentionally empty - discards all telemetry
+    }
+
+    /**
+     * Shutdown (no-op).
+     */
+    public function shutdown(): void
+    {
+        // Nothing to flush
+    }
+}

--- a/src/Telemetry/Drivers/OtlpDriver.php
+++ b/src/Telemetry/Drivers/OtlpDriver.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Drivers;
+
+use OpenTelemetry\API\Common\Time\Clock;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\API\Trace\TraceFlags;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Otlp\ContentTypes;
+use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Contracts\SemanticMapperInterface;
+use Prism\Prism\Telemetry\Otel\PrimedIdGenerator;
+use Prism\Prism\Telemetry\Semantics\PassthroughMapper;
+use Prism\Prism\Telemetry\SpanData;
+
+class OtlpDriver implements TelemetryDriver
+{
+    protected ?TracerProvider $provider = null;
+
+    protected ?PrimedIdGenerator $idGenerator = null;
+
+    protected SemanticMapperInterface $mapper;
+
+    /** @var array<string, mixed> */
+    protected array $config;
+
+    public function __construct(protected string $driver = 'otlp')
+    {
+        $this->config = config("prism.telemetry.drivers.{$this->driver}", []);
+
+        /** @var class-string<SemanticMapperInterface> $mapperClass */
+        $mapperClass = $this->config['mapper'] ?? PassthroughMapper::class;
+        $this->mapper = new $mapperClass;
+    }
+
+    public function recordSpan(SpanData $spanData): void
+    {
+        $this->idGenerator()->primeSpanId($spanData->spanId);
+
+        if (! $spanData->parentSpanId) {
+            $this->idGenerator()->primeTraceId($spanData->traceId);
+        }
+
+        $spanBuilder = $this->provider()->getTracer('prism', '1.0.0')
+            ->spanBuilder($spanData->operation ?: 'unknown')
+            ->setSpanKind(SpanKind::KIND_INTERNAL)
+            ->setStartTimestamp($spanData->startTimeNano);
+
+        if ($spanData->parentSpanId) {
+            $spanBuilder->setParent(Context::getCurrent()->withContextValue(
+                Span::wrap(SpanContext::create($spanData->traceId, $spanData->parentSpanId, TraceFlags::SAMPLED))
+            ));
+        }
+
+        $span = $spanBuilder->startSpan();
+
+        $attributes = $spanData->attributes;
+
+        if ($tags = $this->config['tags'] ?? null) {
+            data_set($attributes, 'metadata.tags', $tags);
+        }
+
+        foreach ($this->mapper->map($spanData->operation, $attributes) as $key => $value) {
+            if ($key !== '') {
+                $span->setAttribute($key, is_array($value) ? json_encode($value) : $value);
+            }
+        }
+
+        foreach ($this->mapper->mapEvents($spanData->events) as $event) {
+            $span->addEvent($event['name'], Attributes::create($event['attributes']), $event['timeNanos']);
+        }
+
+        if ($spanData->hasError()) {
+            $span->setStatus(StatusCode::STATUS_ERROR, $spanData->exception?->getMessage() ?? 'Error');
+        }
+
+        $span->end($spanData->endTimeNano);
+    }
+
+    public function shutdown(): void
+    {
+        $this->provider?->shutdown();
+        $this->provider = null;
+        $this->idGenerator = null;
+    }
+
+    public function getDriver(): string
+    {
+        return $this->driver;
+    }
+
+    protected function provider(): TracerProvider
+    {
+        if ($this->provider instanceof \OpenTelemetry\SDK\Trace\TracerProvider) {
+            return $this->provider;
+        }
+
+        $transport = (new OtlpHttpTransportFactory)->create(
+            endpoint: $this->config['endpoint'] ?? 'http://localhost:4318/v1/traces',
+            contentType: ContentTypes::JSON,
+            headers: ($key = $this->config['api_key'] ?? null) ? ['Authorization' => "Bearer {$key}"] : [],
+            timeout: (float) ($this->config['timeout'] ?? 30.0),
+        );
+
+        return $this->provider = new TracerProvider(
+            spanProcessors: [new BatchSpanProcessor(new SpanExporter($transport), Clock::getDefault())],
+            sampler: new AlwaysOnSampler,
+            resource: ResourceInfo::create(Attributes::create(['service.name' => $this->config['service_name'] ?? 'prism'])),
+            idGenerator: $this->idGenerator(),
+        );
+    }
+
+    protected function idGenerator(): PrimedIdGenerator
+    {
+        return $this->idGenerator ??= new PrimedIdGenerator;
+    }
+}

--- a/src/Telemetry/Events/EmbeddingGenerationCompleted.php
+++ b/src/Telemetry/Events/EmbeddingGenerationCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response;
+
+/**
+ * Dispatched when embedding generation completes successfully.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The embedding request
+ * @property-read Response $response The generated embeddings response
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class EmbeddingGenerationCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        public readonly Response $response,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/EmbeddingGenerationStarted.php
+++ b/src/Telemetry/Events/EmbeddingGenerationStarted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Embeddings\Request;
+
+/**
+ * Dispatched when embedding generation begins.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The embedding request
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class EmbeddingGenerationStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/HttpCallCompleted.php
+++ b/src/Telemetry/Events/HttpCallCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Dispatched when an HTTP request to a provider completes.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read string $method HTTP method (GET, POST, etc.)
+ * @property-read string $url The request URL
+ * @property-read int $statusCode HTTP response status code
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class HttpCallCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly string $method,
+        public readonly string $url,
+        public readonly int $statusCode,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/HttpCallStarted.php
+++ b/src/Telemetry/Events/HttpCallStarted.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Dispatched when an HTTP request to a provider begins.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read string $method HTTP method (GET, POST, etc.)
+ * @property-read string $url The request URL
+ * @property-read array<string, mixed> $headers Request headers
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class HttpCallStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    /**
+     * @param  array<string, mixed>  $headers  Request headers
+     */
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly string $method,
+        public readonly string $url,
+        public readonly array $headers = [],
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/SpanException.php
+++ b/src/Telemetry/Events/SpanException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Throwable;
+
+/**
+ * Dispatched when an exception occurs during a span's execution.
+ *
+ * This allows the span collector to record the exception on the span
+ * before the exception propagates up the call stack.
+ *
+ * @property-read string $spanId The span ID where the exception occurred (16 hex chars)
+ * @property-read Throwable $exception The exception that was thrown
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class SpanException
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly Throwable $exception,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/StreamingCompleted.php
+++ b/src/Telemetry/Events/StreamingCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Streaming\Events\StreamEndEvent;
+use Prism\Prism\Text\Request;
+
+/**
+ * Dispatched when streaming text generation completes.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The streaming request
+ * @property-read StreamEndEvent|null $streamEnd The stream end event with usage/finishReason
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class StreamingCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        public readonly ?StreamEndEvent $streamEnd = null,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/StreamingStarted.php
+++ b/src/Telemetry/Events/StreamingStarted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
+use Prism\Prism\Text\Request;
+
+/**
+ * Dispatched when streaming text generation begins.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The streaming request
+ * @property-read StreamStartEvent|null $streamStart The stream start event with model/provider info
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class StreamingStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        public readonly ?StreamStartEvent $streamStart = null,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/StructuredOutputCompleted.php
+++ b/src/Telemetry/Events/StructuredOutputCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response;
+
+/**
+ * Dispatched when structured output generation completes successfully.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The structured output request
+ * @property-read Response $response The generated structured response
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class StructuredOutputCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        public readonly Response $response,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/StructuredOutputStarted.php
+++ b/src/Telemetry/Events/StructuredOutputStarted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Structured\Request;
+
+/**
+ * Dispatched when structured output generation begins.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The structured output request
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class StructuredOutputStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/TextGenerationCompleted.php
+++ b/src/Telemetry/Events/TextGenerationCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+
+/**
+ * Dispatched when text generation completes successfully.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The text generation request
+ * @property-read Response $response The generated response
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class TextGenerationCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        public readonly Response $response,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/TextGenerationStarted.php
+++ b/src/Telemetry/Events/TextGenerationStarted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\Text\Request;
+
+/**
+ * Dispatched when text generation begins.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read Request $request The text generation request
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class TextGenerationStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly Request $request,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/ToolCallCompleted.php
+++ b/src/Telemetry/Events/ToolCallCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+
+/**
+ * Dispatched when a tool call completes.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read ToolCall $toolCall The tool call that was executed
+ * @property-read ToolResult $toolResult The result of the tool execution
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class ToolCallCompleted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly ToolCall $toolCall,
+        public readonly ToolResult $toolResult,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Events/ToolCallStarted.php
+++ b/src/Telemetry/Events/ToolCallStarted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Prism\Prism\ValueObjects\ToolCall;
+
+/**
+ * Dispatched when a tool call begins execution.
+ *
+ * @property-read string $spanId Unique identifier for this span (16 hex chars)
+ * @property-read string $traceId Trace identifier linking related spans (32 hex chars)
+ * @property-read string|null $parentSpanId Parent span ID for nested operations
+ * @property-read ToolCall $toolCall The tool call being executed
+ * @property-read int $timeNanos Unix epoch timestamp in nanoseconds
+ */
+class ToolCallStarted
+{
+    use Dispatchable;
+
+    public readonly int $timeNanos;
+
+    public function __construct(
+        public readonly string $spanId,
+        public readonly string $traceId,
+        public readonly ?string $parentSpanId,
+        public readonly ToolCall $toolCall,
+        ?int $timeNanos = null,
+    ) {
+        $this->timeNanos = $timeNanos ?? now_nanos();
+    }
+}

--- a/src/Telemetry/Listeners/TelemetryEventListener.php
+++ b/src/Telemetry/Listeners/TelemetryEventListener.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Listeners;
+
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted;
+use Prism\Prism\Telemetry\Events\HttpCallCompleted;
+use Prism\Prism\Telemetry\Events\HttpCallStarted;
+use Prism\Prism\Telemetry\Events\SpanException;
+use Prism\Prism\Telemetry\Events\StreamingCompleted;
+use Prism\Prism\Telemetry\Events\StreamingStarted;
+use Prism\Prism\Telemetry\Events\StructuredOutputCompleted;
+use Prism\Prism\Telemetry\Events\StructuredOutputStarted;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Telemetry\Events\ToolCallCompleted;
+use Prism\Prism\Telemetry\Events\ToolCallStarted;
+use Prism\Prism\Telemetry\SpanCollector;
+
+class TelemetryEventListener
+{
+    public function __construct(
+        protected SpanCollector $collector
+    ) {}
+
+    public function handleTextGenerationStarted(TextGenerationStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleTextGenerationCompleted(TextGenerationCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleStructuredOutputStarted(StructuredOutputStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleStructuredOutputCompleted(StructuredOutputCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleEmbeddingGenerationStarted(EmbeddingGenerationStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleEmbeddingGenerationCompleted(EmbeddingGenerationCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleStreamingStarted(StreamingStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleStreamingCompleted(StreamingCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleHttpCallStarted(HttpCallStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleHttpCallCompleted(HttpCallCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleToolCallStarted(ToolCallStarted $event): void
+    {
+        $this->collector->startSpan($event);
+    }
+
+    public function handleToolCallCompleted(ToolCallCompleted $event): void
+    {
+        $this->collector->endSpan($event);
+    }
+
+    public function handleSpanException(SpanException $event): void
+    {
+        $this->collector->recordException($event);
+    }
+}

--- a/src/Telemetry/Otel/PrimedIdGenerator.php
+++ b/src/Telemetry/Otel/PrimedIdGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Otel;
+
+use OpenTelemetry\SDK\Trace\IdGeneratorInterface;
+use RuntimeException;
+
+/**
+ * An IdGenerator that must be "primed" with specific IDs before use.
+ *
+ * This allows the SDK's TracerProvider to use our exact IDs from SpanData
+ * rather than generating new ones.
+ */
+class PrimedIdGenerator implements IdGeneratorInterface
+{
+    /** @var list<string> */
+    private array $spanIds = [];
+
+    /** @var list<string> */
+    private array $traceIds = [];
+
+    public function primeSpanId(string $spanId): void
+    {
+        $this->spanIds[] = $spanId;
+    }
+
+    public function primeTraceId(string $traceId): void
+    {
+        $this->traceIds[] = $traceId;
+    }
+
+    public function generateSpanId(): string
+    {
+        return array_shift($this->spanIds)
+            ?? throw new RuntimeException('PrimedIdGenerator: spanId not primed. Call primeSpanId() before creating a span.');
+    }
+
+    public function generateTraceId(): string
+    {
+        return array_shift($this->traceIds)
+            ?? throw new RuntimeException('PrimedIdGenerator: traceId not primed. Call primeTraceId() before creating a root span.');
+    }
+}

--- a/src/Telemetry/Semantics/OpenInferenceMapper.php
+++ b/src/Telemetry/Semantics/OpenInferenceMapper.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Semantics;
+
+use Prism\Prism\Telemetry\Contracts\SemanticMapperInterface;
+
+/**
+ * Maps Prism span attributes to OpenInference semantic conventions.
+ *
+ * OpenInference is the semantic convention used by Phoenix/Arize for AI observability.
+ *
+ * @see https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md
+ */
+class OpenInferenceMapper implements SemanticMapperInterface
+{
+    /**
+     * Convert generic Prism attributes to OpenInference format.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    public function map(string $operation, array $attributes): array
+    {
+        $attrs = match ($operation) {
+            'text_generation', 'streaming' => $this->buildLlmSpan($attributes),
+            'tool_call' => $this->buildToolSpan($attributes),
+            'embedding_generation' => $this->buildEmbeddingSpan($attributes),
+            'structured_output' => $this->buildChainSpan($attributes),
+            'http_call' => $this->buildHttpSpan($attributes),
+            default => $this->buildChainSpan($attributes),
+        };
+
+        return $this->filterNulls($attrs);
+    }
+
+    /**
+     * Convert events to OpenInference format.
+     *
+     * @param  array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>  $events
+     * @return array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>
+     */
+    public function mapEvents(array $events): array
+    {
+        return array_map(fn (array $e): array => [
+            'name' => $e['name'],
+            'timeNanos' => $e['timeNanos'],
+            'attributes' => $e['name'] === 'exception' ? [
+                'exception.type' => $e['attributes']['type'] ?? 'Unknown',
+                'exception.message' => $e['attributes']['message'] ?? '',
+                'exception.stacktrace' => $e['attributes']['stacktrace'] ?? '',
+                'exception.escaped' => true,
+            ] : $e['attributes'],
+        ], $events);
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     * @return array<string, mixed>
+     */
+    protected function buildLlmSpan(array $a): array
+    {
+        $attrs = [
+            'openinference.span.kind' => 'LLM',
+            'llm.model_name' => $a['model'] ?? null,
+            'llm.response.model' => $a['response_model'] ?? null,
+            'llm.provider' => $a['provider'] ?? null,
+            'llm.service_tier' => $a['service_tier'] ?? null,
+            'llm.invocation_parameters' => $this->buildInvocationParams($a),
+            'llm.response.id' => $a['response_id'] ?? null,
+            'llm.tool_choice' => isset($a['tool_choice']) ? json_encode($a['tool_choice']) : null,
+            // Prompt template support (if provided)
+            'llm.prompt_template.template' => $a['prompt_template'] ?? null,
+            'llm.prompt_template.variables' => isset($a['prompt_variables']) ? json_encode($a['prompt_variables']) : null,
+        ];
+
+        $this->addSystemPrompt($attrs, $a['messages'] ?? []);
+        $this->addInputOutput($attrs, $a);
+        $this->addTokenUsage($attrs, $a['usage'] ?? null);
+        $this->addInputMessages($attrs, $a['messages'] ?? []);
+        $this->addOutputMessages($attrs, $a['output'] ?? '', $a['tool_calls'] ?? [], $a['finish_reason'] ?? null);
+        $this->addToolDefinitions($attrs, $a['tools'] ?? []);
+        $this->addMetadata($attrs, $a['metadata'] ?? []);
+
+        return $attrs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     * @return array<string, mixed>
+     */
+    protected function buildToolSpan(array $a): array
+    {
+        $tool = $a['tool'] ?? [];
+        $output = $a['output'] ?? null;
+
+        $attrs = [
+            'openinference.span.kind' => 'TOOL',
+            'tool.name' => $tool['name'] ?? null,
+            'tool.call.id' => $tool['call_id'] ?? null,
+            'tool.call.function.name' => $tool['name'] ?? null,
+            'tool.call.function.arguments' => isset($tool['arguments']) ? json_encode($tool['arguments']) : null,
+            'tool.description' => $tool['description'] ?? null,
+            'tool.parameters' => isset($tool['parameters']) ? json_encode($tool['parameters']) : null,
+            'tool.output' => is_string($output) ? $output : (isset($output) ? json_encode($output) : null),
+            'input.value' => isset($a['input']) ? json_encode($a['input']) : null,
+            'input.mime_type' => isset($a['input']) ? 'application/json' : null,
+            'output.value' => is_string($output) ? $output : (isset($output) ? json_encode($output) : null),
+            'output.mime_type' => isset($output) ? (is_string($output) ? 'text/plain' : 'application/json') : null,
+        ];
+
+        $this->addMetadata($attrs, $a['metadata'] ?? []);
+
+        return $attrs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     * @return array<string, mixed>
+     */
+    protected function buildEmbeddingSpan(array $a): array
+    {
+        $attrs = [
+            'openinference.span.kind' => 'EMBEDDING',
+            'embedding.model_name' => $a['model'] ?? null,
+            'embedding.provider' => $a['provider'] ?? null,
+        ];
+
+        // Per OpenInference spec: embedding.embeddings.{i}.embedding.text
+        foreach ($a['inputs'] ?? [] as $i => $text) {
+            $attrs["embedding.embeddings.{$i}.embedding.text"] = $text;
+        }
+
+        // Also set input.value as per spec for span-level input
+        if (! empty($a['inputs'])) {
+            $attrs['input.value'] = count($a['inputs']) === 1
+                ? $a['inputs'][0]
+                : json_encode($a['inputs']);
+            $attrs['input.mime_type'] = count($a['inputs']) === 1
+                ? 'text/plain'
+                : 'application/json';
+        }
+
+        $this->addTokenUsage($attrs, $a['usage'] ?? null);
+        $this->addMetadata($attrs, $a['metadata'] ?? []);
+
+        return $attrs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     * @return array<string, mixed>
+     */
+    protected function buildChainSpan(array $a): array
+    {
+        $attrs = [
+            'openinference.span.kind' => 'CHAIN',
+            'llm.model_name' => $a['model'] ?? null,
+            'llm.response.model' => $a['response_model'] ?? null,
+            'llm.provider' => $a['provider'] ?? null,
+            'llm.service_tier' => $a['service_tier'] ?? null,
+            'llm.response.id' => $a['response_id'] ?? null,
+            'output.schema.name' => $a['schema']['name'] ?? null,
+            'output.schema' => isset($a['schema']['definition']) ? json_encode($a['schema']['definition']) : null,
+        ];
+
+        $this->addInputOutput($attrs, $a);
+        $this->addTokenUsage($attrs, $a['usage'] ?? null);
+        $this->addInputMessages($attrs, $a['messages'] ?? []);
+        $this->addToolDefinitions($attrs, $a['tools'] ?? []);
+        $this->addMetadata($attrs, $a['metadata'] ?? []);
+
+        return $attrs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     * @return array<string, mixed>
+     */
+    protected function buildHttpSpan(array $a): array
+    {
+        $http = $a['http'] ?? [];
+
+        $attrs = [
+            'openinference.span.kind' => 'CHAIN',
+            'http.method' => $http['method'] ?? null,
+            'http.url' => $http['url'] ?? null,
+            'http.status_code' => $http['status_code'] ?? null,
+        ];
+
+        $this->addMetadata($attrs, $a['metadata'] ?? []);
+
+        return $attrs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $a
+     */
+    protected function buildInvocationParams(array $a): ?string
+    {
+        $params = $this->filterNulls([
+            'temperature' => $a['temperature'] ?? null,
+            'max_tokens' => $a['max_tokens'] ?? null,
+            'top_p' => $a['top_p'] ?? null,
+        ]);
+
+        return $params !== [] ? (json_encode($params) ?: null) : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<int, array<string, mixed>>  $messages
+     */
+    protected function addSystemPrompt(array &$attrs, array $messages): void
+    {
+        $systemContent = collect($messages)
+            ->filter(fn ($m): bool => ($m['role'] ?? '') === 'system')
+            ->pluck('content')
+            ->implode("\n");
+
+        if ($systemContent) {
+            $attrs['llm.system'] = $systemContent;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<string, mixed>  $a
+     */
+    protected function addInputOutput(array &$attrs, array $a): void
+    {
+        $input = $a['input'] ?? null;
+        $output = $a['output'] ?? null;
+
+        $attrs['input.value'] = is_string($input) ? $input : (isset($input) ? json_encode($input) : null);
+        $attrs['input.mime_type'] = isset($input) ? (is_string($input) ? 'text/plain' : 'application/json') : null;
+        $attrs['output.value'] = is_string($output) ? $output : (isset($output) ? json_encode($output) : null);
+        $attrs['output.mime_type'] = isset($output) ? (is_string($output) ? 'text/plain' : 'application/json') : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<string, mixed>|null  $usage
+     */
+    protected function addTokenUsage(array &$attrs, ?array $usage): void
+    {
+        if (! $usage) {
+            return;
+        }
+
+        $prompt = $usage['prompt_tokens'] ?? $usage['tokens'] ?? null;
+        $completion = $usage['completion_tokens'] ?? null;
+
+        $attrs['llm.token_count.prompt'] = $prompt;
+        $attrs['llm.token_count.completion'] = $completion;
+        $attrs['llm.token_count.total'] = ($prompt !== null && $completion !== null) ? $prompt + $completion : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<int, array<string, mixed>>  $messages
+     */
+    protected function addInputMessages(array &$attrs, array $messages): void
+    {
+        foreach ($messages as $i => $msg) {
+            $attrs["llm.input_messages.{$i}.message.role"] = $msg['role'];
+            $attrs["llm.input_messages.{$i}.message.content"] = $msg['content'];
+
+            foreach ($msg['tool_calls'] ?? [] as $j => $tc) {
+                $prefix = "llm.input_messages.{$i}.message.tool_calls.{$j}.tool_call";
+                $attrs["{$prefix}.id"] = $tc['id'] ?? null;
+                $attrs["{$prefix}.function.name"] = $tc['name'];
+                $attrs["{$prefix}.function.arguments"] = json_encode($tc['arguments']);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     */
+    protected function addOutputMessages(array &$attrs, string $text, array $toolCalls, ?string $finishReason = null): void
+    {
+        if (! $text && ! $toolCalls) {
+            return;
+        }
+
+        $attrs['llm.output_messages.0.message.role'] = 'assistant';
+        $attrs['llm.output_messages.0.message.content'] = $text;
+
+        // Per OpenInference spec, finish_reason goes on the output message
+        if ($finishReason !== null) {
+            $attrs['llm.output_messages.0.message.finish_reason'] = $finishReason;
+        }
+
+        foreach ($toolCalls as $i => $tc) {
+            $prefix = "llm.output_messages.0.message.tool_calls.{$i}.tool_call";
+            $attrs["{$prefix}.id"] = $tc['id'];
+            $attrs["{$prefix}.function.name"] = $tc['name'];
+            $attrs["{$prefix}.function.arguments"] = json_encode($tc['arguments']);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     * @param  array<int, array<string, mixed>>  $tools
+     */
+    protected function addToolDefinitions(array &$attrs, array $tools): void
+    {
+        foreach ($tools as $i => $tool) {
+            $attrs["llm.tools.{$i}.tool.json_schema"] = json_encode([
+                'type' => 'function',
+                'function' => [
+                    'name' => $tool['name'],
+                    'description' => $tool['description'],
+                    'parameters' => $tool['parameters'],
+                ],
+            ]);
+        }
+    }
+
+    /**
+     * Add metadata to attributes, handling special OpenInference user/session attributes.
+     *
+     * @see https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md#user-attributes
+     *
+     * @param  array<string, mixed>  $attrs
+     * @param  array<string, mixed>  $metadata
+     */
+    protected function addMetadata(array &$attrs, array $metadata): void
+    {
+        // Handle special OpenInference user attributes
+        if (isset($metadata['user_id'])) {
+            $attrs['user.id'] = (string) $metadata['user_id'];
+            unset($metadata['user_id']);
+        }
+
+        if (isset($metadata['session_id'])) {
+            $attrs['session.id'] = (string) $metadata['session_id'];
+            unset($metadata['session_id']);
+        }
+
+        // Handle agent as a reserved OpenInference attribute
+        // @see https://arize-ai.github.io/openinference/spec/semantic_conventions.html
+        if (isset($metadata['agent'])) {
+            $attrs['agent.name'] = (string) $metadata['agent'];
+            unset($metadata['agent']);
+        }
+
+        // Handle tags per OpenInference spec - tag.tags is a list of strings
+        // @see https://arize-ai.github.io/openinference/spec/semantic_conventions.html
+        if (isset($metadata['tags']) && is_array($metadata['tags'])) {
+            $tagList = [];
+            foreach ($metadata['tags'] as $tagKey => $tagValue) {
+                // Convert key-value pairs to "key:value" format
+                $tagList[] = is_int($tagKey)
+                    ? (string) $tagValue
+                    : "{$tagKey}:{$tagValue}";
+            }
+            $attrs['tag.tags'] = json_encode($tagList);
+            unset($metadata['tags']);
+        }
+
+        // Remaining metadata goes under metadata.* prefix
+        foreach ($metadata as $key => $value) {
+            $attrs["metadata.{$key}"] = is_string($value) ? $value : json_encode($value);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     * @return array<string, mixed>
+     */
+    protected function filterNulls(array $array): array
+    {
+        return array_filter($array, fn ($v): bool => $v !== null);
+    }
+}

--- a/src/Telemetry/Semantics/PassthroughMapper.php
+++ b/src/Telemetry/Semantics/PassthroughMapper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry\Semantics;
+
+use Prism\Prism\Telemetry\Contracts\SemanticMapperInterface;
+
+/**
+ * Passthrough mapper that returns attributes unchanged.
+ *
+ * Use this when sending raw Prism attributes without semantic conversion.
+ */
+class PassthroughMapper implements SemanticMapperInterface
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    public function map(string $operation, array $attributes): array
+    {
+        return $attributes;
+    }
+
+    /**
+     * @param  array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>  $events
+     * @return array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>
+     */
+    public function mapEvents(array $events): array
+    {
+        return $events;
+    }
+}

--- a/src/Telemetry/SpanCollector.php
+++ b/src/Telemetry/SpanCollector.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry;
+
+use Illuminate\Support\Facades\Context;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted;
+use Prism\Prism\Telemetry\Events\HttpCallCompleted;
+use Prism\Prism\Telemetry\Events\HttpCallStarted;
+use Prism\Prism\Telemetry\Events\SpanException;
+use Prism\Prism\Telemetry\Events\StreamingCompleted;
+use Prism\Prism\Telemetry\Events\StreamingStarted;
+use Prism\Prism\Telemetry\Events\StructuredOutputCompleted;
+use Prism\Prism\Telemetry\Events\StructuredOutputStarted;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Telemetry\Events\ToolCallCompleted;
+use Prism\Prism\Telemetry\Events\ToolCallStarted;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+/**
+ * Manages span lifecycle and extracts driver-agnostic attributes from Prism events.
+ */
+class SpanCollector
+{
+    /** @var array<string, array<string, mixed>> */
+    protected array $pendingSpans = [];
+
+    public function __construct(
+        protected TelemetryDriver $driver
+    ) {}
+
+    public function startSpan(TextGenerationStarted|StructuredOutputStarted|EmbeddingGenerationStarted|StreamingStarted|HttpCallStarted|ToolCallStarted $event): string
+    {
+        $spanId = $event->spanId;
+
+        $this->pendingSpans[$spanId] = [
+            'spanId' => $spanId,
+            'traceId' => $event->traceId,
+            'parentSpanId' => $event->parentSpanId,
+            'operation' => $this->getOperation($event),
+            'startTimeNano' => $event->timeNanos,
+            'attributes' => $this->extractStartAttributes($event),
+            'events' => [],
+            'exception' => null,
+        ];
+
+        return $spanId;
+    }
+
+    public function endSpan(TextGenerationCompleted|StructuredOutputCompleted|EmbeddingGenerationCompleted|StreamingCompleted|HttpCallCompleted|ToolCallCompleted $event): void
+    {
+        if (! isset($this->pendingSpans[$event->spanId])) {
+            return;
+        }
+
+        $pending = &$this->pendingSpans[$event->spanId];
+        $endAttrs = $this->extractEndAttributes($event);
+
+        // Deep merge metadata, shallow merge everything else
+        $startMetadata = $pending['attributes']['metadata'] ?? [];
+        $endMetadata = $endAttrs['metadata'] ?? [];
+        unset($pending['attributes']['metadata'], $endAttrs['metadata']);
+
+        $pending['attributes'] = array_merge($pending['attributes'], $endAttrs);
+
+        if ($startMetadata || $endMetadata) {
+            $pending['attributes']['metadata'] = array_merge($startMetadata, $endMetadata);
+        }
+
+        $this->driver->recordSpan(new SpanData(
+            spanId: $pending['spanId'],
+            traceId: $pending['traceId'],
+            parentSpanId: $pending['parentSpanId'],
+            operation: $pending['operation'],
+            startTimeNano: $pending['startTimeNano'],
+            endTimeNano: $event->timeNanos,
+            attributes: $this->filterNulls($pending['attributes']),
+            events: $pending['events'],
+            exception: $pending['exception'],
+        ));
+
+        unset($this->pendingSpans[$event->spanId]);
+    }
+
+    /**
+     * Shutdown the telemetry driver, flushing any buffered spans.
+     *
+     * Should be called when a Prism operation completes.
+     */
+    public function shutdown(): void
+    {
+        $this->driver->shutdown();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function addEvent(string $spanId, string $name, int $timeNanos, array $attributes = []): void
+    {
+        if (isset($this->pendingSpans[$spanId])) {
+            $this->pendingSpans[$spanId]['events'][] = [
+                'name' => $name,
+                'timeNanos' => $timeNanos,
+                'attributes' => $attributes,
+            ];
+        }
+    }
+
+    public function recordException(SpanException $event): void
+    {
+        if (isset($this->pendingSpans[$event->spanId])) {
+            $this->pendingSpans[$event->spanId]['exception'] = $event->exception;
+            $this->pendingSpans[$event->spanId]['events'][] = [
+                'name' => 'exception',
+                'timeNanos' => $event->timeNanos,
+                'attributes' => [
+                    'type' => $event->exception::class,
+                    'message' => $event->exception->getMessage(),
+                    'stacktrace' => $event->exception->getTraceAsString(),
+                ],
+            ];
+        }
+    }
+
+    // ========================================================================
+    // Operation & Attribute Extraction
+    // ========================================================================
+
+    protected function getOperation(TextGenerationStarted|StructuredOutputStarted|EmbeddingGenerationStarted|StreamingStarted|HttpCallStarted|ToolCallStarted $event): string
+    {
+        return match (true) {
+            $event instanceof TextGenerationStarted => 'text_generation',
+            $event instanceof StructuredOutputStarted => 'structured_output',
+            $event instanceof EmbeddingGenerationStarted => 'embedding_generation',
+            $event instanceof StreamingStarted => 'streaming',
+            $event instanceof HttpCallStarted => 'http_call',
+            $event instanceof ToolCallStarted => 'tool_call',
+        };
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractStartAttributes(TextGenerationStarted|StructuredOutputStarted|EmbeddingGenerationStarted|StreamingStarted|HttpCallStarted|ToolCallStarted $event): array
+    {
+        $attrs = match (true) {
+            $event instanceof TextGenerationStarted => $this->extractTextGenerationStart($event),
+            $event instanceof StructuredOutputStarted => $this->extractStructuredOutputStart($event),
+            $event instanceof EmbeddingGenerationStarted => $this->extractEmbeddingStart($event),
+            $event instanceof StreamingStarted => $this->extractStreamingStart($event),
+            $event instanceof HttpCallStarted => $this->extractHttpStart($event),
+            $event instanceof ToolCallStarted => $this->extractToolCallStart($event),
+        };
+
+        // Add user metadata from Laravel hidden Context (set by HasTelemetryContext trait)
+        $metadata = Context::getHidden('prism.telemetry.metadata');
+        if (! empty($metadata)) {
+            $attrs['metadata'] = $metadata;
+        }
+
+        return $attrs;
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractEndAttributes(TextGenerationCompleted|StructuredOutputCompleted|EmbeddingGenerationCompleted|StreamingCompleted|HttpCallCompleted|ToolCallCompleted $event): array
+    {
+        return match (true) {
+            $event instanceof TextGenerationCompleted => $this->extractTextGenerationEnd($event),
+            $event instanceof StructuredOutputCompleted => $this->extractStructuredOutputEnd($event),
+            $event instanceof EmbeddingGenerationCompleted => $this->extractEmbeddingEnd($event),
+            $event instanceof StreamingCompleted => $this->extractStreamingEnd($event),
+            $event instanceof HttpCallCompleted => ['http' => ['status_code' => $event->statusCode]],
+            $event instanceof ToolCallCompleted => $this->extractToolCallEnd($event),
+        };
+    }
+
+    // ========================================================================
+    // Start Event Extractors
+    // ========================================================================
+
+    /** @return array<string, mixed> */
+    protected function extractTextGenerationStart(TextGenerationStarted $event): array
+    {
+        $r = $event->request;
+
+        return array_merge($this->extractLlmRequestAttributes($r), [
+            'tools' => $r->tools() ? $this->buildToolDefinitions($r->tools()) : null,
+            'tool_choice' => $r->toolChoice() ? $this->formatToolChoice($r->toolChoice()) : null,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractStreamingStart(StreamingStarted $event): array
+    {
+        $attrs = $this->extractLlmRequestAttributes($event->request);
+
+        // Merge stream start data if available, capturing response model separately
+        if ($event->streamStart !== null) {
+            $startData = $event->streamStart->toArray();
+
+            // Capture response model separately (the actual model used may differ from requested)
+            if (isset($startData['model'])) {
+                $attrs['response_model'] = $startData['model'];
+                unset($startData['model']);
+            }
+
+            $attrs = array_merge($attrs, $startData);
+        }
+
+        return $attrs;
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractStructuredOutputStart(StructuredOutputStarted $event): array
+    {
+        $r = $event->request;
+
+        return array_merge($this->extractLlmRequestAttributes($r), [
+            'schema' => [
+                'name' => $r->schema()->name(),
+                'definition' => $r->schema()->toArray(),
+            ],
+            'tools' => $r->tools() ? $this->buildToolDefinitions($r->tools()) : null,
+            'tool_choice' => $r->toolChoice() ? $this->formatToolChoice($r->toolChoice()) : null,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractEmbeddingStart(EmbeddingGenerationStarted $event): array
+    {
+        $r = $event->request;
+
+        return [
+            'model' => $r->model(),
+            'provider' => $r->provider(),
+            'inputs' => $r->inputs(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractToolCallStart(ToolCallStarted $event): array
+    {
+        $tc = $event->toolCall;
+
+        return [
+            'tool' => [
+                'name' => $tc->name,
+                'call_id' => $tc->id,
+                'arguments' => $tc->arguments(),
+            ],
+            'input' => $tc->arguments(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractHttpStart(HttpCallStarted $event): array
+    {
+        return [
+            'http' => [
+                'method' => $event->method,
+                'url' => $event->url,
+            ],
+        ];
+    }
+
+    // ========================================================================
+    // End Event Extractors
+    // ========================================================================
+
+    /** @return array<string, mixed> */
+    protected function extractTextGenerationEnd(TextGenerationCompleted $event): array
+    {
+        $r = $event->response;
+
+        return [
+            'output' => $r->text,
+            'response_model' => $r->meta->model,
+            'service_tier' => $r->meta->serviceTier,
+            'usage' => [
+                'prompt_tokens' => $r->usage->promptTokens,
+                'completion_tokens' => $r->usage->completionTokens,
+            ],
+            'response_id' => $r->meta->id,
+            'finish_reason' => $r->finishReason->name,
+            'tool_calls' => $r->toolCalls ? array_map(fn (\Prism\Prism\ValueObjects\ToolCall $tc): array => [
+                'id' => $tc->id,
+                'name' => $tc->name,
+                'arguments' => $tc->arguments(),
+            ], $r->toolCalls) : null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractStructuredOutputEnd(StructuredOutputCompleted $event): array
+    {
+        $r = $event->response;
+
+        return [
+            'output' => $r->structured,
+            'response_model' => $r->meta->model,
+            'service_tier' => $r->meta->serviceTier,
+            'usage' => [
+                'prompt_tokens' => $r->usage->promptTokens,
+                'completion_tokens' => $r->usage->completionTokens,
+            ],
+            'response_id' => $r->meta->id,
+            'finish_reason' => $r->finishReason->name,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractEmbeddingEnd(EmbeddingGenerationCompleted $event): array
+    {
+        return [
+            'usage' => ['tokens' => $event->response->usage->tokens],
+            'embedding_count' => count($event->response->embeddings),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractStreamingEnd(StreamingCompleted $event): array
+    {
+        if ($event->streamEnd === null) {
+            return [];
+        }
+
+        return $event->streamEnd->toArray();
+    }
+
+    /** @return array<string, mixed> */
+    protected function extractToolCallEnd(ToolCallCompleted $event): array
+    {
+        return [
+            'output' => $event->toolResult->result,
+        ];
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    /**
+     * Extract common attributes from LLM request objects.
+     *
+     * @return array<string, mixed>
+     */
+    protected function extractLlmRequestAttributes(TextRequest|StructuredRequest $request): array
+    {
+        return [
+            'model' => $request->model(),
+            'provider' => $request->provider(),
+            'temperature' => $request->temperature(),
+            'max_tokens' => $request->maxTokens(),
+            'top_p' => $request->topP(),
+            'input' => $request->prompt(),
+            'messages' => $this->buildMessages($request->systemPrompts(), $request->messages()),
+        ];
+    }
+
+    /**
+     * @param  SystemMessage[]  $systemPrompts
+     * @param  Message[]  $messages
+     * @return array<int, array{role: string, content: string, tool_calls?: array<int, array{id: string, name: string, arguments: array<string, mixed>}>}>
+     */
+    protected function buildMessages(array $systemPrompts, array $messages): array
+    {
+        $result = [];
+
+        foreach ($systemPrompts as $prompt) {
+            $result[] = ['role' => 'system', 'content' => $prompt->content];
+        }
+
+        foreach ($messages as $message) {
+            if ($formatted = $this->formatMessage($message)) {
+                $result[] = $formatted;
+            }
+        }
+
+        return $result;
+    }
+
+    /** @return array{role: string, content: string, tool_calls?: array<int, array{id: string, name: string, arguments: array<string, mixed>}>}|null */
+    protected function formatMessage(Message $message): ?array
+    {
+        return match (true) {
+            $message instanceof UserMessage => ['role' => 'user', 'content' => $message->text()],
+            $message instanceof AssistantMessage => array_filter([
+                'role' => 'assistant',
+                'content' => $message->content,
+                'tool_calls' => $message->toolCalls ? array_map(fn (\Prism\Prism\ValueObjects\ToolCall $tc): array => [
+                    'id' => $tc->id,
+                    'name' => $tc->name,
+                    'arguments' => $tc->arguments(),
+                ], $message->toolCalls) : null,
+            ], fn ($v): bool => $v !== null),
+            $message instanceof ToolResultMessage => [
+                'role' => 'tool',
+                'content' => implode("\n", array_map(
+                    fn (\Prism\Prism\ValueObjects\ToolResult $tr): string|false => is_string($tr->result) ? $tr->result : json_encode($tr->result),
+                    $message->toolResults
+                )),
+            ],
+            $message instanceof SystemMessage => ['role' => 'system', 'content' => $message->content],
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Tool[]  $tools
+     * @return array<int, array{name: string, description: string, parameters: array{type: string, properties: array<string, mixed>, required: array<int, string>}}>
+     */
+    protected function buildToolDefinitions(array $tools): array
+    {
+        return array_map(fn (Tool $tool): array => [
+            'name' => $tool->name(),
+            'description' => $tool->description(),
+            'parameters' => [
+                'type' => 'object',
+                'properties' => $tool->parametersAsArray(),
+                'required' => $tool->requiredParameters(),
+            ],
+        ], $tools);
+    }
+
+    /** @return array{type: string, tool_name?: string} */
+    protected function formatToolChoice(string|ToolChoice $toolChoice): array
+    {
+        return is_string($toolChoice)
+            ? ['type' => 'tool', 'tool_name' => $toolChoice]
+            : ['type' => strtolower($toolChoice->name)];
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     * @return array<string, mixed>
+     */
+    protected function filterNulls(array $array): array
+    {
+        return array_filter($array, fn ($v): bool => $v !== null);
+    }
+}

--- a/src/Telemetry/SpanData.php
+++ b/src/Telemetry/SpanData.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry;
+
+/**
+ * Immutable DTO representing a complete telemetry span.
+ *
+ * Contains driver-agnostic attributes that can be converted to any
+ * telemetry format (OpenInference, OpenTelemetry gen_ai, etc.) by drivers.
+ */
+readonly class SpanData
+{
+    /**
+     * @param  string  $spanId  Unique identifier for this span
+     * @param  string  $traceId  Trace identifier linking related spans
+     * @param  string|null  $parentSpanId  Parent span ID for hierarchical traces
+     * @param  string  $operation  The operation name (e.g., text_generation, tool_call)
+     * @param  int  $startTimeNano  Start time in Unix epoch nanoseconds
+     * @param  int  $endTimeNano  End time in Unix epoch nanoseconds
+     * @param  array<string, mixed>  $attributes  Driver-agnostic span attributes
+     * @param  array<int, array{name: string, timeNanos: int, attributes: array<string, mixed>}>  $events  Mid-span events (exceptions, annotations)
+     * @param  \Throwable|null  $exception  Exception if the span failed
+     */
+    public function __construct(
+        public string $spanId,
+        public string $traceId,
+        public ?string $parentSpanId,
+        public string $operation,
+        public int $startTimeNano,
+        public int $endTimeNano,
+        public array $attributes,
+        public array $events = [],
+        public ?\Throwable $exception = null,
+    ) {}
+
+    /**
+     * Check if the span has an error.
+     */
+    public function hasError(): bool
+    {
+        return $this->exception instanceof \Throwable;
+    }
+
+    /**
+     * Get the duration in nanoseconds.
+     */
+    public function durationNano(): int
+    {
+        return $this->endTimeNano - $this->startTimeNano;
+    }
+
+    /**
+     * Get the duration in milliseconds.
+     */
+    public function durationMs(): float
+    {
+        return $this->durationNano() / 1_000_000;
+    }
+}

--- a/src/Telemetry/TelemetryManager.php
+++ b/src/Telemetry/TelemetryManager.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry;
+
+use Illuminate\Contracts\Foundation\Application;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Drivers\LogDriver;
+use Prism\Prism\Telemetry\Drivers\NullDriver;
+use Prism\Prism\Telemetry\Drivers\OtlpDriver;
+use RuntimeException;
+
+class TelemetryManager
+{
+    public function __construct(
+        protected Application $app
+    ) {}
+
+    /**
+     * Resolve a telemetry driver by name.
+     *
+     * The driver config should contain a 'driver' key specifying the actual driver type.
+     * This allows multiple named configs using the same underlying driver.
+     *
+     * @param  array<string, mixed>  $driverConfig  Optional config overrides
+     *
+     * @throws InvalidArgumentException
+     */
+    public function resolve(string $name, array $driverConfig = []): TelemetryDriver
+    {
+        $config = array_merge($this->getConfig($name), $driverConfig);
+
+        // Get the actual driver type from config (e.g., 'otlp', 'log', 'null')
+        $driverType = $config['driver'] ?? $name;
+
+        $factory = sprintf('create%sDriver', ucfirst($driverType));
+
+        if (method_exists($this, $factory)) {
+            return $this->{$factory}($name, $config);
+        }
+
+        throw new InvalidArgumentException("Telemetry driver [{$driverType}] is not supported.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    protected function createNullDriver(string $name, array $config): NullDriver
+    {
+        return new NullDriver;
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    protected function createLogDriver(string $name, array $config): LogDriver
+    {
+        return new LogDriver(
+            channel: $config['channel'] ?? 'default'
+        );
+    }
+
+    /**
+     * Generic OTLP driver - works for any OTLP-compatible backend.
+     *
+     * @param  array<string, mixed>  $config
+     *
+     * @throws RuntimeException
+     */
+    protected function createOtlpDriver(string $name, array $config): OtlpDriver
+    {
+        if (! class_exists(SpanExporter::class) || ! class_exists(TracerProvider::class)) {
+            throw new RuntimeException(
+                'OpenTelemetry SDK required for OTLP telemetry. '.
+                'Run: composer require open-telemetry/sdk open-telemetry/exporter-otlp'
+            );
+        }
+
+        return new OtlpDriver(driver: $name);
+    }
+
+    /**
+     * Custom driver - allows external packages/apps to provide their own driver.
+     *
+     * Config should include a 'via' key with a class that implements __invoke($app, $config).
+     *
+     * @param  array<string, mixed>  $config
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function createCustomDriver(string $name, array $config): TelemetryDriver
+    {
+        if (! isset($config['via'])) {
+            throw new InvalidArgumentException(
+                "Custom telemetry driver [{$name}] requires a 'via' configuration option."
+            );
+        }
+
+        $factory = $config['via'];
+
+        if (is_string($factory)) {
+            $factory = $this->app->make($factory);
+        }
+
+        return $factory($this->app, $config);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConfig(string $name): array
+    {
+        return config("prism.telemetry.drivers.{$name}", []);
+    }
+}

--- a/src/Telemetry/TelemetryServiceProvider.php
+++ b/src/Telemetry/TelemetryServiceProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Telemetry;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted;
+use Prism\Prism\Telemetry\Events\HttpCallCompleted;
+use Prism\Prism\Telemetry\Events\HttpCallStarted;
+use Prism\Prism\Telemetry\Events\SpanException;
+use Prism\Prism\Telemetry\Events\StreamingCompleted;
+use Prism\Prism\Telemetry\Events\StreamingStarted;
+use Prism\Prism\Telemetry\Events\StructuredOutputCompleted;
+use Prism\Prism\Telemetry\Events\StructuredOutputStarted;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Telemetry\Events\ToolCallCompleted;
+use Prism\Prism\Telemetry\Events\ToolCallStarted;
+use Prism\Prism\Telemetry\Listeners\TelemetryEventListener;
+
+class TelemetryServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(TelemetryManager::class);
+
+        $this->app->scoped(TelemetryDriver::class, function () {
+            $manager = $this->app->make(TelemetryManager::class);
+            $driver = config('prism.telemetry.driver', 'null');
+
+            return $manager->resolve($driver);
+        });
+
+        $this->app->scoped(SpanCollector::class, fn (): SpanCollector => new SpanCollector(
+            $this->app->make(TelemetryDriver::class)
+        ));
+
+        $this->app->scoped(TelemetryEventListener::class, fn (): TelemetryEventListener => new TelemetryEventListener(
+            $this->app->make(SpanCollector::class)
+        ));
+    }
+
+    public function boot(): void
+    {
+        if (config('prism.telemetry.enabled', false)) {
+            $this->registerEventListeners();
+        }
+    }
+
+    protected function registerEventListeners(): void
+    {
+        $listener = $this->app->make(TelemetryEventListener::class);
+
+        Event::listen(TextGenerationStarted::class, $listener->handleTextGenerationStarted(...));
+        Event::listen(TextGenerationCompleted::class, $listener->handleTextGenerationCompleted(...));
+        Event::listen(StructuredOutputStarted::class, $listener->handleStructuredOutputStarted(...));
+        Event::listen(StructuredOutputCompleted::class, $listener->handleStructuredOutputCompleted(...));
+        Event::listen(EmbeddingGenerationStarted::class, $listener->handleEmbeddingGenerationStarted(...));
+        Event::listen(EmbeddingGenerationCompleted::class, $listener->handleEmbeddingGenerationCompleted(...));
+        Event::listen(StreamingStarted::class, $listener->handleStreamingStarted(...));
+        Event::listen(StreamingCompleted::class, $listener->handleStreamingCompleted(...));
+        Event::listen(HttpCallStarted::class, $listener->handleHttpCallStarted(...));
+        Event::listen(HttpCallCompleted::class, $listener->handleHttpCallCompleted(...));
+        Event::listen(ToolCallStarted::class, $listener->handleToolCallStarted(...));
+        Event::listen(ToolCallCompleted::class, $listener->handleToolCallCompleted(...));
+        Event::listen(SpanException::class, $listener->handleSpanException(...));
+    }
+}

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -13,16 +13,24 @@ use Prism\Prism\Concerns\ConfiguresGeneration;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresTools;
+use Prism\Prism\Concerns\EmitsTelemetry;
 use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Concerns\HasProviderTools;
+use Prism\Prism\Concerns\HasTelemetryContext;
 use Prism\Prism\Concerns\HasTools;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Streaming\Adapters\BroadcastAdapter;
 use Prism\Prism\Streaming\Adapters\DataProtocolAdapter;
 use Prism\Prism\Streaming\Adapters\SSEAdapter;
+use Prism\Prism\Streaming\Events\StreamEndEvent;
 use Prism\Prism\Streaming\Events\StreamEvent;
+use Prism\Prism\Streaming\Events\StreamStartEvent;
+use Prism\Prism\Telemetry\Events\StreamingCompleted;
+use Prism\Prism\Telemetry\Events\StreamingStarted;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
 use Prism\Prism\Tool;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -34,10 +42,12 @@ class PendingRequest
     use ConfiguresModels;
     use ConfiguresProviders;
     use ConfiguresTools;
+    use EmitsTelemetry;
     use HasMessages;
     use HasPrompts;
     use HasProviderOptions;
     use HasProviderTools;
+    use HasTelemetryContext;
     use HasTools;
 
     /**
@@ -58,13 +68,30 @@ class PendingRequest
         $request = $this->toRequest();
 
         try {
-            $response = $this->provider->text($request);
+            return $this->withTelemetry(
+                startEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId): TextGenerationStarted => new TextGenerationStarted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                ),
+                endEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId, Response $response): TextGenerationCompleted => new TextGenerationCompleted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                    response: $response,
+                ),
+                execute: function () use ($request, $callback): Response {
+                    $response = $this->provider->text($request);
 
-            if ($callback !== null) {
-                $callback($this, $response);
-            }
+                    if ($callback !== null) {
+                        $callback($this, $response);
+                    }
 
-            return $response;
+                    return $response;
+                },
+            );
         } catch (RequestException $e) {
             $this->provider->handleRequestException($request->model(), $e);
         }
@@ -78,7 +105,25 @@ class PendingRequest
         $request = $this->toRequest();
 
         try {
-            yield from $this->provider->stream($request);
+            yield from $this->withStreamingTelemetry(
+                startEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId, ?StreamStartEvent $streamStart): StreamingStarted => new StreamingStarted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                    streamStart: $streamStart,
+                ),
+                endEventFactory: fn (string $spanId, string $traceId, ?string $parentSpanId, ?StreamEndEvent $streamEnd): StreamingCompleted => new StreamingCompleted(
+                    spanId: $spanId,
+                    traceId: $traceId,
+                    parentSpanId: $parentSpanId,
+                    request: $request,
+                    streamEnd: $streamEnd,
+                ),
+                execute: fn (): Generator => $this->provider->stream($request),
+                startEventType: StreamStartEvent::class,
+                endEventType: StreamEndEvent::class,
+            );
         } catch (RequestException $e) {
             $this->provider->handleRequestException($request->model(), $e);
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -16,3 +16,14 @@ if (! function_exists('prism')) {
         return App::make(Prism::class);
     }
 }
+
+if (! function_exists('now_nanos')) {
+
+    /**
+     * Get the current Unix timestamp in nanoseconds.
+     */
+    function now_nanos(): int
+    {
+        return (int) (microtime(true) * 1_000_000_000);
+    }
+}

--- a/tests/Telemetry/Drivers/LogDriverTest.php
+++ b/tests/Telemetry/Drivers/LogDriverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Telemetry\Drivers\LogDriver;
+use Prism\Prism\Telemetry\SpanData;
+
+beforeEach(function (): void {
+    // Allow any unexpected channel calls (e.g., deprecations channel)
+    Log::shouldReceive('channel')->byDefault()->andReturnSelf();
+    Log::shouldReceive('warning')->byDefault();
+});
+
+it('logs span data when recordSpan is called', function (): void {
+    Log::shouldReceive('channel')
+        ->with('test-channel')
+        ->once()
+        ->andReturnSelf();
+
+    Log::shouldReceive('info')
+        ->once()
+        ->with('Span recorded', Mockery::on(fn ($data): bool => $data['span_id'] === 'test-span-id'
+            && $data['operation'] === 'text_generation'
+            && isset($data['duration_ms'])
+            && $data['has_error'] === false
+            && isset($data['attributes'])));
+
+    $driver = new LogDriver('test-channel');
+    $spanData = createLogSpanData();
+
+    $driver->recordSpan($spanData);
+});
+
+it('logs error when span has exception', function (): void {
+    Log::shouldReceive('channel')
+        ->with('test-channel')
+        ->once()
+        ->andReturnSelf();
+
+    Log::shouldReceive('info')
+        ->once()
+        ->with('Span recorded', Mockery::on(fn ($data): bool => $data['span_id'] === 'test-span-id'
+            && $data['has_error'] === true
+            && isset($data['exception'])
+            && $data['exception']['class'] === Exception::class
+            && $data['exception']['message'] === 'Test exception'));
+
+    $driver = new LogDriver('test-channel');
+    $exception = new Exception('Test exception');
+    $spanData = createLogSpanData(exception: $exception);
+
+    $driver->recordSpan($spanData);
+});
+
+it('handles different channel configurations', function (): void {
+    Log::shouldReceive('channel')
+        ->with('default')
+        ->once()
+        ->andReturnSelf();
+
+    Log::shouldReceive('info')
+        ->once();
+
+    $defaultDriver = new LogDriver;
+    $defaultDriver->recordSpan(createLogSpanData());
+});
+
+it('logs generic attributes directly from span data', function (): void {
+    Log::shouldReceive('channel')
+        ->with('test-channel')
+        ->once()
+        ->andReturnSelf();
+
+    Log::shouldReceive('info')
+        ->once()
+        ->with('Span recorded', Mockery::on(
+            fn ($data): bool => $data['attributes']['model'] === 'gpt-4'
+            && $data['attributes']['provider'] === 'openai'
+            && $data['attributes']['usage']['prompt_tokens'] === 10));
+
+    $driver = new LogDriver('test-channel');
+    $spanData = createLogSpanData();
+
+    $driver->recordSpan($spanData);
+});
+
+function createLogSpanData(?\Throwable $exception = null): SpanData
+{
+    return new SpanData(
+        spanId: 'test-span-id',
+        traceId: bin2hex(random_bytes(16)),
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: (int) (microtime(true) * 1_000_000_000),
+        endTimeNano: (int) (microtime(true) * 1_000_000_000) + 100_000_000,
+        attributes: [
+            'model' => 'gpt-4',
+            'provider' => 'openai',
+            'temperature' => 0.7,
+            'output' => 'Hello there!',
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ],
+        events: [],
+        exception: $exception,
+    );
+}

--- a/tests/Telemetry/Drivers/NullDriverTest.php
+++ b/tests/Telemetry/Drivers/NullDriverTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Telemetry\Drivers\NullDriver;
+use Prism\Prism\Telemetry\SpanData;
+
+it('does not throw when recording a span', function (): void {
+    $driver = new NullDriver;
+    $spanData = createNullDriverSpanData();
+
+    $driver->recordSpan($spanData);
+
+    expect(true)->toBeTrue();
+});
+
+it('handles spans with exceptions gracefully', function (): void {
+    $driver = new NullDriver;
+    $spanData = createNullDriverSpanData(new Exception('Test exception'));
+
+    $driver->recordSpan($spanData);
+
+    expect(true)->toBeTrue();
+});
+
+it('handles spans with events gracefully', function (): void {
+    $driver = new NullDriver;
+
+    $spanData = new SpanData(
+        spanId: 'test-span-id',
+        traceId: bin2hex(random_bytes(16)),
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: (int) (microtime(true) * 1_000_000_000),
+        endTimeNano: (int) (microtime(true) * 1_000_000_000) + 100_000_000,
+        attributes: ['model' => 'gpt-4'],
+        events: [
+            ['name' => 'event1', 'timeNanos' => 1000, 'attributes' => []],
+            ['name' => 'event2', 'timeNanos' => 2000, 'attributes' => ['key' => 'value']],
+        ],
+    );
+
+    $driver->recordSpan($spanData);
+
+    expect(true)->toBeTrue();
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function createNullDriverSpanData(?\Throwable $exception = null): SpanData
+{
+    return new SpanData(
+        spanId: 'test-span-id',
+        traceId: bin2hex(random_bytes(16)),
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: (int) (microtime(true) * 1_000_000_000),
+        endTimeNano: (int) (microtime(true) * 1_000_000_000) + 100_000_000,
+        attributes: [
+            'model' => 'gpt-4',
+        ],
+        events: [],
+        exception: $exception,
+    );
+}

--- a/tests/Telemetry/Drivers/OtlpDriverTest.php
+++ b/tests/Telemetry/Drivers/OtlpDriverTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use Prism\Prism\Telemetry\Drivers\OtlpDriver;
+use Prism\Prism\Telemetry\Otel\PrimedIdGenerator;
+use Prism\Prism\Telemetry\SpanData;
+
+describe('ID Preservation', function (): void {
+    it('uses exact span ID from SpanData', function (): void {
+        $spanId = bin2hex(random_bytes(8));
+        $traceId = bin2hex(random_bytes(16));
+
+        $exportedSpans = [];
+        $driver = createTestableOtlpDriver(function ($spans) use (&$exportedSpans): void {
+            $exportedSpans = array_merge($exportedSpans, iterator_to_array($spans));
+        });
+
+        $driver->recordSpan(new SpanData(
+            spanId: $spanId,
+            traceId: $traceId,
+            parentSpanId: null,
+            operation: 'test_operation',
+            startTimeNano: hrtime(true),
+            endTimeNano: hrtime(true) + 1_000_000,
+            attributes: [],
+            events: [],
+        ));
+
+        $driver->shutdown();
+
+        expect($exportedSpans)->toHaveCount(1)
+            ->and($exportedSpans[0]->getSpanId())->toBe($spanId)
+            ->and($exportedSpans[0]->getTraceId())->toBe($traceId);
+    });
+
+    it('preserves parent span ID in context', function (): void {
+        $spanId = bin2hex(random_bytes(8));
+        $traceId = bin2hex(random_bytes(16));
+        $parentSpanId = bin2hex(random_bytes(8));
+
+        $exportedSpans = [];
+        $driver = createTestableOtlpDriver(function ($spans) use (&$exportedSpans): void {
+            $exportedSpans = array_merge($exportedSpans, iterator_to_array($spans));
+        });
+
+        $driver->recordSpan(new SpanData(
+            spanId: $spanId,
+            traceId: $traceId,
+            parentSpanId: $parentSpanId,
+            operation: 'child_operation',
+            startTimeNano: hrtime(true),
+            endTimeNano: hrtime(true) + 1_000_000,
+            attributes: [],
+            events: [],
+        ));
+
+        $driver->shutdown();
+
+        expect($exportedSpans[0]->getParentSpanId())->toBe($parentSpanId);
+    });
+});
+
+describe('SDK Batching', function (): void {
+    it('batches multiple spans via SDK BatchSpanProcessor', function (): void {
+        $exportCount = 0;
+        $totalSpans = 0;
+
+        $driver = createTestableOtlpDriver(function ($spans) use (&$exportCount, &$totalSpans): void {
+            $exportCount++;
+            $totalSpans += count(iterator_to_array($spans));
+        });
+
+        $driver->recordSpan(createOtlpTestSpanData());
+        $driver->recordSpan(createOtlpTestSpanData());
+        $driver->recordSpan(createOtlpTestSpanData());
+
+        $driver->shutdown();
+
+        // SDK batches spans - typically one export call
+        expect($totalSpans)->toBe(3);
+    });
+
+    it('flushes all spans on shutdown', function (): void {
+        $exportCount = 0;
+
+        $driver = createTestableOtlpDriver(function () use (&$exportCount): void {
+            $exportCount++;
+        });
+
+        $driver->recordSpan(createOtlpTestSpanData());
+        $driver->recordSpan(createOtlpTestSpanData());
+
+        $driver->shutdown();
+
+        // All spans should be exported
+        expect($exportCount)->toBe(2);
+
+        // Second shutdown should not export anything
+        $driver->shutdown();
+        expect($exportCount)->toBe(2);
+    });
+});
+
+describe('Error Handling', function (): void {
+    it('sets error status for failed spans', function (): void {
+        $exportedSpans = [];
+        $driver = createTestableOtlpDriver(function ($spans) use (&$exportedSpans): void {
+            $exportedSpans = array_merge($exportedSpans, iterator_to_array($spans));
+        });
+
+        $driver->recordSpan(new SpanData(
+            spanId: bin2hex(random_bytes(8)),
+            traceId: bin2hex(random_bytes(16)),
+            parentSpanId: null,
+            operation: 'failed_operation',
+            startTimeNano: hrtime(true),
+            endTimeNano: hrtime(true) + 1_000_000,
+            attributes: [],
+            events: [],
+            exception: new RuntimeException('Something failed'),
+        ));
+
+        $driver->shutdown();
+
+        expect($exportedSpans[0]->getStatus()->getCode())->toBe('Error')
+            ->and($exportedSpans[0]->getStatus()->getDescription())->toBe('Something failed');
+    });
+});
+
+describe('Driver Identity', function (): void {
+    it('returns configured driver name', function (): void {
+        expect((new OtlpDriver('phoenix'))->getDriver())->toBe('phoenix');
+    });
+
+    it('defaults to otlp', function (): void {
+        expect((new OtlpDriver)->getDriver())->toBe('otlp');
+    });
+});
+
+describe('Configuration', function (): void {
+    it('applies tags from config', function (): void {
+        config(['prism.telemetry.drivers.tagged' => [
+            'tags' => ['env' => 'testing'],
+            'mapper' => \Prism\Prism\Telemetry\Semantics\OpenInferenceMapper::class,
+        ]]);
+
+        $exportedSpans = [];
+        $driver = createTestableOtlpDriver(function ($spans) use (&$exportedSpans): void {
+            $exportedSpans = array_merge($exportedSpans, iterator_to_array($spans));
+        }, 'tagged');
+
+        $driver->recordSpan(createOtlpTestSpanData());
+        $driver->shutdown();
+
+        $tagsTags = $exportedSpans[0]->getAttributes()->get('tag.tags');
+        expect($tagsTags)->toContain('env:testing');
+    });
+});
+
+describe('PrimedIdGenerator Integration', function (): void {
+    it('uses PrimedIdGenerator for ID generation', function (): void {
+        $driver = new OtlpDriver('otlp');
+
+        $ref = new ReflectionMethod($driver, 'idGenerator');
+        $generator = $ref->invoke($driver);
+
+        expect($generator)->toBeInstanceOf(PrimedIdGenerator::class);
+    });
+});
+
+function createTestableOtlpDriver(callable $onExport, string $driverName = 'otlp'): OtlpDriver
+{
+    $driver = new OtlpDriver($driverName);
+
+    // Create mock exporter
+    $mockExporter = Mockery::mock(SpanExporterInterface::class);
+    $mockExporter->shouldReceive('export')
+        ->andReturnUsing(function ($spans) use ($onExport) {
+            $onExport($spans);
+
+            $future = Mockery::mock(\OpenTelemetry\SDK\Common\Future\FutureInterface::class);
+            $future->shouldReceive('await')->andReturn(true);
+
+            return $future;
+        });
+    $mockExporter->shouldReceive('shutdown')->andReturn(true);
+
+    // Create TracerProvider with mock exporter but real PrimedIdGenerator
+    $idGenerator = new PrimedIdGenerator;
+    $provider = new \OpenTelemetry\SDK\Trace\TracerProvider(
+        spanProcessors: [new \OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor($mockExporter)],
+        sampler: new \OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler,
+        resource: \OpenTelemetry\SDK\Resource\ResourceInfo::create(
+            \OpenTelemetry\SDK\Common\Attribute\Attributes::create(['service.name' => 'test'])
+        ),
+        idGenerator: $idGenerator,
+    );
+
+    // Inject via reflection
+    $providerRef = new ReflectionProperty($driver, 'provider');
+    $providerRef->setValue($driver, $provider);
+
+    $idGenRef = new ReflectionProperty($driver, 'idGenerator');
+    $idGenRef->setValue($driver, $idGenerator);
+
+    return $driver;
+}
+
+function createOtlpTestSpanData(): SpanData
+{
+    return new SpanData(
+        spanId: bin2hex(random_bytes(8)),
+        traceId: bin2hex(random_bytes(16)),
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: hrtime(true),
+        endTimeNano: hrtime(true) + 1_000_000,
+        attributes: [
+            'model' => 'gpt-4',
+            'provider' => 'openai',
+        ],
+        events: [],
+    );
+}

--- a/tests/Telemetry/EmbeddingTelemetryTest.php
+++ b/tests/Telemetry/EmbeddingTelemetryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Embeddings\Response;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationCompleted;
+use Prism\Prism\Telemetry\Events\EmbeddingGenerationStarted;
+use Prism\Prism\ValueObjects\Embedding;
+
+it('emits telemetry events for embeddings when enabled', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        embeddings: [
+            new Embedding([1.0, 2.0, 3.0]),
+        ],
+        usage: new \Prism\Prism\ValueObjects\EmbeddingsUsage(10),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::embeddings()
+        ->using('openai', 'text-embedding-ada-002')
+        ->fromInput('Test input')
+        ->asEmbeddings();
+
+    Event::assertDispatched(EmbeddingGenerationStarted::class);
+    Event::assertDispatched(EmbeddingGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('does not emit telemetry events when disabled', function (): void {
+    config(['prism.telemetry.enabled' => false]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        embeddings: [
+            new Embedding([1.0, 2.0, 3.0]),
+        ],
+        usage: new \Prism\Prism\ValueObjects\EmbeddingsUsage(10),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::embeddings()
+        ->using('openai', 'text-embedding-ada-002')
+        ->fromInput('Test input')
+        ->asEmbeddings();
+
+    Event::assertNotDispatched(EmbeddingGenerationStarted::class);
+    Event::assertNotDispatched(EmbeddingGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('includes traceId and parentSpanId in embedding telemetry events', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        embeddings: [
+            new Embedding([1.0, 2.0, 3.0]),
+        ],
+        usage: new \Prism\Prism\ValueObjects\EmbeddingsUsage(10),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    Prism::embeddings()
+        ->using('openai', 'text-embedding-ada-002')
+        ->fromInput('Test input')
+        ->asEmbeddings();
+
+    Event::assertDispatched(EmbeddingGenerationStarted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null);
+
+    Event::assertDispatched(EmbeddingGenerationCompleted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null
+        && $event->response !== null);
+});

--- a/tests/Telemetry/HttpCallTelemetryTest.php
+++ b/tests/Telemetry/HttpCallTelemetryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Concerns\InitializesClient;
+use Prism\Prism\Telemetry\Events\HttpCallCompleted;
+use Prism\Prism\Telemetry\Events\HttpCallStarted;
+
+class TelemetryMiddlewareTestClass
+{
+    use InitializesClient;
+
+    public function getMiddleware(): Closure
+    {
+        return $this->telemetryMiddleware();
+    }
+}
+
+beforeEach(function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+    Context::forgetHidden('prism.telemetry.trace_id');
+    Context::forgetHidden('prism.telemetry.current_span_id');
+});
+
+describe('successful requests', function (): void {
+    it('dispatches HttpCallStarted and HttpCallCompleted events', function (): void {
+        $promise = executeMiddleware(new FulfilledPromise(new Response(200, [], 'OK')));
+        $promise->wait();
+
+        Event::assertDispatched(HttpCallStarted::class, fn ($e): bool => $e->method === 'POST'
+                && $e->url === 'https://api.example.com/v1/test'
+                && ! empty($e->spanId)
+                && ! empty($e->traceId));
+
+        Event::assertDispatched(HttpCallCompleted::class, fn ($e): bool => $e->method === 'POST'
+                && $e->url === 'https://api.example.com/v1/test'
+                && $e->statusCode === 200);
+    });
+
+    it('resets context span id to parent after completion', function (): void {
+        $parentSpanId = 'parent-span-123';
+        Context::addHidden('prism.telemetry.trace_id', 'trace-123');
+        Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+        $promise = executeMiddleware(new FulfilledPromise(new Response(200)));
+        $promise->wait();
+
+        expect(Context::getHidden('prism.telemetry.current_span_id'))->toBe($parentSpanId);
+    });
+});
+
+describe('failed requests', function (): void {
+    it('dispatches HttpCallStarted but not HttpCallCompleted on failure', function (): void {
+        $promise = executeMiddleware(new RejectedPromise(new Exception('Connection timeout')));
+
+        try {
+            $promise->wait();
+        } catch (Exception) {
+            // Expected
+        }
+
+        Event::assertDispatched(HttpCallStarted::class);
+        Event::assertNotDispatched(HttpCallCompleted::class);
+    });
+
+    it('resets context span id to parent even on failure', function (): void {
+        $parentSpanId = 'parent-span-456';
+        Context::addHidden('prism.telemetry.trace_id', 'trace-456');
+        Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+        $promise = executeMiddleware(new RejectedPromise(new Exception('Connection failed')));
+
+        try {
+            $promise->wait();
+        } catch (Exception) {
+            // Expected
+        }
+
+        expect(Context::getHidden('prism.telemetry.current_span_id'))->toBe($parentSpanId);
+    });
+});
+
+describe('trace context', function (): void {
+    it('preserves existing trace id across http calls', function (): void {
+        $existingTraceId = 'existing-trace-id-789';
+        Context::addHidden('prism.telemetry.trace_id', $existingTraceId);
+
+        $promise = executeMiddleware(new FulfilledPromise(new Response(200)));
+        $promise->wait();
+
+        Event::assertDispatched(HttpCallStarted::class, fn ($e): bool => $e->traceId === $existingTraceId);
+        Event::assertDispatched(HttpCallCompleted::class, fn ($e): bool => $e->traceId === $existingTraceId);
+    });
+});
+
+function executeMiddleware($handlerResult, string $method = 'POST', string $url = 'https://api.example.com/v1/test')
+{
+    $testClass = new TelemetryMiddlewareTestClass;
+    $middleware = $testClass->getMiddleware();
+
+    $mockHandler = fn () => $handlerResult;
+    $wrappedHandler = $middleware($mockHandler);
+
+    return $wrappedHandler(new Request($method, $url), []);
+}

--- a/tests/Telemetry/Otel/PrimedIdGeneratorTest.php
+++ b/tests/Telemetry/Otel/PrimedIdGeneratorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Telemetry\Otel\PrimedIdGenerator;
+
+describe('PrimedIdGenerator', function (): void {
+    it('returns primed span ID', function (): void {
+        $generator = new PrimedIdGenerator;
+        $spanId = bin2hex(random_bytes(8));
+
+        $generator->primeSpanId($spanId);
+
+        expect($generator->generateSpanId())->toBe($spanId);
+    });
+
+    it('returns primed trace ID', function (): void {
+        $generator = new PrimedIdGenerator;
+        $traceId = bin2hex(random_bytes(16));
+
+        $generator->primeTraceId($traceId);
+
+        expect($generator->generateTraceId())->toBe($traceId);
+    });
+
+    it('returns multiple primed IDs in FIFO order', function (): void {
+        $generator = new PrimedIdGenerator;
+        $spanId1 = bin2hex(random_bytes(8));
+        $spanId2 = bin2hex(random_bytes(8));
+        $spanId3 = bin2hex(random_bytes(8));
+
+        $generator->primeSpanId($spanId1);
+        $generator->primeSpanId($spanId2);
+        $generator->primeSpanId($spanId3);
+
+        expect($generator->generateSpanId())->toBe($spanId1)
+            ->and($generator->generateSpanId())->toBe($spanId2)
+            ->and($generator->generateSpanId())->toBe($spanId3);
+    });
+
+    it('throws when span ID not primed', function (): void {
+        $generator = new PrimedIdGenerator;
+
+        expect(fn (): string => $generator->generateSpanId())
+            ->toThrow(RuntimeException::class, 'spanId not primed');
+    });
+
+    it('throws when trace ID not primed', function (): void {
+        $generator = new PrimedIdGenerator;
+
+        expect(fn (): string => $generator->generateTraceId())
+            ->toThrow(RuntimeException::class, 'traceId not primed');
+    });
+
+    it('throws after primed IDs exhausted', function (): void {
+        $generator = new PrimedIdGenerator;
+        $spanId = bin2hex(random_bytes(8));
+
+        $generator->primeSpanId($spanId);
+        $generator->generateSpanId(); // Consumes the primed ID
+
+        expect(fn (): string => $generator->generateSpanId())
+            ->toThrow(RuntimeException::class);
+    });
+});

--- a/tests/Telemetry/Semantics/OpenInferenceMapperTest.php
+++ b/tests/Telemetry/Semantics/OpenInferenceMapperTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Telemetry\Semantics\OpenInferenceMapper;
+
+it('maps text generation span to LLM kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'provider' => 'openai',
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('LLM');
+    expect($attrs['llm.model_name'])->toBe('gpt-4');
+    expect($attrs['llm.provider'])->toBe('openai');
+});
+
+it('maps streaming span to LLM kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('streaming', [
+        'model' => 'gpt-4-turbo',
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('LLM');
+    expect($attrs['llm.model_name'])->toBe('gpt-4-turbo');
+});
+
+it('maps tool_call span to TOOL kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('tool_call', [
+        'tool' => [
+            'name' => 'search',
+            'call_id' => 'call_123',
+            'arguments' => ['query' => 'test'],
+            'description' => 'Search the web',
+            'parameters' => ['type' => 'object'],
+        ],
+        'output' => 'Search results',
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('TOOL');
+    expect($attrs['tool.name'])->toBe('search');
+    expect($attrs['tool.call.id'])->toBe('call_123');
+    expect($attrs['tool.output'])->toBe('Search results');
+    expect($attrs['tool.description'])->toBe('Search the web');
+});
+
+it('maps embedding_generation span to EMBEDDING kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('embedding_generation', [
+        'model' => 'text-embedding-ada-002',
+        'inputs' => ['Hello world', 'Test input'],
+        'usage' => ['tokens' => 10],
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('EMBEDDING');
+    expect($attrs['embedding.model_name'])->toBe('text-embedding-ada-002');
+    expect($attrs['embedding.embeddings.0.embedding.text'])->toBe('Hello world');
+    expect($attrs['embedding.embeddings.1.embedding.text'])->toBe('Test input');
+});
+
+it('maps structured_output span to CHAIN kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('structured_output', [
+        'model' => 'gpt-4',
+        'schema' => [
+            'name' => 'UserProfile',
+            'definition' => ['type' => 'object'],
+        ],
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('CHAIN');
+    expect($attrs['output.schema.name'])->toBe('UserProfile');
+});
+
+it('maps http_call span correctly', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('http_call', [
+        'http' => [
+            'method' => 'POST',
+            'url' => 'https://api.openai.com/v1/chat/completions',
+            'status_code' => 200,
+        ],
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('CHAIN');
+    expect($attrs['http.method'])->toBe('POST');
+    expect($attrs['http.url'])->toBe('https://api.openai.com/v1/chat/completions');
+    expect($attrs['http.status_code'])->toBe(200);
+});
+
+it('converts token usage correctly', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'usage' => [
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+        ],
+    ]);
+
+    expect($attrs['llm.token_count.prompt'])->toBe(100);
+    expect($attrs['llm.token_count.completion'])->toBe(50);
+    expect($attrs['llm.token_count.total'])->toBe(150);
+});
+
+it('converts invocation parameters to JSON', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'temperature' => 0.7,
+        'max_tokens' => 100,
+        'top_p' => 0.9,
+    ]);
+
+    expect($attrs)->toHaveKey('llm.invocation_parameters');
+
+    $params = json_decode((string) $attrs['llm.invocation_parameters'], true);
+    expect($params['temperature'])->toBe(0.7);
+    expect($params['max_tokens'])->toBe(100);
+    expect($params['top_p'])->toBe(0.9);
+});
+
+it('extracts system prompt from messages', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'messages' => [
+            ['role' => 'system', 'content' => 'You are a helpful assistant.'],
+            ['role' => 'user', 'content' => 'Hello'],
+        ],
+    ]);
+
+    expect($attrs['llm.system'])->toBe('You are a helpful assistant.');
+});
+
+it('formats input messages correctly', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hello'],
+            ['role' => 'assistant', 'content' => 'Hi there!'],
+        ],
+    ]);
+
+    expect($attrs['llm.input_messages.0.message.role'])->toBe('user');
+    expect($attrs['llm.input_messages.0.message.content'])->toBe('Hello');
+    expect($attrs['llm.input_messages.1.message.role'])->toBe('assistant');
+    expect($attrs['llm.input_messages.1.message.content'])->toBe('Hi there!');
+});
+
+it('formats output messages correctly', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'output' => 'Hello there!',
+        'tool_calls' => [
+            ['id' => 'call_1', 'name' => 'search', 'arguments' => ['q' => 'test']],
+        ],
+    ]);
+
+    expect($attrs['llm.output_messages.0.message.role'])->toBe('assistant');
+    expect($attrs['llm.output_messages.0.message.content'])->toBe('Hello there!');
+    expect($attrs['llm.output_messages.0.message.tool_calls.0.tool_call.id'])->toBe('call_1');
+});
+
+it('maps user and session attributes to OpenInference format', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'metadata' => [
+            'user_id' => 'user_123',
+            'session_id' => 'session_456',
+        ],
+    ]);
+
+    // OpenInference uses user.id and session.id for user tracking
+    expect($attrs['user.id'])->toBe('user_123');
+    expect($attrs['session.id'])->toBe('session_456');
+});
+
+it('maps agent to agent.name per OpenInference spec', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'metadata' => [
+            'agent' => 'support-bot',
+        ],
+    ]);
+
+    // Agent is a reserved OpenInference attribute
+    // @see https://arize-ai.github.io/openinference/spec/semantic_conventions.html
+    expect($attrs['agent.name'])->toBe('support-bot');
+    expect($attrs)->not->toHaveKey('tag.agent'); // Not a spec attribute
+});
+
+it('formats general metadata with prefix', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'metadata' => [
+            'custom_key' => 'custom_value',
+            'user_email' => 'test@example.com',
+        ],
+    ]);
+
+    // General metadata goes under metadata.* prefix
+    expect($attrs['metadata.custom_key'])->toBe('custom_value');
+    expect($attrs['metadata.user_email'])->toBe('test@example.com');
+});
+
+it('maps tags to OpenInference tag.tags list format', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'metadata' => [
+            'tags' => [
+                'environment' => 'production',
+                'app' => 'my-app',
+            ],
+        ],
+    ]);
+
+    // Per OpenInference spec, tag.tags is a list of strings
+    // Key-value pairs are converted to "key:value" format
+    // @see https://arize-ai.github.io/openinference/spec/semantic_conventions.html
+    expect($attrs['tag.tags'])->toBe('["environment:production","app:my-app"]');
+});
+
+it('supports simple string tags in tag.tags list', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        'metadata' => [
+            'tags' => ['shopping', 'travel'],
+        ],
+    ]);
+
+    // Simple string tags (integer keys) are passed through
+    expect($attrs['tag.tags'])->toBe('["shopping","travel"]');
+});
+
+it('maps exception events correctly', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $events = [
+        [
+            'name' => 'exception',
+            'timeNanos' => 1000000000,
+            'attributes' => [
+                'type' => 'RuntimeException',
+                'message' => 'Test error',
+            ],
+        ],
+    ];
+
+    $mappedEvents = $mapper->mapEvents($events);
+
+    expect($mappedEvents[0]['attributes']['exception.type'])->toBe('RuntimeException');
+    expect($mappedEvents[0]['attributes']['exception.message'])->toBe('Test error');
+    expect($mappedEvents[0]['attributes']['exception.escaped'])->toBeTrue();
+});
+
+it('filters null values from attributes', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('text_generation', [
+        'model' => 'gpt-4',
+        // No usage provided - should not appear in output
+    ]);
+
+    expect($attrs)->not->toHaveKey('llm.token_count.prompt');
+    expect($attrs)->not->toHaveKey('llm.token_count.completion');
+    expect($attrs)->not->toHaveKey('llm.token_count.total');
+});
+
+it('maps unknown operation to CHAIN kind', function (): void {
+    $mapper = new OpenInferenceMapper;
+
+    $attrs = $mapper->map('unknown_operation', [
+        'model' => 'gpt-4',
+    ]);
+
+    expect($attrs['openinference.span.kind'])->toBe('CHAIN');
+});

--- a/tests/Telemetry/Semantics/PassthroughMapperTest.php
+++ b/tests/Telemetry/Semantics/PassthroughMapperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Telemetry\Contracts\SemanticMapperInterface;
+use Prism\Prism\Telemetry\Semantics\PassthroughMapper;
+
+it('implements SemanticMapperInterface', function (): void {
+    $mapper = new PassthroughMapper;
+
+    expect($mapper)->toBeInstanceOf(SemanticMapperInterface::class);
+});
+
+it('returns attributes unchanged', function (): void {
+    $mapper = new PassthroughMapper;
+
+    $attributes = [
+        'model' => 'gpt-4',
+        'provider' => 'openai',
+        'temperature' => 0.7,
+        'custom_field' => 'custom_value',
+    ];
+
+    $result = $mapper->map('text_generation', $attributes);
+
+    expect($result)->toBe($attributes);
+});
+
+it('returns events unchanged', function (): void {
+    $mapper = new PassthroughMapper;
+
+    $events = [
+        [
+            'name' => 'test_event',
+            'timeNanos' => 1000000000,
+            'attributes' => ['key' => 'value'],
+        ],
+    ];
+
+    $result = $mapper->mapEvents($events);
+
+    expect($result)->toBe($events);
+});
+
+it('handles empty attributes', function (): void {
+    $mapper = new PassthroughMapper;
+
+    $result = $mapper->map('text_generation', []);
+
+    expect($result)->toBe([]);
+});
+
+it('handles empty events', function (): void {
+    $mapper = new PassthroughMapper;
+
+    $result = $mapper->mapEvents([]);
+
+    expect($result)->toBe([]);
+});

--- a/tests/Telemetry/SpanCollectorTest.php
+++ b/tests/Telemetry/SpanCollectorTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Context;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Telemetry\Events\SpanException;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Telemetry\SpanCollector;
+use Prism\Prism\Telemetry\SpanData;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+
+describe('span lifecycle', function (): void {
+    it('returns span id when starting a span', function (): void {
+        $driver = Mockery::mock(TelemetryDriver::class);
+        $driver->shouldReceive('recordSpan')->never();
+
+        $collector = new SpanCollector($driver);
+        $spanId = $collector->startSpan(createCollectorMockStartEvent('my-span-123'));
+
+        expect($spanId)->toBe('my-span-123');
+    });
+
+    it('sends span data to driver when span ends', function (): void {
+        $capturedSpan = captureSpan();
+
+        expect($capturedSpan)->toBeInstanceOf(SpanData::class)
+            ->and($capturedSpan->spanId)->toBe('test-span-id')
+            ->and($capturedSpan->operation)->toBe('text_generation')
+            ->and($capturedSpan->attributes)->toBeArray()
+            ->and($capturedSpan->hasError())->toBeFalse();
+    });
+
+    it('calculates span duration correctly', function (): void {
+        $capturedSpan = null;
+        $driver = mockDriver($capturedSpan);
+        $collector = new SpanCollector($driver);
+
+        $collector->startSpan(createCollectorMockStartEvent('test-span-id'));
+        usleep(1000); // 1ms delay
+        $collector->endSpan(createCollectorMockEndEvent('test-span-id'));
+
+        expect($capturedSpan->durationNano())->toBeGreaterThan(0)
+            ->and($capturedSpan->startTimeNano)->toBeLessThan($capturedSpan->endTimeNano);
+    });
+});
+
+describe('attribute extraction', function (): void {
+    it('extracts model attributes from start event', function (): void {
+        $capturedSpan = captureSpan();
+
+        expect($capturedSpan->attributes['model'])->toBe('gpt-4')
+            ->and($capturedSpan->attributes['provider'])->toBe('openai')
+            ->and($capturedSpan->attributes['temperature'])->toBe(0.7)
+            ->and($capturedSpan->attributes['max_tokens'])->toBe(100);
+    });
+
+    it('extracts token usage from end event', function (): void {
+        $capturedSpan = captureSpan();
+
+        expect($capturedSpan->attributes['usage'])->toBeArray()
+            ->and($capturedSpan->attributes['usage']['prompt_tokens'])->toBe(10)
+            ->and($capturedSpan->attributes['usage']['completion_tokens'])->toBe(5);
+    });
+
+    it('extracts output and messages from end event', function (): void {
+        $capturedSpan = captureSpan();
+
+        expect($capturedSpan->attributes['output'])->toBe('Hello there!')
+            ->and($capturedSpan->attributes['messages'])->toBeArray();
+    });
+
+    it('includes operation in span data', function (): void {
+        $capturedSpan = captureSpan();
+
+        expect($capturedSpan->operation)->toBe('text_generation');
+    });
+});
+
+describe('trace context', function (): void {
+    it('uses trace id from event', function (): void {
+        $capturedSpan = captureSpan('test-span-id', 'custom-trace-id-from-event');
+
+        expect($capturedSpan->traceId)->toBe('custom-trace-id-from-event');
+    });
+
+    it('uses parent span id from event', function (): void {
+        $capturedSpan = captureSpan('child-span', 'trace-123', 'parent-span-123');
+
+        expect($capturedSpan->parentSpanId)->toBe('parent-span-123');
+    });
+
+    it('adds context metadata from Laravel hidden Context', function (): void {
+        Context::addHidden('prism.telemetry.metadata', ['user_id' => '123', 'session' => 'abc']);
+
+        $capturedSpan = captureSpan('test-span-id', 'trace-id');
+
+        expect($capturedSpan->attributes['metadata']['user_id'])->toBe('123')
+            ->and($capturedSpan->attributes['metadata']['session'])->toBe('abc');
+
+        Context::forgetHidden('prism.telemetry.metadata');
+    });
+});
+
+describe('span events', function (): void {
+    it('adds events to pending spans', function (): void {
+        $capturedSpan = null;
+        $driver = mockDriver($capturedSpan);
+        $collector = new SpanCollector($driver);
+
+        $collector->startSpan(createCollectorMockStartEvent('test-span-id'));
+        $collector->addEvent('test-span-id', 'token_generated', now_nanos(), ['token_count' => 10]);
+        $collector->addEvent('test-span-id', 'chunk_received', now_nanos());
+        $collector->endSpan(createCollectorMockEndEvent('test-span-id'));
+
+        expect($capturedSpan->events)->toHaveCount(2)
+            ->and($capturedSpan->events[0]['name'])->toBe('token_generated')
+            ->and($capturedSpan->events[0]['attributes'])->toBe(['token_count' => 10])
+            ->and($capturedSpan->events[1]['name'])->toBe('chunk_received');
+    });
+
+    it('ignores events for unknown span id', function (): void {
+        $driver = Mockery::mock(TelemetryDriver::class)->shouldIgnoreMissing();
+        $collector = new SpanCollector($driver);
+
+        $collector->addEvent('unknown-span-id', 'event', now_nanos(), ['key' => 'value']);
+
+        expect(true)->toBeTrue();
+    });
+});
+
+describe('exception handling', function (): void {
+    it('records exceptions on spans', function (): void {
+        $capturedSpan = null;
+        $driver = mockDriver($capturedSpan);
+        $collector = new SpanCollector($driver);
+        $exception = new Exception('Test error');
+
+        $collector->startSpan(createCollectorMockStartEvent('test-span-id'));
+        $collector->recordException(new SpanException('test-span-id', $exception));
+        $collector->endSpan(createCollectorMockEndEvent('test-span-id'));
+
+        expect($capturedSpan->hasError())->toBeTrue()
+            ->and($capturedSpan->exception)->toBe($exception)
+            ->and($capturedSpan->events)->toHaveCount(1)
+            ->and($capturedSpan->events[0]['name'])->toBe('exception')
+            ->and($capturedSpan->events[0]['attributes']['type'])->toBe(Exception::class);
+    });
+
+    it('ignores exceptions for unknown span id', function (): void {
+        $driver = Mockery::mock(TelemetryDriver::class)->shouldIgnoreMissing();
+        $collector = new SpanCollector($driver);
+
+        $collector->recordException(new SpanException('unknown-span-id', new Exception('Test error')));
+
+        expect(true)->toBeTrue();
+    });
+});
+
+describe('edge cases', function (): void {
+    it('does not dispatch for unknown span id', function (): void {
+        $driver = Mockery::mock(TelemetryDriver::class);
+        $driver->shouldReceive('recordSpan')->never();
+
+        $collector = new SpanCollector($driver);
+        $collector->endSpan(createCollectorMockEndEvent('unknown-span-id'));
+
+        expect(true)->toBeTrue();
+    });
+
+    it('tracks multiple spans with different ids', function (): void {
+        $capturedSpans = [];
+        $driver = Mockery::mock(TelemetryDriver::class);
+        $driver->shouldReceive('recordSpan')
+            ->twice()
+            ->with(Mockery::on(function ($span) use (&$capturedSpans): bool {
+                $capturedSpans[] = $span;
+
+                return $span instanceof SpanData;
+            }));
+
+        $collector = new SpanCollector($driver);
+        $traceId = 'shared-trace-id';
+
+        $collector->startSpan(createCollectorMockStartEvent('span-1', $traceId));
+        $collector->startSpan(createCollectorMockStartEvent('span-2', $traceId));
+        $collector->endSpan(createCollectorMockEndEvent('span-1', $traceId));
+        $collector->endSpan(createCollectorMockEndEvent('span-2', $traceId));
+
+        expect($capturedSpans)->toHaveCount(2)
+            ->and($capturedSpans[0]->spanId)->toBe('span-1')
+            ->and($capturedSpans[1]->spanId)->toBe('span-2');
+    });
+});
+
+function mockDriver(?SpanData &$capturedSpan): TelemetryDriver
+{
+    $driver = Mockery::mock(TelemetryDriver::class);
+    $driver->shouldReceive('recordSpan')
+        ->once()
+        ->with(Mockery::on(function ($span) use (&$capturedSpan): bool {
+            $capturedSpan = $span;
+
+            return $span instanceof SpanData;
+        }));
+
+    return $driver;
+}
+
+function captureSpan(
+    string $spanId = 'test-span-id',
+    string $traceId = 'test-trace-id',
+    ?string $parentSpanId = null
+): SpanData {
+    $capturedSpan = null;
+    $driver = mockDriver($capturedSpan);
+    $collector = new SpanCollector($driver);
+
+    $collector->startSpan(createCollectorMockStartEvent($spanId, $traceId, $parentSpanId));
+    $collector->endSpan(createCollectorMockEndEvent($spanId, $traceId, $parentSpanId));
+
+    return $capturedSpan;
+}
+
+function createCollectorMockStartEvent(
+    string $spanId = 'test-span-id',
+    string $traceId = 'test-trace-id',
+    ?string $parentSpanId = null
+): TextGenerationStarted {
+    return new TextGenerationStarted(
+        spanId: $spanId,
+        traceId: $traceId,
+        parentSpanId: $parentSpanId,
+        request: new Request(
+            model: 'gpt-4',
+            providerKey: 'openai',
+            systemPrompts: [],
+            prompt: 'Hello',
+            messages: [],
+            maxSteps: 1,
+            maxTokens: 100,
+            temperature: 0.7,
+            topP: 1.0,
+            tools: [],
+            clientOptions: [],
+            clientRetry: [3],
+            toolChoice: null,
+        ),
+    );
+}
+
+function createCollectorMockEndEvent(
+    string $spanId = 'test-span-id',
+    string $traceId = 'test-trace-id',
+    ?string $parentSpanId = null
+): TextGenerationCompleted {
+    return new TextGenerationCompleted(
+        spanId: $spanId,
+        traceId: $traceId,
+        parentSpanId: $parentSpanId,
+        request: new Request(
+            model: 'gpt-4',
+            providerKey: 'openai',
+            systemPrompts: [],
+            prompt: 'Hello',
+            messages: [],
+            maxSteps: 1,
+            maxTokens: 100,
+            temperature: 0.7,
+            topP: 1.0,
+            tools: [],
+            clientOptions: [],
+            clientRetry: [3],
+            toolChoice: null,
+        ),
+        response: new Response(
+            steps: new Collection,
+            text: 'Hello there!',
+            finishReason: FinishReason::Stop,
+            toolCalls: [],
+            toolResults: [],
+            usage: new Usage(10, 5),
+            meta: new Meta(id: 'resp-123', model: 'gpt-4'),
+            messages: new Collection,
+        ),
+    );
+}

--- a/tests/Telemetry/SpanDataTest.php
+++ b/tests/Telemetry/SpanDataTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Telemetry\SpanData;
+
+it('creates immutable span data with all properties', function (): void {
+    $spanData = new SpanData(
+        spanId: 'span-123',
+        traceId: 'trace-456',
+        parentSpanId: 'parent-789',
+        operation: 'text_generation',
+        startTimeNano: 1000000000,
+        endTimeNano: 2000000000,
+        attributes: ['model' => 'gpt-4'],
+        events: [['name' => 'event1', 'timeNanos' => 1500000000, 'attributes' => []]],
+    );
+
+    expect($spanData->spanId)->toBe('span-123')
+        ->and($spanData->traceId)->toBe('trace-456')
+        ->and($spanData->parentSpanId)->toBe('parent-789')
+        ->and($spanData->operation)->toBe('text_generation')
+        ->and($spanData->startTimeNano)->toBe(1000000000)
+        ->and($spanData->endTimeNano)->toBe(2000000000)
+        ->and($spanData->attributes)->toBe(['model' => 'gpt-4'])
+        ->and($spanData->events)->toHaveCount(1)
+        ->and($spanData->exception)->toBeNull();
+});
+
+it('uses sensible defaults for optional parameters', function (): void {
+    $spanData = new SpanData(
+        spanId: 'span-123',
+        traceId: 'trace-456',
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: 1000000000,
+        endTimeNano: 2000000000,
+        attributes: [],
+    );
+
+    expect($spanData->parentSpanId)->toBeNull()
+        ->and($spanData->events)->toBe([])
+        ->and($spanData->exception)->toBeNull();
+});
+
+describe('hasError', function (): void {
+    it('returns false when exception is null', function (): void {
+        $spanData = createSpanDataWithException(null);
+
+        expect($spanData->hasError())->toBeFalse();
+    });
+
+    it('returns true when exception is present', function (): void {
+        $spanData = createSpanDataWithException(new RuntimeException('Test error'));
+
+        expect($spanData->hasError())->toBeTrue();
+    });
+
+    it('returns true for any Throwable type', function (): void {
+        $spanData = createSpanDataWithException(new Error('Fatal error'));
+
+        expect($spanData->hasError())->toBeTrue();
+    });
+});
+
+describe('durationNano', function (): void {
+    it('calculates duration in nanoseconds', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 2500000000);
+
+        expect($spanData->durationNano())->toBe(1500000000);
+    });
+
+    it('returns zero for same start and end time', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 1000000000);
+
+        expect($spanData->durationNano())->toBe(0);
+    });
+
+    it('handles very small durations (1 nanosecond)', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 1000000001);
+
+        expect($spanData->durationNano())->toBe(1);
+    });
+});
+
+describe('durationMs', function (): void {
+    it('calculates duration in milliseconds', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 2500000000);
+
+        expect($spanData->durationMs())->toBe(1500.0);
+    });
+
+    it('returns float for sub-millisecond precision', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 1000500000);
+
+        expect($spanData->durationMs())->toBe(0.5);
+    });
+
+    it('returns zero for same start and end time', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 1000000000);
+
+        expect($spanData->durationMs())->toBe(0.0);
+    });
+});
+
+describe('attributes', function (): void {
+    it('supports nested arrays and complex structures', function (): void {
+        $spanData = new SpanData(
+            spanId: 'span-123',
+            traceId: 'trace-456',
+            parentSpanId: null,
+            operation: 'text_generation',
+            startTimeNano: 1000000000,
+            endTimeNano: 2000000000,
+            attributes: [
+                'model' => 'gpt-4',
+                'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 20],
+                'messages' => [
+                    ['role' => 'user', 'content' => 'Hello'],
+                    ['role' => 'assistant', 'content' => 'Hi there!'],
+                ],
+            ],
+        );
+
+        expect($spanData->attributes['usage']['prompt_tokens'])->toBe(10)
+            ->and($spanData->attributes['messages'])->toHaveCount(2);
+    });
+
+    it('supports empty attributes', function (): void {
+        $spanData = createSpanDataWithTimes(1000000000, 2000000000);
+
+        expect($spanData->attributes)->toBe([]);
+    });
+});
+
+describe('events', function (): void {
+    it('supports multiple events and preserves order', function (): void {
+        $spanData = new SpanData(
+            spanId: 'span-123',
+            traceId: 'trace-456',
+            parentSpanId: null,
+            operation: 'text_generation',
+            startTimeNano: 1000000000,
+            endTimeNano: 2000000000,
+            attributes: [],
+            events: [
+                ['name' => 'first', 'timeNanos' => 1100000000, 'attributes' => ['size' => 10]],
+                ['name' => 'second', 'timeNanos' => 1200000000, 'attributes' => ['size' => 15]],
+                ['name' => 'third', 'timeNanos' => 1300000000, 'attributes' => []],
+            ],
+        );
+
+        expect($spanData->events)->toHaveCount(3)
+            ->and($spanData->events[0]['name'])->toBe('first')
+            ->and($spanData->events[1]['name'])->toBe('second')
+            ->and($spanData->events[2]['name'])->toBe('third');
+    });
+});
+
+function createSpanDataWithException(?Throwable $exception): SpanData
+{
+    return new SpanData(
+        spanId: 'span-123',
+        traceId: 'trace-456',
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: 1000000000,
+        endTimeNano: 2000000000,
+        attributes: [],
+        exception: $exception,
+    );
+}
+
+function createSpanDataWithTimes(int $startTimeNano, int $endTimeNano): SpanData
+{
+    return new SpanData(
+        spanId: 'span-123',
+        traceId: 'trace-456',
+        parentSpanId: null,
+        operation: 'text_generation',
+        startTimeNano: $startTimeNano,
+        endTimeNano: $endTimeNano,
+        attributes: [],
+    );
+}

--- a/tests/Telemetry/StreamingTelemetryTest.php
+++ b/tests/Telemetry/StreamingTelemetryTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Events\StreamingCompleted;
+use Prism\Prism\Telemetry\Events\StreamingStarted;
+use Prism\Prism\Telemetry\Listeners\TelemetryEventListener;
+use Prism\Prism\Telemetry\SpanCollector;
+use Prism\Prism\Telemetry\SpanData;
+use Prism\Prism\Text\Request;
+
+beforeEach(function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+    Context::forgetHidden('prism.telemetry.trace_id');
+    Context::forgetHidden('prism.telemetry.current_span_id');
+    Context::forgetHidden('prism.telemetry.metadata');
+});
+
+describe('event dispatch', function (): void {
+    it('creates StreamingStarted event with correct properties', function (): void {
+        $request = createStreamingRequest();
+        $event = new StreamingStarted(
+            spanId: 'stream-span-123',
+            traceId: 'stream-trace-123',
+            parentSpanId: null,
+            request: $request,
+        );
+
+        expect($event->spanId)->toBe('stream-span-123')
+            ->and($event->traceId)->toBe('stream-trace-123')
+            ->and($event->request)->toBe($request)
+            ->and($event->streamStart)->toBeNull();
+    });
+
+    it('creates StreamingCompleted event with correct properties', function (): void {
+        $request = createStreamingRequest();
+        $event = new StreamingCompleted(
+            spanId: 'stream-span-123',
+            traceId: 'stream-trace-123',
+            parentSpanId: null,
+            request: $request,
+        );
+
+        expect($event->spanId)->toBe('stream-span-123')
+            ->and($event->request)->toBe($request)
+            ->and($event->streamEnd)->toBeNull();
+    });
+});
+
+describe('SpanCollector', function (): void {
+    it('extracts streaming attributes and sets correct operation', function (): void {
+        $capturedSpan = captureSpanFromCollector();
+
+        expect($capturedSpan)->toBeInstanceOf(SpanData::class)
+            ->and($capturedSpan->operation)->toBe('streaming')
+            ->and($capturedSpan->attributes)->toHaveKey('model')
+            ->and($capturedSpan->attributes['model'])->toBe('gpt-4');
+    });
+
+    it('maintains trace context from events', function (): void {
+        $capturedSpan = captureSpanFromCollector(
+            spanId: 'child-stream-span',
+            traceId: 'parent-trace-id',
+            parentSpanId: 'parent-span-id'
+        );
+
+        expect($capturedSpan->traceId)->toBe('parent-trace-id')
+            ->and($capturedSpan->parentSpanId)->toBe('parent-span-id');
+    });
+
+    it('preserves telemetry context metadata', function (): void {
+        Context::addHidden('prism.telemetry.metadata', [
+            'user_id' => 'stream-user-123',
+            'session_id' => 'stream-session-456',
+        ]);
+
+        $capturedSpan = captureSpanFromCollector();
+
+        expect($capturedSpan->attributes)->toHaveKey('metadata')
+            ->and($capturedSpan->attributes['metadata']['user_id'])->toBe('stream-user-123')
+            ->and($capturedSpan->attributes['metadata']['session_id'])->toBe('stream-session-456');
+
+        Context::forgetHidden('prism.telemetry.metadata');
+    });
+});
+
+describe('TelemetryEventListener', function (): void {
+    it('routes streaming events through collector', function (): void {
+        $capturedSpan = null;
+        $driver = createStreamingMockDriver($capturedSpan);
+        $collector = new SpanCollector($driver);
+        $listener = new TelemetryEventListener($collector);
+
+        $request = createStreamingRequest();
+
+        $listener->handleStreamingStarted(new StreamingStarted(
+            spanId: 'stream-span-123',
+            traceId: 'stream-trace-123',
+            parentSpanId: null,
+            request: $request,
+        ));
+
+        $listener->handleStreamingCompleted(new StreamingCompleted(
+            spanId: 'stream-span-123',
+            traceId: 'stream-trace-123',
+            parentSpanId: null,
+            request: $request,
+        ));
+
+        expect($capturedSpan)->toBeInstanceOf(SpanData::class)
+            ->and($capturedSpan->operation)->toBe('streaming');
+    });
+});
+
+function createStreamingRequest(): Request
+{
+    return new Request(
+        model: 'gpt-4',
+        providerKey: 'openai',
+        systemPrompts: [],
+        prompt: 'Stream this response',
+        messages: [],
+        maxSteps: 1,
+        maxTokens: 200,
+        temperature: 0.5,
+        topP: 1.0,
+        tools: [],
+        clientOptions: [],
+        clientRetry: [3],
+        toolChoice: null,
+    );
+}
+
+function createStreamingMockDriver(?SpanData &$capturedSpan): TelemetryDriver
+{
+    $driver = Mockery::mock(TelemetryDriver::class);
+    $driver->shouldReceive('recordSpan')
+        ->once()
+        ->with(Mockery::on(function ($span) use (&$capturedSpan): bool {
+            $capturedSpan = $span;
+
+            return $span instanceof SpanData;
+        }));
+
+    return $driver;
+}
+
+function captureSpanFromCollector(
+    string $spanId = 'stream-span-123',
+    string $traceId = 'stream-trace-123',
+    ?string $parentSpanId = null
+): SpanData {
+    $capturedSpan = null;
+    $driver = createStreamingMockDriver($capturedSpan);
+    $collector = new SpanCollector($driver);
+    $request = createStreamingRequest();
+
+    $collector->startSpan(new StreamingStarted(
+        spanId: $spanId,
+        traceId: $traceId,
+        parentSpanId: $parentSpanId,
+        request: $request,
+    ));
+
+    $collector->endSpan(new StreamingCompleted(
+        spanId: $spanId,
+        traceId: $traceId,
+        parentSpanId: $parentSpanId,
+        request: $request,
+    ));
+
+    return $capturedSpan;
+}

--- a/tests/Telemetry/StructuredOutputTelemetryTest.php
+++ b/tests/Telemetry/StructuredOutputTelemetryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Response;
+use Prism\Prism\Telemetry\Events\StructuredOutputCompleted;
+use Prism\Prism\Telemetry\Events\StructuredOutputStarted;
+
+it('emits telemetry events for structured output when enabled', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Structured response',
+        structured: ['test'],
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::structured()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Generate structured data')
+        ->withSchema(new StringSchema('test', 'Test schema'))
+        ->asStructured();
+
+    Event::assertDispatched(StructuredOutputStarted::class);
+    Event::assertDispatched(StructuredOutputCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('does not emit telemetry events when disabled', function (): void {
+    config(['prism.telemetry.enabled' => false]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Structured response',
+        structured: ['test'],
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::structured()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Generate structured data')
+        ->withSchema(new StringSchema('test', 'Test schema'))
+        ->asStructured();
+
+    Event::assertNotDispatched(StructuredOutputStarted::class);
+    Event::assertNotDispatched(StructuredOutputCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('includes traceId and parentSpanId in structured output telemetry events', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Structured response',
+        structured: ['test'],
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model')
+    );
+
+    Prism::fake([$mockResponse]);
+
+    Prism::structured()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Generate structured data')
+        ->withSchema(new StringSchema('test', 'Test schema'))
+        ->asStructured();
+
+    Event::assertDispatched(StructuredOutputStarted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null);
+
+    Event::assertDispatched(StructuredOutputCompleted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null
+        && $event->response !== null);
+});

--- a/tests/Telemetry/TelemetryContextTest.php
+++ b/tests/Telemetry/TelemetryContextTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Concerns\EmitsTelemetry;
+use Prism\Prism\Concerns\HasTelemetryContext;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Prism as PrismClass;
+use Prism\Prism\Telemetry\Events\SpanException;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Text\Response;
+
+class TestContextClass
+{
+    use EmitsTelemetry, HasTelemetryContext;
+
+    public function getTelemetryContext(): array
+    {
+        return $this->telemetryContext;
+    }
+
+    public function testPushContext(): void
+    {
+        $this->pushTelemetryContext();
+    }
+}
+
+class TestExceptionClass
+{
+    use EmitsTelemetry, HasTelemetryContext;
+
+    public function executeWithException(): void
+    {
+        $this->withTelemetry(
+            startEventFactory: fn ($spanId, $traceId, $parentSpanId): object => new class($spanId)
+            {
+                public function __construct(public string $spanId) {}
+            },
+            endEventFactory: fn ($spanId, $traceId, $parentSpanId, $response): object => new class($spanId)
+            {
+                public function __construct(public string $spanId) {}
+            },
+            execute: fn () => throw new RuntimeException('Test exception from execute'),
+        );
+    }
+}
+
+beforeEach(function (): void {
+    Context::forgetHidden('prism.telemetry.metadata');
+    Context::forgetHidden('prism.telemetry.trace_id');
+    Context::forgetHidden('prism.telemetry.current_span_id');
+    PrismClass::flushDefaultTelemetryContext();
+});
+
+describe('HasTelemetryContext fluent methods', function (): void {
+    it('sets user context with forUser method', function (): void {
+        $instance = new TestContextClass;
+
+        $result = $instance->forUser('user-123', 'test@example.com');
+
+        expect($result)->toBe($instance)
+            ->and($instance->getTelemetryContext())->toBe([
+                'user_id' => 'user-123',
+                'user_email' => 'test@example.com',
+            ]);
+    });
+
+    it('converts integer user id to string', function (): void {
+        $instance = (new TestContextClass)->forUser(123);
+
+        expect($instance->getTelemetryContext()['user_id'])->toBe('123');
+    });
+
+    it('sets conversation context with forConversation method', function (): void {
+        $instance = (new TestContextClass)->forConversation('conv-456');
+
+        expect($instance->getTelemetryContext())->toBe(['session_id' => 'conv-456']);
+    });
+
+    it('sets agent context with forAgent method', function (): void {
+        $instance = (new TestContextClass)->forAgent('support-bot');
+
+        expect($instance->getTelemetryContext())->toBe(['agent' => 'support-bot']);
+    });
+
+    it('sets arbitrary context with withTelemetryContext method', function (): void {
+        $instance = (new TestContextClass)->withTelemetryContext([
+            'custom_key' => 'custom_value',
+            'environment' => 'production',
+        ]);
+
+        expect($instance->getTelemetryContext())->toBe([
+            'custom_key' => 'custom_value',
+            'environment' => 'production',
+        ]);
+    });
+
+    it('sets tags with withTelemetryTags method', function (): void {
+        $instance = (new TestContextClass)->withTelemetryTags([
+            'priority' => 'high',
+            'department' => 'sales',
+        ]);
+
+        expect($instance->getTelemetryContext()['tags'])->toBe([
+            'priority' => 'high',
+            'department' => 'sales',
+        ]);
+    });
+
+    it('chains multiple context methods together', function (): void {
+        $instance = (new TestContextClass)
+            ->forUser('user-123')
+            ->forConversation('conv-456')
+            ->forAgent('code-assistant')
+            ->withTelemetryTags(['env' => 'test']);
+
+        expect($instance->getTelemetryContext())->toBe([
+            'user_id' => 'user-123',
+            'session_id' => 'conv-456',
+            'agent' => 'code-assistant',
+            'tags' => ['env' => 'test'],
+        ]);
+    });
+});
+
+describe('Laravel Context integration', function (): void {
+    it('pushes context to Laravel hidden context', function (): void {
+        $instance = (new TestContextClass)->forUser('user-789')->forAgent('test-agent');
+        $instance->testPushContext();
+
+        expect(Context::getHidden('prism.telemetry.metadata'))->toBe([
+            'user_id' => 'user-789',
+            'agent' => 'test-agent',
+        ]);
+    });
+});
+
+describe('global default context', function (): void {
+    it('sets and retrieves global default telemetry context', function (): void {
+        PrismClass::defaultTelemetryContext(fn (): array => [
+            'environment' => 'testing',
+            'app_version' => '1.0.0',
+        ]);
+
+        expect(PrismClass::getDefaultTelemetryContext())->toBe([
+            'environment' => 'testing',
+            'app_version' => '1.0.0',
+        ]);
+    });
+
+    it('flushes global default telemetry context', function (): void {
+        PrismClass::defaultTelemetryContext(fn (): array => ['key' => 'value']);
+        PrismClass::flushDefaultTelemetryContext();
+
+        expect(PrismClass::getDefaultTelemetryContext())->toBe([]);
+    });
+
+    it('evaluates resolver lazily on each call', function (): void {
+        $callCount = 0;
+        PrismClass::defaultTelemetryContext(function () use (&$callCount): array {
+            $callCount++;
+
+            return ['call_count' => $callCount];
+        });
+
+        PrismClass::getDefaultTelemetryContext();
+        PrismClass::getDefaultTelemetryContext();
+
+        expect($callCount)->toBe(2);
+    });
+});
+
+describe('context merging', function (): void {
+    it('merges global default context with instance context', function (): void {
+        PrismClass::defaultTelemetryContext(fn (): array => [
+            'environment' => 'testing',
+            'default_key' => 'default_value',
+        ]);
+
+        $instance = (new TestContextClass)->forUser('user-123');
+        $instance->testPushContext();
+
+        expect(Context::getHidden('prism.telemetry.metadata'))->toBe([
+            'environment' => 'testing',
+            'default_key' => 'default_value',
+            'user_id' => 'user-123',
+        ]);
+    });
+
+    it('instance context overrides global default context', function (): void {
+        PrismClass::defaultTelemetryContext(fn (): array => [
+            'user_id' => 'global-user',
+            'environment' => 'production',
+        ]);
+
+        $instance = (new TestContextClass)->forUser('specific-user');
+        $instance->testPushContext();
+
+        $metadata = Context::getHidden('prism.telemetry.metadata');
+        expect($metadata['user_id'])->toBe('specific-user')
+            ->and($metadata['environment'])->toBe('production');
+    });
+});
+
+describe('context flows to telemetry', function (): void {
+    it('context metadata flows through to telemetry events', function (): void {
+        config(['prism.telemetry.enabled' => true]);
+        Event::fake();
+
+        PrismClass::defaultTelemetryContext(fn (): array => ['environment' => 'test']);
+
+        $mockResponse = new Response(
+            steps: collect(),
+            text: 'Test response',
+            finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+            toolCalls: [],
+            toolResults: [],
+            usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+            meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+            messages: collect()
+        );
+
+        Prism::fake([$mockResponse]);
+
+        Prism::text()
+            ->using('openai', 'gpt-4')
+            ->forUser('user-integration-test')
+            ->forAgent('integration-agent')
+            ->withPrompt('Test prompt')
+            ->asText();
+
+        Event::assertDispatched(TextGenerationStarted::class);
+        Event::assertDispatched(TextGenerationCompleted::class);
+    });
+});
+
+describe('exception handling', function (): void {
+    it('dispatches SpanException when operation throws', function (): void {
+        config(['prism.telemetry.enabled' => true]);
+        Event::fake();
+
+        $testClass = new TestExceptionClass;
+
+        try {
+            $testClass->executeWithException();
+            $this->fail('Expected RuntimeException to be thrown');
+        } catch (RuntimeException $e) {
+            expect($e->getMessage())->toBe('Test exception from execute');
+        }
+
+        Event::assertDispatched(SpanException::class, fn ($e): bool => $e->exception instanceof RuntimeException
+                && $e->exception->getMessage() === 'Test exception from execute'
+                && ! empty($e->spanId));
+    });
+
+    it('resets span context even when exception is thrown', function (): void {
+        config(['prism.telemetry.enabled' => true]);
+        Event::fake();
+
+        $parentSpanId = 'parent-span-exception-test';
+        Context::addHidden('prism.telemetry.trace_id', 'trace-exception');
+        Context::addHidden('prism.telemetry.current_span_id', $parentSpanId);
+
+        $testClass = new TestExceptionClass;
+
+        try {
+            $testClass->executeWithException();
+        } catch (RuntimeException) {
+            // Expected
+        }
+
+        expect(Context::getHidden('prism.telemetry.current_span_id'))->toBe($parentSpanId);
+    });
+});

--- a/tests/Telemetry/TelemetryEventListenerTest.php
+++ b/tests/Telemetry/TelemetryEventListenerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Telemetry\Drivers\NullDriver;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Telemetry\Listeners\TelemetryEventListener;
+use Prism\Prism\Telemetry\SpanCollector;
+use Prism\Prism\Telemetry\SpanData;
+use Prism\Prism\Text\Response;
+
+it('dispatches telemetry events when telemetry is enabled', function (): void {
+    config([
+        'prism.telemetry.enabled' => true,
+        'prism.telemetry.driver' => 'null',
+    ]);
+
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-sonnet')
+        ->withPrompt('Test prompt')
+        ->asText();
+
+    // Verify telemetry events were dispatched
+    Event::assertDispatched(TextGenerationStarted::class);
+    Event::assertDispatched(TextGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('does not dispatch events when telemetry is disabled', function (): void {
+    config([
+        'prism.telemetry.enabled' => false,
+    ]);
+
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-sonnet')
+        ->withPrompt('Test prompt')
+        ->asText();
+
+    // Verify events were not dispatched when telemetry is disabled
+    Event::assertNotDispatched(TextGenerationStarted::class);
+    Event::assertNotDispatched(TextGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('can handle telemetry events with event listener', function (): void {
+    $driver = new NullDriver;
+    $collector = new SpanCollector($driver);
+    $listener = new TelemetryEventListener($collector);
+
+    $textRequest = new \Prism\Prism\Text\Request(
+        model: 'claude-3-sonnet',
+        providerKey: 'anthropic:claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'test',
+        messages: [],
+        maxSteps: 1,
+        maxTokens: null,
+        temperature: null,
+        topP: null,
+        tools: [],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: [],
+        providerTools: []
+    );
+
+    $startEvent = new TextGenerationStarted(
+        spanId: 'span-123',
+        traceId: 'trace-123',
+        parentSpanId: null,
+        request: $textRequest,
+    );
+
+    // This should not throw an exception
+    $listener->handleTextGenerationStarted($startEvent);
+
+    expect(true)->toBeTrue();
+});
+
+it('routes events through span collector and extracts attributes', function (): void {
+    $capturedSpan = null;
+
+    $driver = Mockery::mock(TelemetryDriver::class);
+    $driver->shouldReceive('recordSpan')
+        ->once()
+        ->with(Mockery::on(function ($span) use (&$capturedSpan): bool {
+            $capturedSpan = $span;
+
+            return $span instanceof SpanData;
+        }));
+
+    $collector = new SpanCollector($driver);
+    $listener = new TelemetryEventListener($collector);
+
+    $textRequest = new \Prism\Prism\Text\Request(
+        model: 'claude-3-sonnet',
+        providerKey: 'anthropic:claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'test',
+        messages: [],
+        maxSteps: 1,
+        maxTokens: null,
+        temperature: null,
+        topP: null,
+        tools: [],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: [],
+        providerTools: []
+    );
+
+    $textResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    $startEvent = new TextGenerationStarted(
+        spanId: 'span-123',
+        traceId: 'trace-123',
+        parentSpanId: null,
+        request: $textRequest,
+    );
+    $endEvent = new TextGenerationCompleted(
+        spanId: 'span-123',
+        traceId: 'trace-123',
+        parentSpanId: null,
+        request: $textRequest,
+        response: $textResponse,
+    );
+
+    $listener->handleTextGenerationStarted($startEvent);
+    $listener->handleTextGenerationCompleted($endEvent);
+
+    // Verify span was created with generic Prism attributes (not OpenInference)
+    expect($capturedSpan)->toBeInstanceOf(SpanData::class);
+    expect($capturedSpan->operation)->toBe('text_generation');
+    expect($capturedSpan->attributes)->toHaveKey('model');
+    expect($capturedSpan->attributes['model'])->toBe('claude-3-sonnet');
+    expect($capturedSpan->attributes)->toHaveKey('provider');
+    expect($capturedSpan->attributes['provider'])->toBe('anthropic:claude-3-sonnet');
+});

--- a/tests/Telemetry/TelemetryManagerTest.php
+++ b/tests/Telemetry/TelemetryManagerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Contracts\TelemetryDriver;
+use Prism\Prism\Telemetry\Drivers\LogDriver;
+use Prism\Prism\Telemetry\Drivers\NullDriver;
+use Prism\Prism\Telemetry\Drivers\OtlpDriver;
+use Prism\Prism\Telemetry\SpanData;
+use Prism\Prism\Telemetry\TelemetryManager;
+
+it('resolves null driver by default', function (): void {
+    $manager = new TelemetryManager(app());
+
+    $driver = $manager->resolve('null');
+
+    expect($driver)->toBeInstanceOf(NullDriver::class);
+});
+
+it('resolves log driver with configuration', function (): void {
+    $manager = new TelemetryManager(app());
+
+    $driver = $manager->resolve('log');
+
+    expect($driver)->toBeInstanceOf(LogDriver::class);
+});
+
+it('resolves phoenix as otlp driver with openinference mapper', function (): void {
+    $manager = new TelemetryManager(app());
+
+    $driver = $manager->resolve('phoenix');
+
+    expect($driver)->toBeInstanceOf(OtlpDriver::class);
+    expect($driver->getDriver())->toBe('phoenix');
+});
+
+it('resolves custom otlp driver from config', function (): void {
+    config([
+        'prism.telemetry.drivers.langfuse' => [
+            'driver' => 'otlp',
+            'endpoint' => 'https://cloud.langfuse.com',
+            'api_key' => 'test-key',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+
+    $driver = $manager->resolve('langfuse');
+
+    expect($driver)->toBeInstanceOf(OtlpDriver::class);
+    expect($driver->getDriver())->toBe('langfuse');
+});
+
+it('throws exception for unsupported driver type', function (): void {
+    config([
+        'prism.telemetry.drivers.custom' => [
+            'driver' => 'unsupported',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+
+    $manager->resolve('custom');
+})->throws(InvalidArgumentException::class, 'Telemetry driver [unsupported] is not supported.');
+
+it('uses configuration from config file for log driver', function (): void {
+    config([
+        'prism.telemetry.drivers.log' => [
+            'driver' => 'log',
+            'channel' => 'custom-channel',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+    $driver = $manager->resolve('log');
+
+    expect($driver)->toBeInstanceOf(LogDriver::class);
+});
+
+it('resolves custom driver via class', function (): void {
+    $customDriver = new class implements TelemetryDriver
+    {
+        public function recordSpan(SpanData $span): void {}
+
+        public function shutdown(): void {}
+    };
+
+    $factoryClass = new class($customDriver)
+    {
+        public function __construct(private readonly TelemetryDriver $driver) {}
+
+        public function __invoke($app, $config): TelemetryDriver
+        {
+            return $this->driver;
+        }
+    };
+
+    app()->instance('custom-factory', $factoryClass);
+
+    config([
+        'prism.telemetry.drivers.my-custom' => [
+            'driver' => 'custom',
+            'via' => 'custom-factory',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+    $driver = $manager->resolve('my-custom');
+
+    expect($driver)->toBe($customDriver);
+});
+
+it('resolves custom driver via closure', function (): void {
+    $customDriver = new class implements TelemetryDriver
+    {
+        public function recordSpan(SpanData $span): void {}
+
+        public function shutdown(): void {}
+    };
+
+    config([
+        'prism.telemetry.drivers.closure-custom' => [
+            'driver' => 'custom',
+            'via' => fn ($app, $config): object => $customDriver,
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+    $driver = $manager->resolve('closure-custom');
+
+    expect($driver)->toBe($customDriver);
+});
+
+it('throws exception when custom driver missing via key', function (): void {
+    config([
+        'prism.telemetry.drivers.bad-custom' => [
+            'driver' => 'custom',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+    $manager->resolve('bad-custom');
+})->throws(InvalidArgumentException::class, "Custom telemetry driver [bad-custom] requires a 'via' configuration option.");
+
+it('passes config to custom driver factory', function (): void {
+    $receivedConfig = null;
+
+    config([
+        'prism.telemetry.drivers.config-test' => [
+            'driver' => 'custom',
+            'via' => function ($app, $config) use (&$receivedConfig): \Prism\Prism\Contracts\TelemetryDriver {
+                $receivedConfig = $config;
+
+                return new class implements TelemetryDriver
+                {
+                    public function recordSpan(SpanData $span): void {}
+
+                    public function shutdown(): void {}
+                };
+            },
+            'custom_option' => 'test-value',
+        ],
+    ]);
+
+    $manager = new TelemetryManager(app());
+    $manager->resolve('config-test');
+
+    expect($receivedConfig)->toHaveKey('custom_option', 'test-value');
+});

--- a/tests/Telemetry/TextGenerationTelemetryTest.php
+++ b/tests/Telemetry/TextGenerationTelemetryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Telemetry\Events\TextGenerationCompleted;
+use Prism\Prism\Telemetry\Events\TextGenerationStarted;
+use Prism\Prism\Text\Response;
+
+it('emits telemetry events for text generation when enabled', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::text()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Test prompt')
+        ->asText();
+
+    Event::assertDispatched(TextGenerationStarted::class);
+    Event::assertDispatched(TextGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('does not emit telemetry events when disabled', function (): void {
+    config(['prism.telemetry.enabled' => false]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    Prism::fake([$mockResponse]);
+
+    $response = Prism::text()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Test prompt')
+        ->asText();
+
+    Event::assertNotDispatched(TextGenerationStarted::class);
+    Event::assertNotDispatched(TextGenerationCompleted::class);
+
+    expect($response)->toBeInstanceOf(Response::class);
+});
+
+it('includes traceId and parentSpanId in telemetry events', function (): void {
+    config(['prism.telemetry.enabled' => true]);
+    Event::fake();
+
+    $mockResponse = new Response(
+        steps: collect(),
+        text: 'Test response',
+        finishReason: \Prism\Prism\Enums\FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        usage: new \Prism\Prism\ValueObjects\Usage(10, 20),
+        meta: new \Prism\Prism\ValueObjects\Meta('test-id', 'test-model'),
+        messages: collect()
+    );
+
+    Prism::fake([$mockResponse]);
+
+    Prism::text()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Test prompt')
+        ->asText();
+
+    Event::assertDispatched(TextGenerationStarted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null);
+
+    Event::assertDispatched(TextGenerationCompleted::class, fn ($event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->request !== null
+        && $event->response !== null);
+});

--- a/tests/Telemetry/ToolCallTelemetryTest.php
+++ b/tests/Telemetry/ToolCallTelemetryTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Telemetry\Events\ToolCallCompleted;
+use Prism\Prism\Telemetry\Events\ToolCallStarted;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\ToolCall;
+
+it('emits telemetry events for tool calls when enabled', function (): void {
+    config([
+        'prism.telemetry.enabled' => true,
+        'prism.telemetry.driver' => 'null',
+    ]);
+
+    Event::fake();
+
+    // Create a test class that uses the CallsTools trait
+    $testHandler = new class
+    {
+        use CallsTools;
+
+        public function testCallTools(array $tools, array $toolCalls): array
+        {
+            return $this->callTools($tools, $toolCalls);
+        }
+    };
+
+    // Create a mock tool
+    $tool = (new Tool)
+        ->as('test_tool')
+        ->for('Testing tool calls')
+        ->withStringParameter('input', 'Test input')
+        ->using(fn (string $input): string => "Processed: {$input}");
+
+    // Create a tool call
+    $toolCall = new ToolCall(
+        id: 'tool-123',
+        name: 'test_tool',
+        arguments: ['input' => 'test value'],
+        resultId: 'result-123'
+    );
+
+    // Execute the tool call
+    $results = $testHandler->testCallTools([$tool], [$toolCall]);
+
+    // Verify tool call telemetry events were dispatched
+    Event::assertDispatched(ToolCallStarted::class);
+    Event::assertDispatched(ToolCallCompleted::class);
+
+    expect($results)->toHaveCount(1);
+});
+
+it('does not emit tool call events when telemetry is disabled', function (): void {
+    config([
+        'prism.telemetry.enabled' => false,
+    ]);
+
+    Event::fake();
+
+    // Create a test class that uses the CallsTools trait
+    $testHandler = new class
+    {
+        use CallsTools;
+
+        public function testCallTools(array $tools, array $toolCalls): array
+        {
+            return $this->callTools($tools, $toolCalls);
+        }
+    };
+
+    // Create a mock tool
+    $tool = (new Tool)
+        ->as('test_tool')
+        ->for('Testing tool calls')
+        ->withStringParameter('input', 'Test input')
+        ->using(fn (string $input): string => "Processed: {$input}");
+
+    // Create a tool call
+    $toolCall = new ToolCall(
+        id: 'tool-123',
+        name: 'test_tool',
+        arguments: ['input' => 'test value'],
+        resultId: 'result-123'
+    );
+
+    // Execute the tool call
+    $results = $testHandler->testCallTools([$tool], [$toolCall]);
+
+    // Verify tool call events were not dispatched when telemetry is disabled
+    Event::assertNotDispatched(ToolCallStarted::class);
+    Event::assertNotDispatched(ToolCallCompleted::class);
+
+    expect($results)->toHaveCount(1);
+});
+
+it('includes traceId and parentSpanId in tool call telemetry events', function (): void {
+    config([
+        'prism.telemetry.enabled' => true,
+        'prism.telemetry.driver' => 'null',
+    ]);
+
+    Event::fake();
+
+    // Create a test class that uses the CallsTools trait
+    $testHandler = new class
+    {
+        use CallsTools;
+
+        public function testCallTools(array $tools, array $toolCalls): array
+        {
+            return $this->callTools($tools, $toolCalls);
+        }
+    };
+
+    // Create a mock tool
+    $tool = (new Tool)
+        ->as('test_tool')
+        ->for('Testing tool calls')
+        ->withStringParameter('input', 'Test input')
+        ->using(fn (string $input): string => "Processed: {$input}");
+
+    // Create a tool call
+    $toolCall = new ToolCall(
+        id: 'tool-123',
+        name: 'test_tool',
+        arguments: ['input' => 'test value'],
+        resultId: 'result-123'
+    );
+
+    // Execute the tool call
+    $results = $testHandler->testCallTools([$tool], [$toolCall]);
+
+    // Verify tool call events contain traceId and parentSpanId as properties
+    Event::assertDispatched(ToolCallStarted::class, function (ToolCallStarted $event): bool {
+        return ! empty($event->spanId)
+            && ! empty($event->traceId)
+            && $event->parentSpanId === null; // No parent when called directly
+    });
+
+    Event::assertDispatched(ToolCallCompleted::class, fn (ToolCallCompleted $event): bool => ! empty($event->spanId)
+        && ! empty($event->traceId)
+        && $event->parentSpanId === null);
+
+    expect($results)->toHaveCount(1);
+});


### PR DESCRIPTION
## Description

Adds comprehensive telemetry support to Prism, enabling observability through configurable drivers. This feature was built on the foundations of the `eventelemetry` branch by @sixlive.

### Features

- **Configurable Drivers**: Choose from `null`, `log`, or `otlp` drivers via `PRISM_TELEMETRY_DRIVER`
- **Phoenix/Arize Integration**: First-class support for [Arize Phoenix](https://phoenix.arize.com/) with OpenInference semantic conventions
- **Custom Drivers**: Register custom telemetry drivers via factory classes or closures
- **User Context Tracking**: Track `user_id`, `session_id`, and `agent` across spans
- **Streaming Support**: Telemetry for streaming responses with `StreamStartEvent`/`StreamEndEvent` capture
- **Async Export**: Queue-based span export with configurable retry (3 attempts, 5s backoff)
- **Exception Recording**: Automatic `SpanException` dispatch on failures with context preservation

### Configuration

```php
// Enable telemetry
PRISM_TELEMETRY_ENABLED=true
PRISM_TELEMETRY_DRIVER=phoenix

// Phoenix configuration
PHOENIX_ENDPOINT=https://app.phoenix.arize.com/v1/traces
PHOENIX_API_KEY=your-api-key
```

### Usage

```php
Prism::text()
    ->using('openai', 'gpt-4')
    ->forUser(auth()->id())
    ->forConversation($conversation->id)
    ->forAgent('support-bot')
    ->withPrompt('Hello')
    ->asText();
```

### Global Context

```php
// In a service provider
Prism::defaultTelemetryContext(fn () => [
    'user_id' => auth()->id(),
    'environment' => app()->environment(),
]);
```

### Optional Dependencies

For OTLP drivers (Phoenix, etc.), install:

```bash
composer require open-telemetry/sdk open-telemetry/exporter-otlp
```

## Breaking Changes

None. Telemetry is disabled by default and fully opt-in.