### PR TITLE
fix(gemini): structured output with thinking

### DIFF
--- a/tests/Fixtures/gemini/generate-structured-with-thoughts-1.json
+++ b/tests/Fixtures/gemini/generate-structured-with-thoughts-1.json
@@ -1,0 +1,27 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Let me think about how to extract this information and structure it properly according to the schema requirements.",
+            "thought": true
+          },
+          {
+            "text": "{\"result\": \"Successfully extracted information\"}"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -0.05
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 50,
+    "candidatesTokenCount": 30,
+    "totalTokenCount": 100,
+    "thoughtsTokenCount": 20
+  },
+  "modelVersion": "gemini-2.0-flash-exp"
+}


### PR DESCRIPTION
## Description

Closes https://github.com/prism-php/prism/issues/798

Fixes Gemini structured output parsing when `includeThoughts: true` is enabled. Previously, the Structured handler always read from `parts[0].text`, which contained thinking content instead of the JSON response when thoughts were included.

- Ported thought-filtering logic from `Text.php` to `Structured.php`
- Added `extractTextContent()`, `extractThoughtSummaries()`, and `hasToolCalls()` helper methods
- Thought summaries now available in `additionalContent` for structured responses
