### PR TITLE
fix(streaming): artifact data protocol key

### DIFF
--- a/docs/core-concepts/streaming-output.md
+++ b/docs/core-concepts/streaming-output.md
@@ -417,7 +417,7 @@ eventSource.addEventListener('text_delta', (event) => {
 
 ### Artifact Events with Vercel AI SDK
 
-When using `asDataStreamResponse()`, artifacts are sent as data protocol messages with type `artifact`:
+When using `asDataStreamResponse()`, artifacts are sent as custom data parts with type `data-artifact`:
 
 ```javascript
 import { useChat } from '@ai-sdk/react';
@@ -433,8 +433,8 @@ export default function Chat() {
         },
         onData: (data) => {
             // Handle artifact data messages
-            if (data.type === 'artifact') {
-                setArtifacts(prev => [...prev, data.artifact]);
+            if (data.type === 'data-artifact') {
+                setArtifacts(prev => [...prev, data.data.artifact]);
             }
         },
     });

--- a/src/Streaming/Adapters/DataProtocolAdapter.php
+++ b/src/Streaming/Adapters/DataProtocolAdapter.php
@@ -276,14 +276,16 @@ class DataProtocolAdapter
     protected function handleArtifact(ArtifactEvent $event): array
     {
         return [
-            'type' => 'artifact',
-            'toolCallId' => $event->toolCallId,
-            'toolName' => $event->toolName,
-            'artifact' => [
-                'id' => $event->artifact->id,
-                'mimeType' => $event->artifact->mimeType,
-                'data' => $event->artifact->data,
-                'metadata' => $event->artifact->metadata,
+            'type' => 'data-artifact',
+            'data' => [
+                'toolCallId' => $event->toolCallId,
+                'toolName' => $event->toolName,
+                'artifact' => [
+                    'id' => $event->artifact->id,
+                    'mimeType' => $event->artifact->mimeType,
+                    'data' => $event->artifact->data,
+                    'metadata' => $event->artifact->metadata,
+                ],
             ],
         ];
     }


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

`DataProtocolAdapter::handleArtifact()` emitted artifact events with `type: "artifact"`, which fails Zod validation in `@ai-sdk/react` v2's `useChat`. The AI SDK only accepts custom data parts with a `data-` prefix.

### Changes

- Changed artifact event type from `artifact` to `data-artifact`
- Nested the payload (`toolCallId`, `toolName`, `artifact`) under a `data` key, matching the convention already used by `handleDefault()`
- Updated Vercel AI SDK documentation example to reflect the new format
- Added test verifying the `data-artifact` type and nested structure

### Breaking Change

Consumers parsing the raw stream need to update artifact handling:

```diff
- if (data.type === 'artifact') {
-     artifacts.set(data.toolCallId, data.artifact);
+ if (data.type === 'data-artifact') {
+     artifacts.set(data.data.toolCallId, data.data.artifact);
  }
```
