### PR TITLE
Feat: 💰 Track cost in Usage value object

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -502,7 +502,8 @@ class Stream
             promptTokens: (int) data_get($usage, 'prompt_tokens', 0),
             completionTokens: (int) data_get($usage, 'completion_tokens', 0),
             cacheReadInputTokens: (int) data_get($usage, 'prompt_tokens_details.cached_tokens', 0),
-            thoughtTokens: (int) data_get($usage, 'completion_tokens_details.reasoning_tokens', 0)
+            thoughtTokens: (int) data_get($usage, 'completion_tokens_details.reasoning_tokens', 0),
+            cost: ($cost = data_get($usage, 'cost')) !== null ? (float) $cost : null,
         );
     }
 }

--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -154,8 +154,9 @@ class Structured
             text: data_get($data, 'choices.0.message.content') ?? '',
             finishReason: $this->mapFinishReason($data),
             usage: new Usage(
-                (int) data_get($data, 'usage.prompt_tokens', 0),
-                (int) data_get($data, 'usage.completion_tokens', 0),
+                promptTokens: (int) data_get($data, 'usage.prompt_tokens', 0),
+                completionTokens: (int) data_get($data, 'usage.completion_tokens', 0),
+                cost: ($cost = data_get($data, 'usage.cost')) !== null ? (float) $cost : null,
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -123,8 +123,9 @@ class Text
             toolResults: $toolResults,
             providerToolCalls: [],
             usage: new Usage(
-                (int) data_get($data, 'usage.prompt_tokens', 0),
-                (int) data_get($data, 'usage.completion_tokens', 0),
+                promptTokens: (int) data_get($data, 'usage.prompt_tokens', 0),
+                completionTokens: (int) data_get($data, 'usage.completion_tokens', 0),
+                cost: ($cost = data_get($data, 'usage.cost')) !== null ? (float) $cost : null,
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Streaming/Events/StreamEndEvent.php
+++ b/src/Streaming/Events/StreamEndEvent.php
@@ -42,13 +42,7 @@ readonly class StreamEndEvent extends StreamEvent
             'id' => $this->id,
             'timestamp' => $this->timestamp,
             'finish_reason' => $this->finishReason->name,
-            'usage' => $this->usage instanceof Usage ? [
-                'prompt_tokens' => $this->usage->promptTokens,
-                'completion_tokens' => $this->usage->completionTokens,
-                'cache_write_input_tokens' => $this->usage->cacheWriteInputTokens,
-                'cache_read_input_tokens' => $this->usage->cacheReadInputTokens,
-                'thought_tokens' => $this->usage->thoughtTokens,
-            ] : null,
+            'usage' => $this->usage?->toArray(),
             'citations' => $this->citations !== null ? array_map(
                 fn (MessagePartWithCitations $citationPart): array => [
                     'output_text' => $citationPart->outputText,

--- a/src/Streaming/StreamState.php
+++ b/src/Streaming/StreamState.php
@@ -238,7 +238,10 @@ class StreamState
             completionTokens: $this->usage->completionTokens + $usage->completionTokens,
             cacheWriteInputTokens: ($this->usage->cacheWriteInputTokens ?? 0) + ($usage->cacheWriteInputTokens ?? 0),
             cacheReadInputTokens: ($this->usage->cacheReadInputTokens ?? 0) + ($usage->cacheReadInputTokens ?? 0),
-            thoughtTokens: ($this->usage->thoughtTokens ?? 0) + ($usage->thoughtTokens ?? 0)
+            thoughtTokens: ($this->usage->thoughtTokens ?? 0) + ($usage->thoughtTokens ?? 0),
+            cost: ($this->usage->cost !== null || $usage->cost !== null)
+                ? ($this->usage->cost ?? 0.0) + ($usage->cost ?? 0.0)
+                : null,
         );
 
         return $this;

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -123,6 +123,9 @@ readonly class ResponseBuilder
             thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
                 : null,
+            cost: $this->steps->contains(fn (Step $result): bool => $result->usage->cost !== null)
+                ? (float) $this->steps->sum(fn (Step $result): float => $result->usage->cost ?? 0.0)
+                : null,
         );
     }
 }

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -77,6 +77,9 @@ readonly class ResponseBuilder
             thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
                 : null,
