### PR TITLE
feat(voyageai): add multimodal image embedding support

### DIFF
--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -10,6 +10,7 @@ use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Embedding;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Media\Image;
 use Prism\Prism\ValueObjects\Meta;
 
 class Embeddings
@@ -44,6 +45,18 @@ class Embeddings
 
     protected function sendRequest(): void
     {
+        if ($this->request->hasImages()) {
+            $this->sendMultimodalRequest();
+        } else {
+            $this->sendTextRequest();
+        }
+    }
+
+    /**
+     * Send a text-only embedding request to the /embeddings endpoint.
+     */
+    protected function sendTextRequest(): void
+    {
         $providerOptions = $this->request->providerOptions();
 
         /** @var Response $response */
@@ -55,6 +68,70 @@ class Embeddings
         ]));
 
         $this->httpResponse = $response;
+    }
+
+    /**
+     * Send a multimodal embedding request to the /multimodalembeddings endpoint.
+     *
+     * Each input is an object with a "content" array containing text and/or image parts.
+     * Images and text inputs are combined into separate multimodal input objects.
+     *
+     * @see https://docs.voyageai.com/reference/multimodal-embeddings-api
+     */
+    protected function sendMultimodalRequest(): void
+    {
+        $providerOptions = $this->request->providerOptions();
+        $inputs = [];
+
+        // Each text input becomes a separate multimodal input
+        foreach ($this->request->inputs() as $text) {
+            $inputs[] = [
+                'content' => [
+                    ['type' => 'text', 'text' => $text],
+                ],
+            ];
+        }
+
+        // Each image becomes a separate multimodal input
+        foreach ($this->request->images() as $image) {
+            $inputs[] = [
+                'content' => [
+                    $this->mapImage($image),
+                ],
+            ];
+        }
+
+        /** @var Response $response */
+        $response = $this->client->post('multimodalembeddings', Arr::whereNotNull([
+            'model' => $this->request->model(),
+            'inputs' => $inputs,
+            'input_type' => $providerOptions['inputType'] ?? null,
+            'truncation' => $providerOptions['truncation'] ?? null,
+        ]));
+
+        $this->httpResponse = $response;
+    }
+
+    /**
+     * Map a Prism Image to a Voyage multimodal content part.
+     *
+     * @return array{type: string, image_base64?: string, image_url?: string}
+     */
+    protected function mapImage(Image $image): array
+    {
+        if ($image->isUrl()) {
+            return [
+                'type' => 'image_url',
+                'image_url' => (string) $image->url(),
+            ];
+        }
+
+        $mimeType = $image->mimeType() ?? 'image/jpeg';
+
+        return [
+            'type' => 'image_base64',
+            'image_base64' => "data:{$mimeType};base64,{$image->base64()}",
+        ];
     }
 
     protected function validateResponse(): void

--- a/tests/Fixtures/voyageai/multimodal-embeddings-image-1.json
+++ b/tests/Fixtures/voyageai/multimodal-embeddings-image-1.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[0.012345678,-0.023456789,0.034567890,-0.045678901,0.056789012],"index":0}],"model":"voyage-multimodal-3","usage":{"total_tokens":215}}

--- a/tests/Fixtures/voyageai/multimodal-embeddings-image-url-1.json
+++ b/tests/Fixtures/voyageai/multimodal-embeddings-image-url-1.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[0.098765432,-0.087654321,0.076543210,-0.065432109,0.054321098],"index":0}],"model":"voyage-multimodal-3","usage":{"total_tokens":215}}

--- a/tests/Fixtures/voyageai/multimodal-embeddings-text-and-image-1.json
+++ b/tests/Fixtures/voyageai/multimodal-embeddings-text-and-image-1.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[0.011111111,-0.022222222,0.033333333,-0.044444444,0.055555555],"index":0},{"object":"embedding","embedding":[0.066666666,-0.077777777,0.088888888,-0.099999999,0.010101010],"index":1}],"model":"voyage-multimodal-3","usage":{"total_tokens":223}}

