### PR TITLE
feat(openai): Image generation meta

### DIFF
--- a/src/Providers/OpenAI/Handlers/Images.php
+++ b/src/Providers/OpenAI/Handlers/Images.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Prism\Prism\Images\Request;
 use Prism\Prism\Images\Response;
@@ -46,6 +47,13 @@ class Images
                 rateLimits: $this->processRateLimits($response),
             ),
             images: $images,
+            additionalContent: Arr::whereNotNull([
+                'input_tokens_details' => data_get($data, 'usage.input_tokens_details'),
+                'quality' => data_get($data, 'quality'),
+                'size' => data_get($data, 'size'),
+                'output_format' => data_get($data, 'output_format'),
+                'background' => data_get($data, 'background'),
+            ]),
             raw: $data,
         );
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes https://github.com/prism-php/prism/issues/583

Surfaces OpenAI-specific image response metadata via `additionalContent` on the image response. This includes `input_tokens_details` (text_tokens, image_tokens) and resolved parameters (quality, size, output_format, background) returned by gpt-image-1.

Uses `Arr::whereNotNull()` so older models (DALL-E 2/3) that don't return these fields simply have an empty `additionalContent` array — no breaking changes.

## Changes

- **`src/Providers/OpenAI/Handlers/Images.php`** — Populate `additionalContent` on the `ResponseBuilder` with `input_tokens_details`, `quality`, `size`, `output_format`, and `background` from the API response
- **`tests/Providers/OpenAI/ImagesTest.php`** — Assert `additionalContent` values for gpt-image-1 generation and image edit responses; assert empty `additionalContent` for DALL-E 3 (no regression)
