### PR TITLE
fix: tool choice call loop

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -505,6 +505,7 @@ class Stream
             ));
 
             $request->addMessage(new ToolResultMessage($toolResults));
+            $request->resetToolChoice();
 
             // Emit step finish after tool calls
             $this->state->markStepFinished();

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -170,6 +170,7 @@ class Structured
         }
 
         $this->request->addMessage($message);
+        $this->request->resetToolChoice();
         $this->addStep($toolCalls, $tempResponse, $toolResults);
 
         if ($this->canContinue()) {

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -110,6 +110,7 @@ class Text
         }
 
         $this->request->addMessage($message);
+        $this->request->resetToolChoice();
 
         $this->addStep($toolResults);
 

--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -381,6 +381,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->state->markStepFinished();
         yield new StepFinishEvent(

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -70,6 +70,7 @@ class Text
         );
 
         $request = $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $toolResults);
 

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -328,6 +328,7 @@ class Stream
         if ($toolResults !== []) {
             $request->addMessage(new AssistantMessage($this->state->currentText(), $mappedToolCalls));
             $request->addMessage(new ToolResultMessage($toolResults));
+            $request->resetToolChoice();
 
             // Emit step finish after tool calls
             $this->state->markStepFinished();

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -206,6 +206,7 @@ class Structured
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, FinishReason::ToolCalls, $toolResults);
 

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -153,6 +153,7 @@ class Text
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, FinishReason::ToolCalls, $toolResults);
 

--- a/src/Providers/Groq/Handlers/Stream.php
+++ b/src/Providers/Groq/Handlers/Stream.php
@@ -276,6 +276,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         // Emit step finish after tool calls
         $this->state->markStepFinished();

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -92,6 +92,7 @@ class Text
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $clientResponse, FinishReason::ToolCalls, $toolResults);
 

--- a/src/Providers/Mistral/Handlers/Stream.php
+++ b/src/Providers/Mistral/Handlers/Stream.php
@@ -271,6 +271,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->state->markStepFinished();
         yield new StepFinishEvent(

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -78,6 +78,7 @@ class Text
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $clientResponse, $toolResults);
 

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -293,6 +293,7 @@ class Stream
         // Add messages for next turn
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         // Emit step finish after tool calls
         $this->state->markStepFinished();

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -102,6 +102,7 @@ class Text
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $toolResults);
 

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -398,6 +398,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($this->state->currentText(), $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         // Emit step finish after tool calls
         $this->state->markStepFinished();

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -97,6 +97,7 @@ class Structured
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $clientResponse, $toolResults);
 

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -97,6 +97,7 @@ class Text
         );
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $clientResponse, $toolResults);
 

--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -387,6 +387,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->state
             ->resetTextState()

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -69,6 +69,7 @@ class Text
         );
 
         $request = $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $toolResults);
 

--- a/src/Providers/XAI/Handlers/Stream.php
+++ b/src/Providers/XAI/Handlers/Stream.php
@@ -368,6 +368,7 @@ class Stream
 
         $request->addMessage(new AssistantMessage($text, $mappedToolCalls));
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->state->markStepFinished();
         yield new StepFinishEvent(

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -80,6 +80,7 @@ class Text
         $toolResults = $this->callTools($request->tools(), $toolCalls);
 
         $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
 
         $this->addStep($data, $request, $toolResults);
 

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -156,4 +156,13 @@ class Request implements PrismRequest
     {
         return $this->providerTools;
     }
+
+    public function resetToolChoice(): self
+    {
+        if (is_string($this->toolChoice) || $this->toolChoice === ToolChoice::Any) {
+            $this->toolChoice = ToolChoice::Auto;
+        }
+
+        return $this;
+    }
 }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -142,4 +142,13 @@ class Request implements PrismRequest
 
         return $this;
     }
+
+    public function resetToolChoice(): self
+    {
+        if (is_string($this->toolChoice) || $this->toolChoice === ToolChoice::Any) {
+            $this->toolChoice = ToolChoice::Auto;
+        }
+
+        return $this;
+    }
 }

