### PR TITLE
Fixed tool calls message ID reset to empty

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -351,7 +351,7 @@ class Stream
             $depth++;
             if ($depth < $request->maxSteps()) {
                 $previousUsage = $this->state->usage();
-                $this->state->reset();
+                $this->state->reset()->withMessageId(EventID::generate());
                 $this->currentThoughtSignature = null;
                 $nextResponse = $this->sendRequest($request);
                 yield from $this->processStream($nextResponse, $request, $depth);


### PR DESCRIPTION
## Description
After executing the tool call, the message ID is reset to null.