### PR TITLE
Testing stream docs

### DIFF
--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -406,6 +406,17 @@ it('can generate embeddings', function () {
 
 `PrismFake` provides several helpful assertion methods:
 
+> [!NOTE]
+> When testing streamed responses, you must consume the stream before assertions will work. The `asStream()` method returns a generator, and the request is only recorded once the generator is iterated.
+>
+> ```php
+> // Consume the stream before making assertions
+> $chunks = collect($prism->asStream());
+>
+> // Now assertions will work
+> $fake->assertCallCount(1);
+> ```
+
 ```php
 // Assert specific prompt was sent
 $fake->assertPrompt('Who are you?');


### PR DESCRIPTION
## Description

Closes #749

Adds documentation note explaining that streams must be consumed before `PrismFake` assertions will work.

## Changes

- Added a note in the Assertions section of `docs/core-concepts/testing.md` clarifying that `asStream()` returns a generator and the request is only recorded once iterated
- Included example code showing how to consume the stream before making assertions
