### PR TITLE
docs: fix header anchor symbol visibility

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -193,6 +193,10 @@ div[class*="language-"] {
   border-top: none !important;
 }
 
+.header-anchor {
+  -webkit-text-fill-color: currentColor;
+}
+
 /* Header anchors with vaporwave color */
 .header-anchor:hover {
   color: var(--vp-c-brand-1);


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
### Changes
- Fixed header anchor "#" symbol not appearing on hover

### Issue
The anchor links were being generated but remained invisible due to inheriting `-webkit-text-fill-color: transparent` from the gradient-styled headings.

### Solution
Added `-webkit-text-fill-color: currentColor` to `.header-anchor` to override the inherited transparent fill, making the "#" symbol visible while preserving the heading gradient effect.
