### PR TITLE
Use the container to resolve broadcast classes

### DIFF
--- a/src/Streaming/Adapters/BroadcastAdapter.php
+++ b/src/Streaming/Adapters/BroadcastAdapter.php
@@ -61,7 +61,7 @@ class BroadcastAdapter
     public function __invoke(Generator $events, ?PendingRequest $pendingRequest = null, ?callable $callback = null): void
     {
         /** @var Collection<int, StreamEvent> $collectedEvents */
-        $collectedEvents = new Collection;
+        $collectedEvents = resolve(Collection::class);
 
         foreach ($events as $event) {
             $collectedEvents->push($event);
@@ -76,23 +76,23 @@ class BroadcastAdapter
     protected function broadcastEvent(StreamEvent $event): ShouldBroadcast
     {
         return match ($event::class) {
-            StreamStartEvent::class => new StreamStartBroadcast($event, $this->channels),
-            StepStartEvent::class => new StepStartBroadcast($event, $this->channels),
-            TextStartEvent::class => new TextStartBroadcast($event, $this->channels),
-            TextDeltaEvent::class => new TextDeltaBroadcast($event, $this->channels),
-            TextCompleteEvent::class => new TextCompleteBroadcast($event, $this->channels),
-            ThinkingStartEvent::class => new ThinkingStartBroadcast($event, $this->channels),
-            ThinkingEvent::class => new ThinkingBroadcast($event, $this->channels),
-            ThinkingCompleteEvent::class => new ThinkingCompleteBroadcast($event, $this->channels),
-            ToolCallEvent::class => new ToolCallBroadcast($event, $this->channels),
-            ToolCallDeltaEvent::class => new ToolCallDeltaBroadcast($event, $this->channels),
-            ToolResultEvent::class => new ToolResultBroadcast($event, $this->channels),
-            ArtifactEvent::class => new ArtifactBroadcast($event, $this->channels),
-            CitationEvent::class => new CitationBroadcast($event, $this->channels),
-            ProviderToolEvent::class => new ProviderToolEventBroadcast($event, $this->channels),
-            ErrorEvent::class => new ErrorBroadcast($event, $this->channels),
-            StepFinishEvent::class => new StepFinishBroadcast($event, $this->channels),
-            StreamEndEvent::class => new StreamEndBroadcast($event, $this->channels),
+            StreamStartEvent::class => resolve(StreamStartBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            StepStartEvent::class => resolve(StepStartBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            TextStartEvent::class => resolve(TextStartBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            TextDeltaEvent::class => resolve(TextDeltaBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            TextCompleteEvent::class => resolve(TextCompleteBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ThinkingStartEvent::class => resolve(ThinkingStartBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ThinkingEvent::class => resolve(ThinkingBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ThinkingCompleteEvent::class => resolve(ThinkingCompleteBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ToolCallEvent::class => resolve(ToolCallBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ToolCallDeltaEvent::class => resolve(ToolCallDeltaBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ToolResultEvent::class => resolve(ToolResultBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ArtifactEvent::class => resolve(ArtifactBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            CitationEvent::class => resolve(CitationBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ProviderToolEvent::class => resolve(ProviderToolEventBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            ErrorEvent::class => resolve(ErrorBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            StepFinishEvent::class => resolve(StepFinishBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
+            StreamEndEvent::class => resolve(StreamEndBroadcast::class, ['event' => $event, 'channels' => $this->channels]),
             default => throw new InvalidArgumentException('Unsupported event type for broadcasting: '.$event::class),
         };
     }


### PR DESCRIPTION
## Description

This PR changes the `new` keyword usage in the `BroadcastAdapter` to use `resolve()` to pull instances from the container. This allows applications to override/replace specific broadcast classes to override behavior.
