### PR TITLE
Expose request builder methods

### DIFF
--- a/src/Audio/PendingRequest.php
+++ b/src/Audio/PendingRequest.php
@@ -59,7 +59,7 @@ class PendingRequest
         }
     }
 
-    protected function toTextToSpeechRequest(): TextToSpeechRequest
+    public function toTextToSpeechRequest(): TextToSpeechRequest
     {
         if (! is_string($this->input)) {
             throw new InvalidArgumentException('Text-to-speech requires string input');
@@ -76,7 +76,7 @@ class PendingRequest
         );
     }
 
-    protected function toSpeechToTextRequest(): SpeechToTextRequest
+    public function toSpeechToTextRequest(): SpeechToTextRequest
     {
         if (! ($this->input instanceof Audio)) {
             throw new InvalidArgumentException('Speech-to-text requires Audio input');


### PR DESCRIPTION
## Description

The audio request now exposes its `toTextToSpeechRequest` and `toSpeechToTextRequest` methods.

This can be useful for example if you have to preprocess request data in a configurator.

Example code:

```php
<?php

protected function preprocessAudio(): void
{
    try {
        $audio = $this->request->toSpeechToTextRequest()->input();
    } catch (InvalidArgumentException) {
        // Is not a speech-to-text request
        return;
    }

    if (!$audio->hasRawContent()) {
        // Does not have readable content
        return;
    }

    $mimeType = $audio->mimeType();
    $content  = $audio->rawContent();
    Assert::notNull($content);

    // Preprocess $content here

    $audio = Audio::fromRawContent($content, $mimeType);

    $this->request->withInput($audio);
}
```