### PR TITLE
fix: encode empty tool arguments as JSON object instead of array

### DIFF
--- a/src/Providers/DeepSeek/Maps/MessageMap.php
+++ b/src/Providers/DeepSeek/Maps/MessageMap.php
@@ -95,7 +95,7 @@ class MessageMap
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments()),
+                'arguments' => json_encode($toolCall->arguments() ?: (object) []),
             ],
         ], $message->toolCalls);
 

--- a/src/Providers/Groq/Maps/MessageMap.php
+++ b/src/Providers/Groq/Maps/MessageMap.php
@@ -95,7 +95,7 @@ class MessageMap
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments()),
+                'arguments' => json_encode($toolCall->arguments() ?: (object) []),
             ],
         ], $message->toolCalls);
 

--- a/src/Providers/Mistral/Maps/MessageMap.php
+++ b/src/Providers/Mistral/Maps/MessageMap.php
@@ -96,7 +96,7 @@ class MessageMap
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments()),
+                'arguments' => json_encode($toolCall->arguments() ?: (object) []),
             ],
         ], $message->toolCalls);
 

--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -155,7 +155,7 @@ class MessageMap
                     'call_id' => $toolCall->resultId,
                     'type' => 'function_call',
                     'name' => $toolCall->name,
-                    'arguments' => json_encode($toolCall->arguments()),
+                    'arguments' => json_encode($toolCall->arguments() ?: (object) []),
                 ], $message->toolCalls)
             );
         }

--- a/src/Providers/OpenRouter/Maps/MessageMap.php
+++ b/src/Providers/OpenRouter/Maps/MessageMap.php
@@ -159,7 +159,7 @@ class MessageMap
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments()),
+                'arguments' => json_encode($toolCall->arguments() ?: (object) []),
             ],
         ], $message->toolCalls);
 

--- a/src/Providers/XAI/Maps/MessageMap.php
+++ b/src/Providers/XAI/Maps/MessageMap.php
@@ -95,7 +95,7 @@ class MessageMap
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments()),
+                'arguments' => json_encode($toolCall->arguments() ?: (object) []),
             ],
         ], $message->toolCalls);
 

--- a/tests/Providers/DeepSeek/MessageMapTest.php
+++ b/tests/Providers/DeepSeek/MessageMapTest.php
@@ -137,6 +137,33 @@ it('maps assistant message with tool calls', function (): void {
     ]]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    []
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'assistant',
+        'tool_calls' => [[
+            'id' => 'tool_1234',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_schema',
+                'arguments' => '{}',
+            ],
+        ]],
+    ]]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [

--- a/tests/Providers/Groq/MessageMapTest.php
+++ b/tests/Providers/Groq/MessageMapTest.php
@@ -139,6 +139,33 @@ it('maps assistant message with tool calls', function (): void {
     ]]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    []
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'assistant',
+        'tool_calls' => [[
+            'id' => 'tool_1234',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_schema',
+                'arguments' => '{}',
+            ],
+        ]],
+    ]]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [

--- a/tests/Providers/Mistral/MessageMapTest.php
+++ b/tests/Providers/Mistral/MessageMapTest.php
@@ -99,6 +99,33 @@ it('maps assistant message with tool calls', function (): void {
     ]]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    []
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'assistant',
+        'tool_calls' => [[
+            'id' => 'tool_1234',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_schema',
+                'arguments' => '{}',
+            ],
+        ]],
+    ]]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -189,6 +189,32 @@ it('maps assistant message with tool calls', function (): void {
     ]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    [],
+                    'call_1234'
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([
+        [
+            'id' => 'tool_1234',
+            'call_id' => 'call_1234',
+            'type' => 'function_call',
+            'name' => 'get_schema',
+            'arguments' => '{}',
+        ],
+    ]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [

--- a/tests/Providers/OpenRouter/MessageMapTest.php
+++ b/tests/Providers/OpenRouter/MessageMapTest.php
@@ -177,6 +177,33 @@ it('maps assistant message with tool calls', function (): void {
     ]]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    []
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'assistant',
+        'tool_calls' => [[
+            'id' => 'tool_1234',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_schema',
+                'arguments' => '{}',
+            ],
+        ]],
+    ]]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [

--- a/tests/Providers/XAI/MessageMapTest.php
+++ b/tests/Providers/XAI/MessageMapTest.php
@@ -75,6 +75,33 @@ it('maps assistant message with tool calls', function (): void {
     ]]);
 });
 
+it('maps assistant message with tool calls with empty arguments as json object', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('', [
+                new ToolCall(
+                    'tool_1234',
+                    'get_schema',
+                    []
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([[
+        'role' => 'assistant',
+        'tool_calls' => [[
+            'id' => 'tool_1234',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_schema',
+                'arguments' => '{}',
+            ],
+        ]],
+    ]]);
+});
+
 it('maps tool result messages', function (): void {
     $messageMap = new MessageMap(
         messages: [


### PR DESCRIPTION
## Problem

When using multi-step tool calling with tools that have **no parameters**, the second request fails because empty tool arguments are encoded as a JSON array (`"[]"`) instead of a JSON object (`"{}"`).

This causes provider-side validation errors. For example, OpenRouter (which translates to Anthropic format internally) returns:

```
OpenRouter Bad Request: messages.1.content.0.tool_use.input: Input should be a valid dictionary
```

### Reproduction

This happens in any multi-step tool calling scenario where a tool has no parameters:

```php
$tool = Tool::as('get_current_time')
    ->for('Get the current server time')
    ->using(fn (): string => now()->toISOString());

$response = Prism::text()
    ->using(Provider::OpenRouter, 'anthropic/claude-sonnet-4')
    ->withTools([$tool])
    ->withMaxSteps(3)
    ->withPrompt('What time is it?')
    ->asStream();
```

When the model calls this tool during streaming, Prism's `Stream` handler:

1. Receives `arguments: "{}"` from the model
2. Decodes it with `json_decode("{}", true)` which returns `[]` (empty PHP array)
3. Stores it in the `ToolCall` value object
4. On the next step, `MessageMap` re-encodes it with `json_encode([])` which produces `"[]"`

The provider then rejects `"[]"` because function arguments must be a JSON **object**, not an array.

### Root cause

This is a PHP-specific ambiguity: an empty PHP array `[]` is both a valid list and a valid dictionary. `json_encode([])` produces `"[]"` (JSON array), but the OpenAI API specification requires function arguments to always be a JSON object string.

## Solution

Use `json_encode($toolCall->arguments() ?: (object) [])` to ensure empty arguments are encoded as `"{}"`. When arguments are non-empty, the `?:` operator short-circuits and behavior is unchanged.

## Affected providers

The same pattern existed in all providers that encode tool call arguments in `MessageMap`:

- OpenRouter
- OpenAI
- Groq
- XAI
- DeepSeek
- Mistral

All six have been fixed with the same one-line change, along with a corresponding test for each.
