### PR TITLE
fix(gemini): streaming thought signatures

### DIFF
--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -434,4 +434,9 @@ it('can generate text stream using multiple parallel tool calls', function (): v
         ->and(count($toolResults))->toBe(2)
         ->and($text)->toContain('50')
         ->and($text)->toContain('75');
+
+    // Both tool calls should have reasoningId from the first tool call's thoughtSignature
+    expect($toolCalls[0]->reasoningId)->not->toBeNull();
+    expect($toolCalls[1]->reasoningId)->not->toBeNull();
+    expect($toolCalls[0]->reasoningId)->toBe($toolCalls[1]->reasoningId);
 });


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes #830 

Fixes Gemini streaming with multiple parallel tool calls when thinking is enabled. Per [Google's docs](https://ai.google.dev/gemini-api/docs/thought-signatures), only the first function call part has a `thoughtSignature`, but all tool calls need one when sending results back to Gemini.

**Solution:** Store the first `thoughtSignature` and reuse it for subsequent tool calls in the same response.
