### PR TITLE
(feat) Add gpt-5.1 and gpt-5.2 to list of supported openai structured modes

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -40,6 +40,8 @@ class StructuredModeResolver
             'gpt-5',
             'gpt-5-mini',
             'gpt-5-nano',
+            'gpt-5.1',
+            'gpt-5.2',
         ]);
     }
 


### PR DESCRIPTION
Add gpt-5.1 and gpt-5.2 to list of supported openai structured modes

It would be great if we could keep this more in sync. A couple of ideas:

- Allow forcing the structured mode (setting usingStructuredMode() does not work
 because of this;
 if ($mode !== StructuredMode::Structured) {
            throw new PrismException(sprintf('%s model does not support structured mode', $request->model()));
        }

- Instead of a whitelist have a blocklist of models that do not support structured mode, I think most new openai models support it.

If you have a preferences, I'm happy to PR it :)
