### PR TITLE
fix: prevent content truncation during OpenRouter reasoning-to-text transition

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -182,9 +182,9 @@ class Stream
                         delta: $reasoningDelta,
                         reasoningId: $this->state->reasoningId()
                     );
-                }
 
-                continue;
+                    continue;
+                }
             }
 
             $content = $this->extractContentDelta($data);


### PR DESCRIPTION
When streaming models that emit thinking tokens (e.g. `qwen/qwen3-8b` via OpenRouter), transition chunks contain an empty `reasoning` field alongside the start of the actual `content`.

`hasReasoningDelta()` uses `isset()`, which returns `true` for empty strings. The unconditional `continue` on line 187 then skips content extraction for these chunks, truncating the first characters of the response.

**Fix:** Move `continue` inside the `$reasoningDelta !== ''` check so that chunks with empty reasoning fall through to content processing.