+            cost: $this->steps->contains(fn (Step $result): bool => $result->usage->cost !== null)
+                ? (float) $this->steps->sum(fn (Step $result): float => $result->usage->cost ?? 0.0)
+                : null,
         );
     }
 }

--- a/src/ValueObjects/Usage.php
+++ b/src/ValueObjects/Usage.php
@@ -17,6 +17,7 @@ readonly class Usage implements Arrayable
         public ?int $cacheWriteInputTokens = null,
         public ?int $cacheReadInputTokens = null,
         public ?int $thoughtTokens = null,
+        public ?float $cost = null,
     ) {}
 
     /**
@@ -31,6 +32,7 @@ readonly class Usage implements Arrayable
             'cache_write_input_tokens' => $this->cacheWriteInputTokens,
             'cache_read_input_tokens' => $this->cacheReadInputTokens,
             'thought_tokens' => $this->thoughtTokens,
+            'cost' => $this->cost,
         ];
     }
 }

--- a/tests/Providers/Anthropic/StreamTest.php
+++ b/tests/Providers/Anthropic/StreamTest.php
@@ -103,6 +103,7 @@ it('can return usage with a basic stream', function (): void {
         'cacheWriteInputTokens' => 0,
         'cacheReadInputTokens' => 0,
         'thoughtTokens' => null,
+        'cost' => null,
     ]);
 
     // Verify the HTTP request

--- a/tests/Streaming/Adapters/BroadcastAdapterTest.php
+++ b/tests/Streaming/Adapters/BroadcastAdapterTest.php
@@ -440,6 +440,7 @@ it('validates broadcast event structure for multiple event types', function (): 
             'cache_write_input_tokens' => null,
             'cache_read_input_tokens' => null,
             'thought_tokens' => null,
+            'cost' => null,
         ]);
 
         return true;

--- a/tests/Structured/ResponseBuilderTest.php
+++ b/tests/Structured/ResponseBuilderTest.php
@@ -208,6 +208,49 @@ test('StructuredResponseBuilder aggregates tool results from multiple steps as T
         ->and($response->toolResults[2]->result)->toBe('High');
 });
 
+test('StructuredResponseBuilder aggregates cost across steps', function (): void {
+    $builder = new ResponseBuilder;
+
+    $builder->addStep(new Step(
+        text: 'intermediate',
+        finishReason: FinishReason::Length,
+        usage: new Usage(promptTokens: 10, completionTokens: 5, cost: 0.0015),
+        meta: new Meta('step1', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $builder->addStep(new Step(
+        text: '{"value":42}',
+        finishReason: FinishReason::Stop,
+        usage: new Usage(promptTokens: 3, completionTokens: 2, cost: 0.0008),
+        meta: new Meta('step2', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $response = $builder->toResponse();
+
+    expect($response->usage->cost)->toBe(0.0023);
+});
+
+test('StructuredResponseBuilder keeps cost null when no steps have cost', function (): void {
+    $builder = new ResponseBuilder;
+
+    $builder->addStep(new Step(
+        text: '{"value":42}',
+        finishReason: FinishReason::Stop,
+        usage: new Usage(promptTokens: 10, completionTokens: 5),
+        meta: new Meta('step1', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $response = $builder->toResponse();
+
+    expect($response->usage->cost)->toBeNull();
+});
+
 test('StructuredResponseBuilder returns empty arrays when no tool calls or results exist', function (): void {
     $builder = new ResponseBuilder;
 

--- a/tests/Text/ResponseBuilderTest.php
+++ b/tests/Text/ResponseBuilderTest.php
@@ -45,3 +45,55 @@ test('TextResponseBuilder aggregates usage and forwards final step text', functi
         ->and($response->finishReason)->toBe(FinishReason::Stop)
         ->and($response->steps)->toHaveCount(2);
 });
+
+test('TextResponseBuilder aggregates cost across steps', function (): void {
+    $builder = new ResponseBuilder;
+
+    $builder->addStep(new Step(
+        text: 'hello ',
+        finishReason: FinishReason::Length,
+        toolCalls: [],
+        toolResults: [],
+        providerToolCalls: [],
+        usage: new Usage(promptTokens: 5, completionTokens: 0, cost: 0.001),
+        meta: new Meta('s1', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $builder->addStep(new Step(
+        text: 'world',
+        finishReason: FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        providerToolCalls: [],
+        usage: new Usage(promptTokens: 2, completionTokens: 3, cost: 0.002),
+        meta: new Meta('s2', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $response = $builder->toResponse();
+
+    expect($response->usage->cost)->toBe(0.003);
+});
+
+test('TextResponseBuilder keeps cost null when no steps have cost', function (): void {
+    $builder = new ResponseBuilder;
+
+    $builder->addStep(new Step(
+        text: 'hello',
+        finishReason: FinishReason::Stop,
+        toolCalls: [],
+        toolResults: [],
+        providerToolCalls: [],
+        usage: new Usage(promptTokens: 5, completionTokens: 3),
+        meta: new Meta('s1', 'test-model'),
+        messages: [],
+        systemPrompts: [],
+    ));
+
+    $response = $builder->toResponse();
+
+    expect($response->usage->cost)->toBeNull();
+});

--- a/tests/Unit/Streaming/Events/StreamEndEventTest.php
+++ b/tests/Unit/Streaming/Events/StreamEndEventTest.php
@@ -95,6 +95,7 @@ it('converts to array with complete usage information', function (): void {
             'cache_write_input_tokens' => 25,
             'cache_read_input_tokens' => 10,
             'thought_tokens' => 5,
+            'cost' => null,
         ],
         'citations' => null,
     ]);
@@ -125,6 +126,7 @@ it('converts to array with partial usage information', function (): void {
             'cache_write_input_tokens' => null,
             'cache_read_input_tokens' => null,
             'thought_tokens' => null,
+            'cost' => null,
         ],
         'citations' => null,
     ]);

--- a/tests/Unit/Streaming/StreamStateTest.php
+++ b/tests/Unit/Streaming/StreamStateTest.php
@@ -597,7 +597,8 @@ it('handles complex Usage with all optional fields', function (): void {
         completionTokens: 50,
         cacheWriteInputTokens: 25,
         cacheReadInputTokens: 10,
-        thoughtTokens: 5
+        thoughtTokens: 5,
+        cost: 0.0042,
     );
 
     $state->withUsage($usage);
@@ -607,7 +608,48 @@ it('handles complex Usage with all optional fields', function (): void {
         ->and($state->usage()->completionTokens)->toBe(50)
         ->and($state->usage()->cacheWriteInputTokens)->toBe(25)
         ->and($state->usage()->cacheReadInputTokens)->toBe(10)
-        ->and($state->usage()->thoughtTokens)->toBe(5);
+        ->and($state->usage()->thoughtTokens)->toBe(5)
+        ->and($state->usage()->cost)->toBe(0.0042);
+});
+
+it('addUsage accumulates cost from multiple usages', function (): void {
+    $state = new StreamState;
+
+    $state->addUsage(new Usage(
+        promptTokens: 50,
+        completionTokens: 25,
+        cost: 0.002,
+    ));
+
+    $state->addUsage(new Usage(
+        promptTokens: 30,
+        completionTokens: 15,
+        cost: 0.001,
+    ));
+
+    expect($state->usage()->promptTokens)->toBe(80)
+        ->and($state->usage()->completionTokens)->toBe(40)
+        ->and($state->usage()->cost)->toBe(0.003);
+});
+
+it('addUsage keeps cost null when no usage has cost', function (): void {
+    $state = new StreamState;
+
+    $state->addUsage(new Usage(promptTokens: 50, completionTokens: 25));
+    $state->addUsage(new Usage(promptTokens: 30, completionTokens: 15));
+
+    expect($state->usage()->promptTokens)->toBe(80)
+        ->and($state->usage()->completionTokens)->toBe(40)
+        ->and($state->usage()->cost)->toBeNull();
+});
+
+it('addUsage treats null cost as zero when accumulating with non-null cost', function (): void {
+    $state = new StreamState;
+
+    $state->addUsage(new Usage(promptTokens: 50, completionTokens: 25, cost: 0.002));
+    $state->addUsage(new Usage(promptTokens: 30, completionTokens: 15));
+
+    expect($state->usage()->cost)->toBe(0.002);
 });
 
 it('handles MessagePartWithCitations with all fields', function (): void {

--- a/tests/ValueObjects/UsageTest.php
+++ b/tests/ValueObjects/UsageTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\ValueObjects\Usage;
+
+it('constructs with required parameters', function (): void {
+    $usage = new Usage(
+        promptTokens: 100,
+        completionTokens: 50,
+    );
+
+    expect($usage->promptTokens)->toBe(100)
+        ->and($usage->completionTokens)->toBe(50)
+        ->and($usage->cacheWriteInputTokens)->toBeNull()
+        ->and($usage->cacheReadInputTokens)->toBeNull()
+        ->and($usage->thoughtTokens)->toBeNull()
+        ->and($usage->cost)->toBeNull();
+});
+
+it('constructs with all parameters including cost', function (): void {
+    $usage = new Usage(
+        promptTokens: 100,
+        completionTokens: 50,
+        cacheWriteInputTokens: 25,
+        cacheReadInputTokens: 10,
+        thoughtTokens: 5,
+        cost: 0.00325,
+    );
+
+    expect($usage->promptTokens)->toBe(100)
+        ->and($usage->completionTokens)->toBe(50)
+        ->and($usage->cacheWriteInputTokens)->toBe(25)
+        ->and($usage->cacheReadInputTokens)->toBe(10)
+        ->and($usage->thoughtTokens)->toBe(5)
+        ->and($usage->cost)->toBe(0.00325);
+});
+
+it('converts to array without cost', function (): void {
+    $usage = new Usage(
+        promptTokens: 100,
+        completionTokens: 50,
+    );
+
+    expect($usage->toArray())->toBe([
+        'prompt_tokens' => 100,
+        'completion_tokens' => 50,
+        'cache_write_input_tokens' => null,
+        'cache_read_input_tokens' => null,
+        'thought_tokens' => null,
+        'cost' => null,
+    ]);
+});
+
+it('converts to array with cost', function (): void {
+    $usage = new Usage(
+        promptTokens: 100,
+        completionTokens: 50,
+        cacheWriteInputTokens: 25,
+        cacheReadInputTokens: 10,
+        thoughtTokens: 5,
+        cost: 0.0042,
+    );
+
+    expect($usage->toArray())->toBe([
+        'prompt_tokens' => 100,
+        'completion_tokens' => 50,
+        'cache_write_input_tokens' => 25,
+        'cache_read_input_tokens' => 10,
+        'thought_tokens' => 5,
+        'cost' => 0.0042,
+    ]);
+});
+
+it('allows zero cost', function (): void {
+    $usage = new Usage(
+        promptTokens: 0,
+        completionTokens: 0,
+        cost: 0.0,
+    );
+
+    expect($usage->cost)->toBe(0.0);
+});
+
+it('allows very small cost values', function (): void {
+    $usage = new Usage(
+        promptTokens: 10,
+        completionTokens: 5,
+        cost: 0.000001,
+    );
+
+    expect($usage->cost)->toBe(0.000001);
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Track cost in `Usage` value object. Some providers like OpenRouter return the cost of a request in their usage response. This adds a nullable `float $cost` property to `Usage` so that cost data can be captured when available, while remaining `null` for providers that don't report it.

Changes:
- Added `?float $cost = null` to `Usage` value object and its `toArray()` output
- Updated `Text\ResponseBuilder` and `Structured\ResponseBuilder` to aggregate cost across steps
- Updated `StreamState::addUsage()` to accumulate cost during streaming
- Updated `StreamEndEvent::toArray()` to delegate to `Usage::toArray()` instead of inlining fields
- Updated OpenRouter Text, Structured, and Stream handlers to extract `usage.cost` from API responses
- Added `UsageTest` and updated existing tests for ResponseBuilders, StreamState, StreamEndEvent, and BroadcastAdapter