### PR TITLE
fix(openrouter): de-duplicate tool merging logic

### DIFF
--- a/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
+++ b/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
@@ -30,7 +30,7 @@ trait BuildsRequestOptions
             'tools' => ToolMap::map($request->tools()),
             'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
         ]));
-        
+
         return Arr::whereNotNull(array_merge($options, $additional));
     }
 }


### PR DESCRIPTION
Removed redundant merging of tools and tool_choice for TextRequest for OpenRouter.

Resolved #922 

## Description
Pass `tools` to OpenRouter for Gemini calling tools in structured output

## Breaking Changes
* Possible bugs when caller uses tools for structured output with models which doesnt support tool_call with structured output