### PR TITLE
fix: laravel mcp structured usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "symplify/rule-doc-generator-contracts": "^11.2",
     "phpstan/phpdoc-parser": "^2.0",
     "spatie/laravel-ray": "^1.39",
-    "laravel/mcp": "^0.3.2"
+    "laravel/mcp": "^0.5.2"
   },
   "autoload-dev": {
     "psr-4": {

--- a/tests/Tools/LaravelMcpToolTest.php
+++ b/tests/Tools/LaravelMcpToolTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Tool as McpTool;
+use Prism\Prism\Tools\LaravelMcpTool;
+
+it('can handle a tool that returns a Response', function (): void {
+    $mcpTool = new class extends McpTool
+    {
+        protected string $name = 'test-tool';
+
+        protected string $description = 'A test tool';
+
+        public function handle(Request $request): Response
+        {
+            return Response::text('Hello, World!');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $tool = new LaravelMcpTool($mcpTool);
+
+    $result = $tool->handle();
+
+    expect($result)->toBe('Hello, World!');
+});
+
+it('can handle a tool that returns a ResponseFactory from Response::structured()', function (): void {
+    $mcpTool = new class extends McpTool
+    {
+        protected string $name = 'structured-tool';
+
+        protected string $description = 'A tool that returns structured data';
+
+        public function handle(Request $request): ResponseFactory
+        {
+            return Response::structured([
+                'status' => 'success',
+                'data' => [
+                    'id' => 123,
+                    'name' => 'Test',
+                ],
+            ]);
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $tool = new LaravelMcpTool($mcpTool);
+
+    $result = $tool->handle();
+
+    expect($result)->toContain('"status": "success"')
+        ->and($result)->toContain('"id": 123')
+        ->and($result)->toContain('"name": "Test"');
+});
+
+it('can handle a tool that returns a ResponseFactory from Response::make()', function (): void {
+    $mcpTool = new class extends McpTool
+    {
+        protected string $name = 'make-tool';
+
+        protected string $description = 'A tool that uses Response::make()';
+
+        public function handle(Request $request): ResponseFactory
+        {
+            return Response::make([
+                Response::text('First response'),
+                Response::text('Second response'),
+            ]);
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $tool = new LaravelMcpTool($mcpTool);
+
+    $result = $tool->handle();
+
+    expect($result)->toBe("First response\nSecond response");
+});
+
+it('can handle a tool that returns a Generator of Responses', function (): void {
+    $mcpTool = new class extends McpTool
+    {
+        protected string $name = 'generator-tool';
+
+        protected string $description = 'A tool that yields responses';
+
+        /** @return \Generator<Response> */
+        public function handle(Request $request): \Generator
+        {
+            yield Response::text('Yielded first');
+            yield Response::text('Yielded second');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $tool = new LaravelMcpTool($mcpTool);
+
+    $result = $tool->handle();
+
+    expect($result)->toBe("Yielded first\nYielded second");
+});


### PR DESCRIPTION
## Description

Fixes #788

When a Laravel MCP tool returns `Response::structured()` or `Response::make()`, Prism throws an error because these methods return a `ResponseFactory` instead of a `Response`. The `ResponseFactory` class is neither iterable nor has a `content()` method, causing the code to fail.

This PR adds explicit handling for `ResponseFactory` in `LaravelMcpTool::__invoke()` by extracting the responses from the factory and converting them to strings.

### Changes

- Add `ResponseFactory` import and type annotation in `LaravelMcpTool`
- Handle `ResponseFactory` responses by calling `responses()` and mapping content to strings
- Add integration tests for all response types (single Response, ResponseFactory, Generator)
- Bump `laravel/mcp` dependency to `^0.5.2`
