### PR TITLE
fix(streaming): add null usage fallback to all providers

### DIFF
--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -268,7 +268,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage(),
+            usage: $this->state->usage() ?? new Usage(0, 0),
             citations: $this->state->citations() !== [] ? $this->state->citations() : null,
             additionalContent: [
                 'thinking' => $this->state->thinkingSummaries() === [] ? null : implode('', $this->state->thinkingSummaries()),

--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -242,7 +242,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage()
+            usage: $this->state->usage() ?? new Usage(0, 0),
         );
     }
 

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -253,7 +253,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage(),
+            usage: $this->state->usage() ?? new Usage(0, 0),
             additionalContent: Arr::whereNotNull([
                 'grounding_metadata' => $this->state->metadata()['grounding_metadata'] ?? null,
                 'thoughtSummaries' => $this->state->thinkingSummaries() === [] ? null : $this->state->thinkingSummaries(),

--- a/src/Providers/Groq/Handlers/Stream.php
+++ b/src/Providers/Groq/Handlers/Stream.php
@@ -199,7 +199,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage()
+            usage: $this->state->usage() ?? new Usage(0, 0),
         );
     }
 

--- a/src/Providers/Mistral/Handlers/Stream.php
+++ b/src/Providers/Mistral/Handlers/Stream.php
@@ -251,7 +251,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage()
+            usage: $this->state->usage() ?? new Usage(0, 0),
         );
     }
 

--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -257,7 +257,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage()
+            usage: $this->state->usage() ?? new Usage(0, 0),
         );
     }
 

--- a/src/Providers/XAI/Handlers/Stream.php
+++ b/src/Providers/XAI/Handlers/Stream.php
@@ -227,7 +227,7 @@ class Stream
             id: EventID::generate(),
             timestamp: time(),
             finishReason: $this->state->finishReason() ?? FinishReason::Stop,
-            usage: $this->state->usage()
+            usage: $this->state->usage() ?? new Usage(0, 0),
         );
     }
 


### PR DESCRIPTION
## Summary

- `StreamEndEvent.usage` can be `null` when providers don't include usage data in their final stream chunk, causing a `TypeError` downstream (e.g. in `laravel/ai`)
- Adds `?? new Usage(0, 0)` fallback to `emitStreamEndEvent()` in all 7 providers missing it: Groq, XAI, OpenRouter, Mistral, DeepSeek, Anthropic, and Gemini
- Matches the existing pattern already used in the OpenAI stream handler

Refs #900

## Test plan

- [x] Full test suite passes (1361 tests, 0 failures)
- [x] PHPStan level 8 clean
- [x] Pint + Rector formatted