### PR TITLE
Add raw key to the responses for all the available provider

### DIFF
--- a/docs/core-concepts/image-generation.md
+++ b/docs/core-concepts/image-generation.md
@@ -85,6 +85,9 @@ if ($response->hasImages()) {
 // Check usage information
 echo "Prompt tokens: {$response->usage->promptTokens}";
 echo "Model used: {$response->meta->model}";
+
+// Access the raw API response data
+$rawResponse = $response->raw;
 ```
 
 ## Provider-Specific Options

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -122,8 +122,8 @@ echo $response->finishReason->name;
 echo "Prompt tokens: {$response->usage->promptTokens}";
 echo "Completion tokens: {$response->usage->completionTokens}";
 
-// Access provider-specific response data
-$rawResponse = $response->response;
+// Access the raw API response data
+$rawResponse = $response->raw;
 ```
 
 > [!TIP]

--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -200,10 +200,15 @@ echo $response->finishReason->name;
 echo "Prompt tokens: {$response->usage->promptTokens}";
 echo "Completion tokens: {$response->usage->completionTokens}";
 
+// Access the raw API response data
+$rawResponse = $response->raw;
+
 // For multi-step generations, examine each step
 foreach ($response->steps as $step) {
     echo "Step text: {$step->text}";
     echo "Step tokens: {$step->usage->completionTokens}";
+    // Access raw response for individual steps
+    $stepRawResponse = $step->raw;
 }
 
 // Access message history

--- a/src/Embeddings/Response.php
+++ b/src/Embeddings/Response.php
@@ -12,10 +12,12 @@ readonly class Response
 {
     /**
      * @param  Embedding[]  $embeddings
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public array $embeddings,
         public EmbeddingsUsage $usage,
-        public Meta $meta
+        public Meta $meta,
+        public ?array $raw = null
     ) {}
 }

--- a/src/Images/Response.php
+++ b/src/Images/Response.php
@@ -13,12 +13,14 @@ readonly class Response
     /**
      * @param  GeneratedImage[]  $images
      * @param  array<string,mixed>  $additionalContent
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public array $images,
         public Usage $usage,
         public Meta $meta,
-        public array $additionalContent = []
+        public array $additionalContent = [],
+        public ?array $raw = null
     ) {}
 
     public function firstImage(): ?GeneratedImage

--- a/src/Images/ResponseBuilder.php
+++ b/src/Images/ResponseBuilder.php
@@ -16,7 +16,9 @@ readonly class ResponseBuilder
         /** @var GeneratedImage[] */
         public array $images = [],
         /** @var array<string,mixed> */
-        public array $additionalContent = []
+        public array $additionalContent = [],
+        /** @var array<string,mixed>|null */
+        public ?array $raw = null
     ) {}
 
     public function toResponse(): Response
@@ -26,6 +28,7 @@ readonly class ResponseBuilder
             usage: $this->usage,
             meta: $this->meta,
             additionalContent: $this->additionalContent,
+            raw: $this->raw,
         );
     }
 }

--- a/src/Moderation/Response.php
+++ b/src/Moderation/Response.php
@@ -11,10 +11,12 @@ readonly class Response
 {
     /**
      * @param  ModerationResult[]  $results
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public array $results,
-        public Meta $meta
+        public Meta $meta,
+        public ?array $raw = null
     ) {}
 
     /**

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -247,6 +247,7 @@ class Structured
      */
     protected function addStep(array $toolCalls, Response $tempResponse, array $toolResults = []): void
     {
+        $data = $this->httpResponse->json();
         $isStructuredStep = $this->determineIfStructuredStep($toolCalls, $toolResults);
 
         $this->responseBuilder->addStep(new Step(
@@ -260,6 +261,7 @@ class Structured
             structured: $isStructuredStep ? ($tempResponse->structured ?? []) : [],
             toolCalls: $toolCalls,
             toolResults: $toolResults,
+            raw: $data,
         ));
     }
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -132,6 +132,8 @@ class Text
      */
     protected function addStep(array $toolResults = []): void
     {
+        $data = $this->httpResponse->json();
+
         $this->responseBuilder->addStep(new Step(
             text: $this->tempResponse->text,
             finishReason: $this->tempResponse->finishReason,
@@ -143,6 +145,7 @@ class Text
             messages: $this->request->messages(),
             systemPrompts: $this->request->systemPrompts(),
             additionalContent: $this->tempResponse->additionalContent,
+            raw: $data,
         ));
     }
 

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -97,6 +97,7 @@ class Structured
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data
         );
 
         $this->responseBuilder->addStep($step);

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -141,6 +141,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 }

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -41,6 +41,7 @@ class Embeddings
                 id: '',
                 model: '',
             ),
