### PR TITLE
feat(voyageai): add output_dimension support for embeddings

### DIFF
--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -51,6 +51,7 @@ class Embeddings
             'model' => $this->request->model(),
             'input' => $this->request->inputs(),
             'input_type' => $providerOptions['inputType'] ?? null,
+            'output_dimension' => $providerOptions['outputDimension'] ?? null,
             'truncation' => $providerOptions['truncation'] ?? null,
         ]));
 

--- a/tests/Fixtures/voyageai/embeddings-with-output-dimension-1.json
+++ b/tests/Fixtures/voyageai/embeddings-with-output-dimension-1.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,0.3,0.4],"index":0}],"model":"voyage-3-lite","usage":{"total_tokens":8}}

--- a/tests/Providers/VoyageAI/EmbeddingsTest.php
+++ b/tests/Providers/VoyageAI/EmbeddingsTest.php
@@ -98,6 +98,41 @@ it('returns embeddings with inputType and truncation', function (): void {
     expect($response->usage->tokens)->toBe(7);
 });
 
+it('returns embeddings with outputDimension set', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/embeddings-with-output-dimension');
+
+    $response = Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-3-lite')
+        ->fromInput('The food was delicious and the waiter...')
+        ->withProviderOptions(['outputDimension' => 4])
+        ->asEmbeddings();
+
+    expect($response->embeddings)->toBeArray();
+    expect($response->embeddings[0]->embedding)->toHaveCount(4);
+    expect($response->usage->tokens)->toBe(8);
+
+    Http::assertSent(function ($request): bool {
+        $body = json_decode((string) $request->body(), true);
+
+        return $body['output_dimension'] === 4;
+    });
+});
+
+it('does not include output_dimension when not set', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'voyageai/embeddings-from-input');
+
+    Prism::embeddings()
+        ->using(Provider::VoyageAI, 'voyage-3-lite')
+        ->fromInput('The food was delicious and the waiter...')
+        ->asEmbeddings();
+
+    Http::assertSent(function ($request): bool {
+        $body = json_decode((string) $request->body(), true);
+
+        return ! array_key_exists('output_dimension', $body);
+    });
+});
+
 it('throws a PrismRateLimitedException for a 429 response code', function (): void {
     Http::fake([
         '*' => Http::response(


### PR DESCRIPTION
## Description

Adds `outputDimension` provider option support to the VoyageAI embeddings handler, allowing control over the number of dimensions in embedding responses.

Voyage AI models like `voyage-4` and `voyage-multimodal-3.5` support [Matryoshka-style dimension truncation](https://docs.voyageai.com/docs/embeddings#matryoshka-embeddings) via the `output_dimension` API parameter. This was previously not forwarded by the Prism handler.

### Usage

```php
Prism::embeddings()
    ->using(Provider::VoyageAI, 'voyage-4')
    ->fromInput('some text')
    ->withProviderOptions(['outputDimension' => 2048])
    ->asEmbeddings();
```

When `outputDimension` is not set, the parameter is omitted from the request (no change in default behaviour).

### Tests

- Verifies `output_dimension` is included in the API request when `outputDimension` provider option is set
- Verifies `output_dimension` is omitted from the API request when not set
- All existing VoyageAI embeddings tests continue to pass