### PR TITLE
feat(ToolChoiceMap): add 'required' mapping for ToolChoice::Any and u…

### DIFF
--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -25,6 +25,7 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
+            ToolChoice::Any => 'required',
             null => $toolChoice,
             default => throw new PrismException('Invalid tool choice')
         };

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Enums\ToolChoice;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Facades\Tool;
@@ -132,15 +131,14 @@ describe('Text generation for Groq', function (): void {
     });
 
     it('throws an exception for ToolChoice::Any', function (): void {
-        $this->expectException(PrismException::class);
-        $this->expectExceptionMessage('Invalid tool choice');
+        FixtureResponse::fakeResponseSequence('v1/chat/completions', 'groq/generate-text-with-required-tool-call');
 
         Prism::text()
             ->using('groq', 'gpt-4')
             ->withPrompt('Who are you?')
             ->withToolChoice(ToolChoice::Any)
             ->asText();
-    });
+    })->throwsNoExceptions();
 });
 
 describe('Image support with grok', function (): void {


### PR DESCRIPTION
### Add support for ToolChoice::Any (required tool choice) in Groq provider

Adds support for the required tool choice mode (ToolChoice::Any) in the Groq provider, allowing the model to be forced to use a tool when needed.

[Issue 478](https://github.com/prism-php/prism/issues/478)