+            raw: $data,
         );
     }
 

--- a/src/Providers/Gemini/Handlers/Images.php
+++ b/src/Providers/Gemini/Handlers/Images.php
@@ -41,6 +41,7 @@ class Images
                 model: data_get($data, 'modelVersion', ''),
             ),
             images: $images,
+            raw: $data,
         );
 
         return $responseBuilder->toResponse();

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -243,6 +243,7 @@ class Structured
                 structured: $isStructuredStep ? $this->extractStructuredData(data_get($data, 'candidates.0.content.parts.0.text') ?? '') : [],
                 toolCalls: $finishReason === FinishReason::ToolCalls ? ToolCallMap::map(data_get($data, 'candidates.0.content.parts', [])) : [],
                 toolResults: $toolResults,
+                raw: $data,
             )
         );
     }

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -205,6 +205,7 @@ class Text
                 'urlMetadata' => data_get($data, 'candidates.0.urlContextMetadata.urlMetadata'),
                 'thoughtSummaries' => $thoughtSummaries !== [] ? $thoughtSummaries : null,
             ]),
+            raw: $data,
         ));
     }
 

--- a/src/Providers/Groq/Handlers/Structured.php
+++ b/src/Providers/Groq/Handlers/Structured.php
@@ -86,6 +86,7 @@ class Structured
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         );
 
         $this->responseBuilder->addStep($step);

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -141,6 +141,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 

--- a/src/Providers/Mistral/Handlers/Embeddings.php
+++ b/src/Providers/Mistral/Handlers/Embeddings.php
@@ -35,7 +35,8 @@ class Embeddings
                 id: data_get($data, 'id', ''),
                 model: data_get($data, 'model', ''),
                 rateLimits: $this->processRateLimits($response)
-            )
+            ),
+            raw: $data,
         );
     }
 

--- a/src/Providers/Mistral/Handlers/Structured.php
+++ b/src/Providers/Mistral/Handlers/Structured.php
@@ -90,6 +90,7 @@ class Structured
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data
         );
 
         $this->responseBuilder->addStep($step);

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -131,6 +131,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: $this->extractThinking(data_get($data, 'choices.0.message', [])),
+            raw: $data,
         ));
     }
 

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -37,6 +37,7 @@ class Embeddings
                 id: '',
                 model: data_get($data, 'model', ''),
             ),
+            raw: $data,
         );
     }
 

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -65,6 +65,7 @@ class Structured
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -150,6 +150,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 

--- a/src/Providers/OpenAI/Handlers/Embeddings.php
+++ b/src/Providers/OpenAI/Handlers/Embeddings.php
@@ -37,6 +37,7 @@ class Embeddings
                 model: data_get($data, 'model', ''),
                 rateLimits: $this->processRateLimits($response),
             ),
+            raw: $data,
         );
     }
 

--- a/src/Providers/OpenAI/Handlers/Images.php
+++ b/src/Providers/OpenAI/Handlers/Images.php
@@ -46,6 +46,7 @@ class Images
                 rateLimits: $this->processRateLimits($response),
             ),
             images: $images,
+            raw: $data,
         );
 
         return $responseBuilder->toResponse();

--- a/src/Providers/OpenAI/Handlers/Moderation.php
+++ b/src/Providers/OpenAI/Handlers/Moderation.php
@@ -39,6 +39,7 @@ class Moderation
                 model: data_get($data, 'model', $request->model()),
                 rateLimits: $this->processRateLimits($response),
             ),