--- a/tests/Fixtures/openai/text-with-specific-tool-choice-1.json
+++ b/tests/Fixtures/openai/text-with-specific-tool-choice-1.json
@@ -1,0 +1,30 @@
+{
+  "id": "resp_test_tool_choice_1",
+  "object": "response",
+  "created_at": 1741989983,
+  "status": "completed",
+  "model": "gpt-4o-2024-08-06",
+  "output": [
+    {
+      "id": "fc_test_tool_call_1",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"city\": \"New York\"}",
+      "call_id": "call_test_1",
+      "name": "weather"
+    }
+  ],
+  "usage": {
+    "input_tokens": 100,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 25,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 125
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_test"
+}

--- a/tests/Fixtures/openai/text-with-specific-tool-choice-2.json
+++ b/tests/Fixtures/openai/text-with-specific-tool-choice-2.json
@@ -1,0 +1,36 @@
+{
+  "id": "resp_test_tool_choice_2",
+  "object": "response",
+  "created_at": 1741989985,
+  "status": "completed",
+  "model": "gpt-4o-2024-08-06",
+  "output": [
+    {
+      "id": "msg_test_final",
+      "type": "message",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "text": "The weather in New York is 72 degrees Fahrenheit and sunny.",
+          "refusal": null
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 150,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 20,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 170
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_test"
+}

--- a/tests/Providers/XAI/StreamTest.php
+++ b/tests/Providers/XAI/StreamTest.php
@@ -323,7 +323,17 @@ it('handles tool choice parameter correctly', function (): void {
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
 
-        return isset($body['tool_choice'])
+        // First request has specific tool choice, subsequent requests have 'auto' after resetToolChoice()
+        if (! isset($body['tool_choice'])) {
+            return false;
+        }
+
+        // After tool calls, toolChoice is reset to 'auto'
+        if ($body['tool_choice'] === 'auto') {
+            return true;
+        }
+
+        return is_array($body['tool_choice'])
             && $body['tool_choice']['type'] === 'function'
             && $body['tool_choice']['function']['name'] === 'get_weather';
     });

--- a/tests/Structured/RequestTest.php
+++ b/tests/Structured/RequestTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Request;
+
+function createStructuredRequestWithToolChoice(string|ToolChoice|null $toolChoice): Request
+{
+    return new Request(
+        systemPrompts: [],
+        model: 'gpt-4',
+        providerKey: 'openai',
+        prompt: 'Hello',
+        messages: [],
+        maxTokens: null,
+        temperature: null,
+        topP: null,
+        clientOptions: [],
+        clientRetry: [3, 100],
+        schema: new ObjectSchema(
+            name: 'user',
+            description: 'A user object',
+            properties: [
+                new StringSchema('name', 'The user name'),
+            ],
+            requiredFields: ['name'],
+        ),
+        mode: StructuredMode::Auto,
+        tools: [],
+        toolChoice: $toolChoice,
+        maxSteps: 5,
+    );
+}
+
+describe('resetToolChoice', function (): void {
+    it('resets string tool choice to auto', function (): void {
+        $request = createStructuredRequestWithToolChoice('weather');
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('resets ToolChoice::Any to auto', function (): void {
+        $request = createStructuredRequestWithToolChoice(ToolChoice::Any);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('does not reset ToolChoice::Auto', function (): void {
+        $request = createStructuredRequestWithToolChoice(ToolChoice::Auto);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('does not reset ToolChoice::None', function (): void {
+        $request = createStructuredRequestWithToolChoice(ToolChoice::None);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::None);
+    });
+
+    it('does not reset null', function (): void {
+        $request = createStructuredRequestWithToolChoice(null);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBeNull();
+    });
+
+    it('returns self for method chaining', function (): void {
+        $request = createStructuredRequestWithToolChoice('weather');
+
+        $result = $request->resetToolChoice();
+
+        expect($result)->toBe($request);
+    });
+});

--- a/tests/Text/RequestTest.php
+++ b/tests/Text/RequestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Text\Request;
+
+function createTextRequestWithToolChoice(string|ToolChoice|null $toolChoice): Request
+{
+    return new Request(
+        model: 'gpt-4',
+        providerKey: 'openai',
+        systemPrompts: [],
+        prompt: 'Hello',
+        messages: [],
+        maxSteps: 5,
+        maxTokens: null,
+        temperature: null,
+        topP: null,
+        tools: [],
+        clientOptions: [],
+        clientRetry: [3, 100],
+        toolChoice: $toolChoice,
+    );
+}
+
+describe('resetToolChoice', function (): void {
+    it('resets string tool choice to auto', function (): void {
+        $request = createTextRequestWithToolChoice('weather');
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('resets ToolChoice::Any to auto', function (): void {
+        $request = createTextRequestWithToolChoice(ToolChoice::Any);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('does not reset ToolChoice::Auto', function (): void {
+        $request = createTextRequestWithToolChoice(ToolChoice::Auto);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::Auto);
+    });
+
+    it('does not reset ToolChoice::None', function (): void {
+        $request = createTextRequestWithToolChoice(ToolChoice::None);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBe(ToolChoice::None);
+    });
+
+    it('does not reset null', function (): void {
+        $request = createTextRequestWithToolChoice(null);
+
+        $request->resetToolChoice();
+
+        expect($request->toolChoice())->toBeNull();
+    });
+
+    it('returns self for method chaining', function (): void {
+        $request = createTextRequestWithToolChoice('weather');
+
+        $result = $request->resetToolChoice();
+
+        expect($result)->toBe($request);
+    });
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes #822 

When a specific tool name was set, the `toolChoice` property persisted across all step iterations, forcing the model to call the same tool repeatedly until `maxSteps` was reached. This PR adds a `resetToolChoice()` method that resets forced tool choices to `ToolChoice::Auto` after the first tool call, allowing the model to decide naturally on subsequent iterations.

**Reset behavior:**
- `string` (specific tool name) → `ToolChoice::Auto`
- `ToolChoice::Any` → `ToolChoice::Auto`
- `ToolChoice::Auto`, `ToolChoice::None`, `null` → unchanged