--- a/tests/Providers/VoyageAI/MultimodalEmbeddingsTest.php
+++ b/tests/Providers/VoyageAI/MultimodalEmbeddingsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\ValueObjects\Media\Image;
+use Tests\Fixtures\FixtureResponse;
+
+// Minimal 1x1 red PNG for testing
+$testImageBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+it('returns embeddings from an image using the multimodal endpoint', function () use ($testImageBase64): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/multimodal-embeddings-image');
+
+    $image = Image::fromBase64($testImageBase64, 'image/png');
+
+    $response = Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-multimodal-3')
+        ->fromImage($image)
+        ->asEmbeddings();
+
+    expect($response->meta->model)->toBe('voyage-multimodal-3');
+    expect($response->embeddings)->toBeArray();
+    expect($response->embeddings)->toHaveCount(1);
+    expect($response->usage->tokens)->toBe(215);
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'multimodalembeddings')
+        && $request['model'] === 'voyage-multimodal-3'
+        && isset($request['inputs'][0]['content'][0])
+        && $request['inputs'][0]['content'][0]['type'] === 'image_base64');
+});
+
+it('returns embeddings from an image URL using the multimodal endpoint', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/multimodal-embeddings-image-url');
+
+    $image = Image::fromUrl('https://example.com/photo.jpg');
+
+    $response = Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-multimodal-3')
+        ->fromImage($image)
+        ->asEmbeddings();
+
+    expect($response->meta->model)->toBe('voyage-multimodal-3');
+    expect($response->embeddings)->toBeArray();
+    expect($response->embeddings)->toHaveCount(1);
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'multimodalembeddings')
+        && $request['inputs'][0]['content'][0]['type'] === 'image_url'
+        && $request['inputs'][0]['content'][0]['image_url'] === 'https://example.com/photo.jpg');
+});
+
+it('returns embeddings from text and image combined', function () use ($testImageBase64): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/multimodal-embeddings-text-and-image');
+
+    $image = Image::fromBase64($testImageBase64, 'image/png');
+
+    $response = Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-multimodal-3')
+        ->fromInput('A photo of a sunset')
+        ->fromImage($image)
+        ->asEmbeddings();
+
+    expect($response->meta->model)->toBe('voyage-multimodal-3');
+    expect($response->embeddings)->toBeArray();
+    expect($response->embeddings)->toHaveCount(2);
+    expect($response->usage->tokens)->toBe(223);
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'multimodalembeddings')
+        && $request['inputs'][0]['content'][0]['type'] === 'text'
+        && $request['inputs'][1]['content'][0]['type'] === 'image_base64');
+});
+
+it('uses the text-only endpoint when no images are provided', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/embeddings-from-input');
+
+    $response = Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-3-lite')
+        ->fromInput('The food was delicious and the waiter...')
+        ->asEmbeddings();
+
+    expect($response->meta->model)->toBe('voyage-3-lite');
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), '/embeddings')
+        && ! str_contains((string) $request->url(), 'multimodal')
+        && isset($request['input']));
+});
+
+it('passes inputType provider option to multimodal endpoint', function () use ($testImageBase64): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/multimodal-embeddings-image');
+
+    $image = Image::fromBase64($testImageBase64, 'image/png');
+
+    Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-multimodal-3')
+        ->fromImage($image)
+        ->withProviderOptions(['inputType' => 'document'])
+        ->asEmbeddings();
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'multimodalembeddings')
+        && $request['input_type'] === 'document');
+});


### PR DESCRIPTION
## Summary

The Embeddings API already supports image inputs via `fromImage()` / `fromImages()` (added in #789), but the VoyageAI provider was ignoring them and only sending text to the `/embeddings` endpoint.

This PR updates the VoyageAI embeddings handler to route image-containing requests to Voyage's [`/multimodalembeddings`](https://docs.voyageai.com/reference/multimodal-embeddings-api) endpoint with the correct content structure:

- **Base64 images** — sent as `data:{mime};base64,...` format
- **Image URLs** — sent as `image_url` type
- **Mixed text + image** — each input becomes a separate multimodal content object
- **Text-only requests** — unchanged, still use `/embeddings`
- **Provider options** (`inputType`, `truncation`) forwarded to both endpoints

## Example usage

```php
use Prism\Prism\Enums\Provider;
use Prism\Prism\Facades\Prism;
use Prism\Prism\ValueObjects\Media\Image;

// Image embedding
$response = Prism::embeddings()
    ->using(Provider::VoyageAI, 'voyage-multimodal-3')
    ->fromImage(Image::fromStoragePath('photos/sunset.jpg', 's3'))
    ->withProviderOptions(['inputType' => 'document'])
    ->asEmbeddings();

// Text query embedding (for searching against image embeddings)
$response = Prism::embeddings()
    ->using(Provider::VoyageAI, 'voyage-multimodal-3')
    ->fromInput('sunset over the ocean')
    ->withProviderOptions(['inputType' => 'query'])
    ->asEmbeddings();
```

## Test plan

- [x] Image via base64 routes to `/multimodalembeddings`
- [x] Image via URL routes to `/multimodalembeddings` with `image_url` type
- [x] Mixed text + image returns multiple embeddings
- [x] Text-only still uses `/embeddings` (regression)
- [x] Provider options forwarded to multimodal endpoint
- [x] All 1355 existing tests pass