+            raw: $data,
         );
     }
 

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -156,6 +156,7 @@ class Structured
             structured: $isStructuredStep ? $this->extractStructuredData(data_get($data, 'output.{last}.content.0.text') ?? '') : [],
             toolCalls: $toolCalls,
             toolResults: $toolResults,
+            raw: $data,
         ));
     }
 

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -200,6 +200,7 @@ class Text
                     ->filter()
                     ->toArray(),
             ]),
+            raw: $data,
         ));
     }
 }

--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -106,6 +106,7 @@ class Structured
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data
         );
 
         $this->responseBuilder->addStep($step);

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -135,6 +135,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 }

--- a/src/Providers/XAI/Handlers/Structured.php
+++ b/src/Providers/XAI/Handlers/Structured.php
@@ -74,6 +74,7 @@ class Structured
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
             structured: $parsed ?? [],
+            raw: $data,
         ));
     }
 

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -170,6 +170,7 @@ class Text
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
             additionalContent: [],
+            raw: $data,
         ));
     }
 }

--- a/src/Structured/Response.php
+++ b/src/Structured/Response.php
@@ -19,6 +19,7 @@ readonly class Response
      * @param  array<int, ToolCall>  $toolCalls
      * @param  array<int, ToolResult>  $toolResults
      * @param  array<string,mixed>  $additionalContent
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public Collection $steps,
@@ -29,6 +30,7 @@ readonly class Response
         public Meta $meta,
         public array $toolCalls = [],
         public array $toolResults = [],
-        public array $additionalContent = []
+        public array $additionalContent = [],
+        public ?array $raw = null
     ) {}
 }

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -41,6 +41,7 @@ readonly class ResponseBuilder
             toolCalls: $this->aggregateToolCalls(),
             toolResults: $this->aggregateToolResults(),
             additionalContent: $finalStep->additionalContent,
+            raw: $finalStep->raw,
         );
     }
 

--- a/src/Structured/Step.php
+++ b/src/Structured/Step.php
@@ -21,6 +21,7 @@ readonly class Step
      * @param  array<string,mixed>  $structured
      * @param  array<int, ToolCall>  $toolCalls
      * @param  array<int, ToolResult>  $toolResults
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public string $text,
@@ -32,6 +33,7 @@ readonly class Step
         public array $additionalContent = [],
         public array $structured = [],
         public array $toolCalls = [],
-        public array $toolResults = []
+        public array $toolResults = [],
+        public ?array $raw = null
     ) {}
 }

--- a/src/Text/Response.php
+++ b/src/Text/Response.php
@@ -20,6 +20,7 @@ readonly class Response
      * @param  ToolResult[]  $toolResults
      * @param  Collection<int, Message>  $messages
      * @param  array<string,mixed>  $additionalContent
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public Collection $steps,
@@ -30,6 +31,7 @@ readonly class Response
         public Usage $usage,
         public Meta $meta,
         public Collection $messages,
-        public array $additionalContent = []
+        public array $additionalContent = [],
+        public ?array $raw = null
     ) {}
 }

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -39,6 +39,7 @@ readonly class ResponseBuilder
             meta: $finalStep->meta,
             messages: collect($finalStep->messages),
             additionalContent: $finalStep->additionalContent,
+            raw: $finalStep->raw,
         );
     }
 

--- a/src/Text/Step.php
+++ b/src/Text/Step.php
@@ -22,6 +22,7 @@ readonly class Step
      * @param  Message[]  $messages
      * @param  SystemMessage[]  $systemPrompts
      * @param  array<string,mixed>  $additionalContent
+     * @param  array<string,mixed>|null  $raw
      */
     public function __construct(
         public string $text,
@@ -33,6 +34,7 @@ readonly class Step
         public Meta $meta,
         public array $messages,
         public array $systemPrompts,
-        public array $additionalContent = []
+        public array $additionalContent = [],
+        public ?array $raw = null
     ) {}
 }


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Add the raw key to the response of all of the providers. The only exception is audio and stream, where I did not add it to stream cause i doesn't really get how stream works.                                                                               
                                                                                                                              
I think this a better way to handle any niche key where you need something specific for your use case from the api but it  not provided response DTO.                                                                                                  

So you can use the raw object to get the key that you need for your api.
