### PR TITLE
fix return type mismatch

### DIFF
--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -89,7 +89,7 @@ readonly class ResponseBuilder
         return $this->steps
             ->flatMap(fn (Step $step): array => $step->toolCalls)
             ->values()
-            ->toArray();
+            ->all();
     }
 
     /**


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
The return type from the comments and where it is called in other places in the code is not compatible with ->toArray(). switching to ->all() should keep the type as a ToolCall
