### PR TITLE
Enhance provider errors

### DIFF
--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -68,6 +68,24 @@ class PrismException extends Exception
         ]), previous: $previous);
     }
 
+    public static function providerRequestErrorWithDetails(
+        string $provider,
+        int $statusCode,
+        ?string $errorType,
+        ?string $errorMessage,
+        ?Throwable $previous = null
+    ): self {
+        $message = sprintf(
+            '%s Error [%d]: %s%s',
+            $provider,
+            $statusCode,
+            $errorType !== null ? "{$errorType} - " : '',
+            $errorMessage ?? 'Unknown error'
+        );
+
+        return new self($message, $statusCode, $previous);
+    }
+
     public static function unsupportedProviderAction(string $method, string $provider): self
     {
         return new self(sprintf(

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -87,8 +87,21 @@ class Anthropic extends Provider
             ),
             529 => throw PrismProviderOverloadedException::make(ProviderName::Anthropic),
             413 => throw PrismRequestTooLargeException::make(ProviderName::Anthropic),
-            default => throw PrismException::providerRequestError($model, $e),
+            default => $this->handleResponseErrors($e),
         };
+    }
+
+    protected function handleResponseErrors(RequestException $e): never
+    {
+        $data = $e->response->json() ?? [];
+
+        throw PrismException::providerRequestErrorWithDetails(
+            provider: 'Anthropic',
+            statusCode: $e->response->getStatusCode(),
+            errorType: data_get($data, 'error.type'),
+            errorMessage: data_get($data, 'error.message'),
+            previous: $e
+        );
     }
 
     /**

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -130,8 +130,21 @@ class Mistral extends Provider
             ),
             529 => throw PrismProviderOverloadedException::make(ProviderName::Mistral),
             413 => throw PrismRequestTooLargeException::make(ProviderName::Mistral),
-            default => throw PrismException::providerRequestError($model, $e),
+            default => $this->handleResponseErrors($e),
         };
+    }
+
+    protected function handleResponseErrors(RequestException $e): never
+    {
+        $data = $e->response->json() ?? [];
+
+        throw PrismException::providerRequestErrorWithDetails(
+            provider: 'Mistral',
+            statusCode: $e->response->getStatusCode(),
+            errorType: data_get($data, 'type') ?? data_get($data, 'object'),
+            errorMessage: data_get($data, 'message'),
+            previous: $e
+        );
     }
 
     /**

--- a/tests/Providers/Anthropic/ExceptionHandlingTest.php
+++ b/tests/Providers/Anthropic/ExceptionHandlingTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Anthropic\Anthropic;
+
+beforeEach(function (): void {
+    $this->provider = new Anthropic(
+        apiKey: 'test-key',
+        apiVersion: '2023-06-01',
+        url: 'https://api.anthropic.com/v1'
+    );
+});
+
+function createAnthropicMockResponse(int $statusCode, array $json = [], array $headers = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+
+    if (isset($headers['retry-after'])) {
+        $mockResponse->shouldReceive('hasHeader')->with('retry-after')->andReturn(true);
+        $mockResponse->shouldReceive('getHeader')->with('retry-after')->andReturn([$headers['retry-after']]);
+    } else {
+        $mockResponse->shouldReceive('hasHeader')->with('retry-after')->andReturn(false);
+    }
+
+    // Rate limit headers for Anthropic
+    $mockResponse->shouldReceive('getHeaders')->andReturn([]);
+
+    return $mockResponse;
+}
+
+it('handles rate limit errors (429)', function (): void {
+    $mockResponse = createAnthropicMockResponse(429, [
+        'error' => ['type' => 'rate_limit_error', 'message' => 'Rate limit exceeded'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismRateLimitedException::class);
+});
+
+it('handles provider overloaded errors (529)', function (): void {
+    $mockResponse = createAnthropicMockResponse(529, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismProviderOverloadedException::class);
+});
+
+it('handles request too large errors (413)', function (): void {
+    $mockResponse = createAnthropicMockResponse(413, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismRequestTooLargeException::class);
+});
+
+it('handles errors with detailed error information', function (): void {
+    $mockResponse = createAnthropicMockResponse(400, [
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'messages: text content blocks must be non-empty',
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismException::class, 'Anthropic Error [400]: invalid_request_error - messages: text content blocks must be non-empty');
+});
+
+it('handles errors without error type', function (): void {
+    $mockResponse = createAnthropicMockResponse(500, [
+        'error' => ['message' => 'Internal server error'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismException::class, 'Anthropic Error [500]: Internal server error');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createAnthropicMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('claude-3-opus', $exception))
+        ->toThrow(PrismException::class, 'Anthropic Error [500]: Unknown error');
+});

--- a/tests/Providers/Gemini/ExceptionHandlingTest.php
+++ b/tests/Providers/Gemini/ExceptionHandlingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Providers\Gemini\Gemini;
+
+beforeEach(function (): void {
+    $this->provider = new Gemini(
+        apiKey: 'test-key',
+        url: 'https://generativelanguage.googleapis.com/v1beta'
+    );
+});
+
+function createGeminiMockResponse(int $statusCode, array $json = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+
+    return $mockResponse;
+}
+
+it('handles rate limit errors (429)', function (): void {
+    $mockResponse = createGeminiMockResponse(429, [
+        'error' => ['status' => 'RESOURCE_EXHAUSTED', 'message' => 'Rate limit exceeded'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gemini-pro', $exception))
+        ->toThrow(PrismRateLimitedException::class);
+});
+
+it('handles provider overloaded errors (503)', function (): void {
+    $mockResponse = createGeminiMockResponse(503, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gemini-pro', $exception))
+        ->toThrow(PrismProviderOverloadedException::class);
+});
+
+it('handles errors with status and message', function (): void {
+    $mockResponse = createGeminiMockResponse(400, [
+        'error' => [
+            'status' => 'INVALID_ARGUMENT',
+            'message' => 'Invalid value at \'contents\' (type.googleapis.com/google.ai.generativelanguage.v1beta.Content)',
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gemini-pro', $exception))
+        ->toThrow(PrismException::class, 'Gemini Error [400]: INVALID_ARGUMENT - Invalid value at \'contents\'');
+});
+
+it('handles errors without error status', function (): void {
+    $mockResponse = createGeminiMockResponse(500, [
+        'error' => ['message' => 'Internal server error'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gemini-pro', $exception))
+        ->toThrow(PrismException::class, 'Gemini Error [500]: Internal server error');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createGeminiMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gemini-pro', $exception))
+        ->toThrow(PrismException::class, 'Gemini Error [500]: Unknown error');
+});

--- a/tests/Providers/Groq/ExceptionHandlingTest.php
+++ b/tests/Providers/Groq/ExceptionHandlingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Groq\Groq;
+
+beforeEach(function (): void {
+    $this->provider = new Groq(
+        apiKey: 'test-key',
+        url: 'https://api.groq.com/openai/v1'
+    );
+});
+
+function createGroqMockResponse(int $statusCode, array $json = [], array $headers = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+    $mockResponse->shouldReceive('header')->with('retry-after')->andReturn($headers['retry-after'] ?? '0');
+    $mockResponse->shouldReceive('getHeaders')->andReturn([]);
+
+    return $mockResponse;
+}
+
+it('handles rate limit errors (429)', function (): void {
+    $mockResponse = createGroqMockResponse(429, [
+        'error' => ['type' => 'rate_limit_error', 'message' => 'Rate limit exceeded'],
+    ], ['retry-after' => '60']);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismRateLimitedException::class);
+});
+
+it('handles provider overloaded errors (529)', function (): void {
+    $mockResponse = createGroqMockResponse(529, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismProviderOverloadedException::class);
+});
+
+it('handles request too large errors (413)', function (): void {
+    $mockResponse = createGroqMockResponse(413, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismRequestTooLargeException::class);
+});
+
+it('handles errors with detailed error information', function (): void {
+    $mockResponse = createGroqMockResponse(400, [
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'Invalid request parameters',
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismException::class, 'Groq Error [400]: invalid_request_error - Invalid request parameters');
+});
+
+it('handles errors without error type', function (): void {
+    $mockResponse = createGroqMockResponse(500, [
+        'error' => ['message' => 'Internal server error'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismException::class, 'Groq Error [500]: Internal server error');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createGroqMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3-8b-8192', $exception))
+        ->toThrow(PrismException::class, 'Groq Error [500]: Unknown error');
+});

--- a/tests/Providers/Mistral/ExceptionHandlingTest.php
+++ b/tests/Providers/Mistral/ExceptionHandlingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Mistral\Mistral;
+
+beforeEach(function (): void {
+    $this->provider = new Mistral(
+        apiKey: 'test-key',
+        url: 'https://api.mistral.ai/v1'
+    );
+});
+
+function createMistralMockResponse(int $statusCode, array $json = [], array $headers = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+    $mockResponse->shouldReceive('getHeaders')->andReturn($headers);
+    $mockResponse->shouldReceive('header')->with('ratelimitbysize-limit')->andReturn($headers['ratelimitbysize-limit'] ?? '0');
+    $mockResponse->shouldReceive('header')->with('ratelimitbysize-remaining')->andReturn($headers['ratelimitbysize-remaining'] ?? '0');
+    $mockResponse->shouldReceive('header')->with('ratelimitbysize-reset')->andReturn($headers['ratelimitbysize-reset'] ?? '0');
+
+    return $mockResponse;
+}
+
+it('handles rate limit errors (429)', function (): void {
+    $mockResponse = createMistralMockResponse(429, [
+        'object' => 'error',
+        'message' => 'Rate limit exceeded',
+        'type' => 'rate_limit_error',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismRateLimitedException::class);
+});
+
+it('handles provider overloaded errors (529)', function (): void {
+    $mockResponse = createMistralMockResponse(529, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismProviderOverloadedException::class);
+});
+
+it('handles request too large errors (413)', function (): void {
+    $mockResponse = createMistralMockResponse(413, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismRequestTooLargeException::class);
+});
+
+it('handles errors with type and message', function (): void {
+    $mockResponse = createMistralMockResponse(400, [
+        'object' => 'error',
+        'type' => 'invalid_request_error',
+        'message' => 'Invalid model specified',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismException::class, 'Mistral Error [400]: invalid_request_error - Invalid model specified');
+});
+
+it('handles errors with object fallback for type', function (): void {
+    $mockResponse = createMistralMockResponse(400, [
+        'object' => 'error',
+        'message' => 'Invalid model specified',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismException::class, 'Mistral Error [400]: error - Invalid model specified');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createMistralMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('mistral-large', $exception))
+        ->toThrow(PrismException::class, 'Mistral Error [500]: Unknown error');
+});

--- a/tests/Providers/Ollama/ExceptionHandlingTest.php
+++ b/tests/Providers/Ollama/ExceptionHandlingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Ollama\Ollama;
+
+beforeEach(function (): void {
+    $this->provider = new Ollama(
+        apiKey: '',
+        url: 'http://localhost:11434'
+    );
+});
+
+function createOllamaMockResponse(int $statusCode, array $json = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+
+    return $mockResponse;
+}
+
+it('handles errors with error message', function (): void {
+    $mockResponse = createOllamaMockResponse(400, [
+        'error' => 'model "unknown-model" not found',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('unknown-model', $exception))
+        ->toThrow(PrismException::class, 'Ollama Error [400]: model "unknown-model" not found');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createOllamaMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3', $exception))
+        ->toThrow(PrismException::class, 'Ollama Error [500]: Unknown error');
+});
+
+it('handles server errors', function (): void {
+    $mockResponse = createOllamaMockResponse(503, [
+        'error' => 'Service unavailable',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('llama3', $exception))
+        ->toThrow(PrismException::class, 'Ollama Error [503]: Service unavailable');
+});

--- a/tests/Providers/OpenAI/ExceptionHandlingTest.php
+++ b/tests/Providers/OpenAI/ExceptionHandlingTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\OpenAI\OpenAI;
+
+beforeEach(function (): void {
+    $this->provider = new OpenAI(
+        apiKey: 'test-key',
+        url: 'https://api.openai.com/v1',
+        organization: null,
+        project: null
+    );
+});
+
+function createOpenAIMockResponse(int $statusCode, array $json = [], array $headers = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+    $mockResponse->shouldReceive('header')->with('retry-after')->andReturn($headers['retry-after'] ?? '0');
+    $mockResponse->shouldReceive('getHeaders')->andReturn([]);
+
+    return $mockResponse;
+}
+
+it('handles rate limit errors (429)', function (): void {
+    $mockResponse = createOpenAIMockResponse(429, [
+        'error' => ['type' => 'rate_limit_error', 'message' => 'Rate limit exceeded'],
+    ], ['retry-after' => '60']);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismRateLimitedException::class);
+});
+
+it('handles provider overloaded errors (529)', function (): void {
+    $mockResponse = createOpenAIMockResponse(529, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismProviderOverloadedException::class);
+});
+
+it('handles request too large errors (413)', function (): void {
+    $mockResponse = createOpenAIMockResponse(413, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismRequestTooLargeException::class);
+});
+
+it('handles errors with detailed error information', function (): void {
+    $mockResponse = createOpenAIMockResponse(400, [
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'Invalid model specified',
+            'param' => 'model',
+            'code' => 'model_not_found',
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismException::class, 'OpenAI Error [400]: invalid_request_error - Invalid model specified');
+});
+
+it('handles errors without error type', function (): void {
+    $mockResponse = createOpenAIMockResponse(500, [
+        'error' => ['message' => 'Internal server error'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismException::class, 'OpenAI Error [500]: Internal server error');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createOpenAIMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismException::class, 'OpenAI Error [500]: Unknown error');
+});
+
+it('handles errors with array message', function (): void {
+    $mockResponse = createOpenAIMockResponse(400, [
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => ['First error', 'Second error'],
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('gpt-4o', $exception))
+        ->toThrow(PrismException::class, 'OpenAI Error [400]: invalid_request_error - First error, Second error');
+});

--- a/tests/Providers/VoyageAI/ExceptionHandlingTest.php
+++ b/tests/Providers/VoyageAI/ExceptionHandlingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\VoyageAI\VoyageAI;
+
+beforeEach(function (): void {
+    $this->provider = new VoyageAI(
+        apiKey: 'test-key',
+        baseUrl: 'https://api.voyageai.com/v1'
+    );
+});
+
+function createVoyageAIMockResponse(int $statusCode, array $json = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+
+    return $mockResponse;
+}
+
+it('handles errors with detail message', function (): void {
+    $mockResponse = createVoyageAIMockResponse(400, [
+        'detail' => 'Invalid input: text cannot be empty',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('voyage-3', $exception))
+        ->toThrow(PrismException::class, 'VoyageAI Error [400]: Invalid input: text cannot be empty');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createVoyageAIMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('voyage-3', $exception))
+        ->toThrow(PrismException::class, 'VoyageAI Error [500]: Unknown error');
+});
+
+it('handles authentication errors', function (): void {
+    $mockResponse = createVoyageAIMockResponse(401, [
+        'detail' => 'Invalid API key',
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('voyage-3', $exception))
+        ->toThrow(PrismException::class, 'VoyageAI Error [401]: Invalid API key');
+});

--- a/tests/Providers/XAI/ExceptionHandlingTest.php
+++ b/tests/Providers/XAI/ExceptionHandlingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\XAI\XAI;
+
+beforeEach(function (): void {
+    $this->provider = new XAI(
+        apiKey: 'test-key',
+        url: 'https://api.x.ai/v1'
+    );
+});
+
+function createXAIMockResponse(int $statusCode, array $json = []): Response
+{
+    $mockResponse = Mockery::mock(Response::class);
+    $mockResponse->shouldReceive('getStatusCode')->andReturn($statusCode);
+    $mockResponse->shouldReceive('status')->andReturn($statusCode);
+    $mockResponse->shouldReceive('json')->andReturn($json);
+    $mockResponse->shouldReceive('toPsrResponse')->andReturn(new PsrResponse($statusCode));
+
+    return $mockResponse;
+}
+
+it('handles errors with detailed error information', function (): void {
+    $mockResponse = createXAIMockResponse(400, [
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'Invalid request parameters',
+        ],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('grok-2', $exception))
+        ->toThrow(PrismException::class, 'XAI Error [400]: invalid_request_error - Invalid request parameters');
+});
+
+it('handles errors without error type', function (): void {
+    $mockResponse = createXAIMockResponse(500, [
+        'error' => ['message' => 'Internal server error'],
+    ]);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('grok-2', $exception))
+        ->toThrow(PrismException::class, 'XAI Error [500]: Internal server error');
+});
+
+it('handles errors without any error details', function (): void {
+    $mockResponse = createXAIMockResponse(500, []);
+    $exception = new RequestException($mockResponse);
+
+    expect(fn () => $this->provider->handleRequestException('grok-2', $exception))
+        ->toThrow(PrismException::class, 'XAI Error [500]: Unknown error');
+});


### PR DESCRIPTION
## Description

Closes #844

Improves error messages when providers return error responses. Previously, exceptions only included the generic HTTP message (e.g., "HTTP request returned status code 400"). Now, exceptions include the actual error details from the response body.

**Before:**
```
Sending to model (claude-3-opus) failed: HTTP request returned status code 400
```

**After:**
```
Anthropic Error [400]: invalid_request_error - messages: text content blocks must be non-empty
```

## Changes

- Added `PrismException::providerRequestErrorWithDetails()` factory method that accepts structured error data (provider name, status code, error type, error message)
- Updated all providers to parse their error response formats and use the new factory method:
  - **Anthropic**: Parses `error.type` and `error.message`
  - **OpenAI**: Parses `error.type` and `error.message` (now applies to all errors, not just 400)
  - **Gemini**: Parses `error.status` and `error.message`
  - **Mistral**: Parses `type`/`object` and `message`
  - **Groq**: Parses `error.type` and `error.message`
  - **DeepSeek**: Parses `error.type` and `error.message`
  - **Ollama**: Parses `error` string
  - **XAI**: Parses `error.type` and `error.message`
  - **VoyageAI**: Parses `detail`
- Added `handleRequestException` to Ollama, XAI, and VoyageAI providers (previously relied on base class)
- Added unit tests for exception handling across all updated providers
