### PR TITLE
Expose raw tool call arguments

### DIFF
--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -13,7 +13,7 @@ class ToolCall
     public function __construct(
         public readonly string $id,
         public readonly string $name,
-        protected string|array $arguments,
+        public readonly string|array $arguments,
         public readonly ?string $resultId = null,
         public readonly ?string $reasoningId = null,
         public readonly ?array $reasoningSummary = null,

--- a/tests/ValueObjects/ToolCallTest.php
+++ b/tests/ValueObjects/ToolCallTest.php
@@ -11,6 +11,7 @@ it('handles empty string arguments correctly', function (): void {
         arguments: ''
     );
 
+    expect($toolCall->arguments)->toBe('');
     expect($toolCall->arguments())->toBe([]);
 });
 
@@ -21,6 +22,18 @@ it('handles null arguments correctly', function (): void {
         arguments: []
     );
 
+    expect($toolCall->arguments)->toBe([]);
+    expect($toolCall->arguments())->toBe([]);
+});
+
+it('handles empty object arguments correctly', function (): void {
+    $toolCall = new ToolCall(
+        id: 'test-id',
+        name: 'test-tool',
+        arguments: '{}'
+    );
+
+    expect($toolCall->arguments)->toBe('{}');
     expect($toolCall->arguments())->toBe([]);
 });
 
@@ -29,6 +42,10 @@ it('handles valid JSON string arguments correctly', function (): void {
         id: 'test-id',
         name: 'test-tool',
         arguments: '{"param1": "value1", "param2": 42}'
+    );
+
+    expect($toolCall->arguments)->toBe(
+        '{"param1": "value1", "param2": 42}'
     );
 
     expect($toolCall->arguments())->toBe([
@@ -46,6 +63,7 @@ it('handles array arguments correctly', function (): void {
         arguments: $arguments
     );
 
+    expect($toolCall->arguments)->toBe($arguments);
     expect($toolCall->arguments())->toBe($arguments);
 });
 
@@ -56,5 +74,6 @@ it('throws exception for malformed JSON string arguments', function (): void {
         arguments: '{"invalid json"'
     );
 
+    expect($toolCall->arguments)->toBe('{"invalid json"');
     expect($toolCall->arguments(...))->toThrow(JsonException::class);
 });


### PR DESCRIPTION
## Description

Tool calls now expose arguments in their raw form.

This is relevant for when json en-/decoding returns slightly different results than the real data provided.

#### Example

- Raw arguments: "{}"
- Parsed arguments: []

This cannot be re-encoded into "{}" - `json_encode([])` would return "[]".

## Breaking Changes

None