### PR TITLE
feat: Add ModelsLab provider for image generation

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -49,6 +49,10 @@ return [
             'api_key' => env('ELEVENLABS_API_KEY', ''),
             'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1/'),
         ],
+        'modelslab' => [
+            'api_key' => env('MODELSLAB_API_KEY', ''),
+            'url' => env('MODELSLAB_URL', 'https://modelslab.com/api/v6'),
+        ],
         'voyageai' => [
             'api_key' => env('VOYAGEAI_API_KEY', ''),
             'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),

--- a/src/Enums/Provider.php
+++ b/src/Enums/Provider.php
@@ -17,4 +17,5 @@ enum Provider: string
     case Gemini = 'gemini';
     case VoyageAI = 'voyageai';
     case ElevenLabs = 'elevenlabs';
+    case ModelsLab = 'modelslab';
 }

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -14,6 +14,7 @@ use Prism\Prism\Providers\ElevenLabs\ElevenLabs;
 use Prism\Prism\Providers\Gemini\Gemini;
 use Prism\Prism\Providers\Groq\Groq;
 use Prism\Prism\Providers\Mistral\Mistral;
+use Prism\Prism\Providers\ModelsLab\ModelsLab;
 use Prism\Prism\Providers\Ollama\Ollama;
 use Prism\Prism\Providers\OpenAI\OpenAI;
 use Prism\Prism\Providers\OpenRouter\OpenRouter;
@@ -196,6 +197,17 @@ class PrismManager
         return new Gemini(
             apiKey: $config['api_key'],
             url: $config['url'],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    protected function createModelslabProvider(array $config): ModelsLab
+    {
+        return new ModelsLab(
+            apiKey: $config['api_key'],
+            url: $config['url'] ?? 'https://modelslab.com/api/v6',
         );
     }
 

--- a/src/Providers/ModelsLab/Handlers/Images.php
+++ b/src/Providers/ModelsLab/Handlers/Images.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\ModelsLab\Handlers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Images\Request;
+use Prism\Prism\Images\Response;
+use Prism\Prism\Images\ResponseBuilder;
+use Prism\Prism\ValueObjects\GeneratedImage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+
+class Images
+{
+    public function __construct(
+        protected PendingRequest $client,
+        protected string $apiKey,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $response = $this->sendRequest($request);
+
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
+        $images = $this->extractImages($data);
+
+        $responseBuilder = new ResponseBuilder(
+            usage: new Usage(promptTokens: 0, completionTokens: 0),
+            meta: new Meta(
+                id: (string) data_get($data, 'id', 'ml_'.bin2hex(random_bytes(8))),
+                model: $request->model(),
+            ),
+            images: $images,
+            raw: $data,
+        );
+
+        return $responseBuilder->toResponse();
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        $payload = array_merge(
+            [
+                'key'                 => $this->apiKey,
+                'prompt'              => $request->prompt(),
+                'model_id'            => $request->model(),
+                'width'               => (string) ($request->providerOptions('width') ?? 1024),
+                'height'              => (string) ($request->providerOptions('height') ?? 1024),
+                'samples'             => (string) ($request->providerOptions('samples') ?? 1),
+                'num_inference_steps' => (string) ($request->providerOptions('num_inference_steps') ?? 30),
+                'guidance_scale'      => $request->providerOptions('guidance_scale') ?? 7.5,
+                'safety_checker'      => $request->providerOptions('safety_checker') ?? 'no',
+            ],
+            array_filter([
+                'negative_prompt' => $request->providerOptions('negative_prompt'),
+                'seed'            => $request->providerOptions('seed'),
+            ])
+        );
+
+        /** @var ClientResponse $response */
+        $response = $this->client->post('images/text2img', $payload);
+
+        return $response;
+    }
+
+    protected function validateResponse(ClientResponse $response): void
+    {
+        if ($response->status() === 429) {
+            throw new PrismRateLimitedException([]);
+        }
+
+        if (! $response->successful()) {
+            throw PrismException::providerResponseError(
+                sprintf(
+                    'ModelsLab API error %d: %s',
+                    $response->status(),
+                    $response->body()
+                )
+            );
+        }
+
+        $data = $response->json();
+
+        if (data_get($data, 'status') === 'error') {
+            $message = data_get($data, 'message') ?? data_get($data, 'messege') ?? 'Unknown error';
+            throw PrismException::providerResponseError("ModelsLab error: {$message}");
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return GeneratedImage[]
+     */
+    protected function extractImages(array $data): array
+    {
+        $urls = data_get($data, 'output', []);
+
+        if (empty($urls)) {
+            return [];
+        }
+
+        return array_map(
+            fn (string $url): GeneratedImage => new GeneratedImage(url: $url),
+            $urls
+        );
+    }
+}

--- a/src/Providers/ModelsLab/ModelsLab.php
+++ b/src/Providers/ModelsLab/ModelsLab.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\ModelsLab;
+
+use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\InitializesClient;
+use Prism\Prism\Images\Request as ImagesRequest;
+use Prism\Prism\Images\Response as ImagesResponse;
+use Prism\Prism\Providers\ModelsLab\Handlers\Images;
+use Prism\Prism\Providers\Provider;
+
+class ModelsLab extends Provider
+{
+    use InitializesClient;
+
+    public function __construct(
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
+    ) {}
+
+    #[\Override]
+    public function images(ImagesRequest $request): ImagesResponse
+    {
+        return (new Images(
+            client: $this->client($request->clientOptions(), $request->clientRetry()),
+            apiKey: $this->apiKey,
+        ))->handle($request);
+    }
+
+    protected function client(array $options = [], array $retry = []): PendingRequest
+    {
+        return $this->baseClient()
+            ->withOptions($options)
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($this->url);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **ModelsLab** as a new image generation provider in [Prism](https://github.com/echolabsdev/prism) — a unified AI interface for Laravel.

## What this PR adds

### Provider class (`src/Providers/ModelsLab/ModelsLab.php`)
- Implements the `images()` method following the Provider interface
- Uses the standard Prism HTTP client pattern

### Image handler (`src/Providers/ModelsLab/Handlers/Images.php`)
- Handles text-to-image generation via ModelsLab REST API
- Supports: Flux, SDXL, Realistic Vision, DreamShaper, Anything, and community models
- API key in request body (ModelsLab uses `"key": "api_key"`, not Bearer token)

### Configuration (`config/prism.php`)
```php
'modelslab' => [
    'api_key' => env('MODELSLAB_API_KEY', ''),
    => env('MODELSLAB_URL', 'https:// 'url'modelslab.com/api/v6'),
],
```

### Usage

```php
use Prism\Prism\Facades\Prism;

// Using the facade
\$image = Prism::images()
    ->using('modelslab', [api_key => 'your-key'])
    ->generate('A sunset over mountains in watercolor style');

// Or via config
// Set MODELSLAB_API_KEY in .env, then:
\$image = Prism::images()
    ->using('modelslab')
    ->generate('A sunset over mountains');
```

### Supported provider options
- `width` (default: 1024)
- `height` (default: 1024)
- `samples` (default: 1)
- `num_inference_steps` (default: 30)
- `guidance_scale` (default: 7.5)
- `negative_prompt`
- `seed`
- `safety_checker` (default: "no")

## API Reference
- [ModelsLab text-to-image docs](https://docs.modelslab.com/image-generation/overview)
- [Get API key](https://modelslab.com/dashboard/api-keys)
