### PR TITLE
fix(openai): stream start order

### DIFF
--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -250,6 +250,8 @@ class Stream
                     timestamp: time(),
                     messageId: $this->state->messageId()
                 );
+
+                $this->state->markTextCompleted();
             }
 
             if (data_get($data, 'type') === 'response.completed') {

--- a/src/Streaming/StreamState.php
+++ b/src/Streaming/StreamState.php
@@ -118,6 +118,13 @@ class StreamState
         return $this;
     }
 
+    public function markTextCompleted(): self
+    {
+        $this->textStarted = false;
+
+        return $this;
+    }
+
     public function markThinkingStarted(): self
     {
         $this->thinkingStarted = true;

--- a/tests/Unit/Streaming/StreamStateTest.php
+++ b/tests/Unit/Streaming/StreamStateTest.php
@@ -101,6 +101,17 @@ it('markTextStarted returns self and sets flag', function (): void {
         ->and($state->hasTextStarted())->toBeTrue();
 });
 
+it('markTextCompleted returns self and resets flag', function (): void {
+    $state = new StreamState;
+    $state->markTextStarted();
+
+    $result = $state->markTextCompleted();
+
+    expect($result)->toBe($state)
+        ->and($state->hasTextStarted())->toBeFalse()
+        ->and($state->shouldEmitTextStart())->toBeTrue();
+});
+
 it('markThinkingStarted returns self and sets flag', function (): void {
     $state = new StreamState;
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes #870

## Changes

- Added `markTextCompleted()` method to `StreamState` that resets the `textStarted` flag
- Called `markTextCompleted()` after emitting `TextCompleteEvent` in the OpenAI stream handler
- Added unit test for the new method

## Root Cause

When OpenAI returns multiple text content parts in a single response, the handler emitted `TextStart` only once (on first text delta) but `TextComplete` for each part. After the first `TextComplete`, subsequent text deltas arrived without triggering a new `TextStart` because `textStarted` remained `true`.
