### PR TITLE
fix(anthropic): replace deprecated output_format with output_config.format

### DIFF
--- a/src/Providers/Anthropic/Handlers/StructuredStrategies/NativeOutputFormatStructuredStrategy.php
+++ b/src/Providers/Anthropic/Handlers/StructuredStrategies/NativeOutputFormatStructuredStrategy.php
@@ -20,9 +20,11 @@ class NativeOutputFormatStructuredStrategy extends AnthropicStructuredStrategy
     {
         $schemaArray = $this->request->schema()->toArray();
 
-        $payload['output_format'] = [
-            'type' => 'json_schema',
-            'schema' => $schemaArray,
+        $payload['output_config'] = [
+            'format' => [
+                'type' => 'json_schema',
+                'schema' => $schemaArray,
+            ],
         ];
 
         return $payload;

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -372,6 +372,36 @@ describe('native structured outputs', function (): void {
         expect($response->structured['demo_requested'])->toBe(true);
     });
 
+    it('sends output_config.format instead of deprecated output_format in the request payload', function (): void {
+        Prism::fake();
+
+        $schema = new ObjectSchema(
+            'output',
+            'the output object',
+            [
+                new StringSchema('weather', 'The weather forecast'),
+                new BooleanSchema('coat_required', 'whether a coat is required'),
+            ],
+            ['weather', 'coat_required']
+        );
+
+        $request = Prism::structured()
+            ->withSchema($schema)
+            ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
+            ->withPrompt('What is the weather?');
+
+        $payload = Structured::buildHttpRequestPayload($request->toRequest());
+
+        expect($payload)->not->toHaveKey('output_format');
+        expect($payload)->toHaveKey('output_config');
+        expect($payload['output_config'])->toBe([
+            'format' => [
+                'type' => 'json_schema',
+                'schema' => $schema->toArray(),
+            ],
+        ]);
+    });
+
     it('throws error when citations and native output format are used together', function (): void {
         $schema = new ObjectSchema('output', 'the output object', [
             new StringSchema('answer', 'The answer'),


### PR DESCRIPTION
## Description
Fixes #912

Anthropic's API deprecated the \`output_format\` field and now returns a 400 error. This updates the Anthropic provider to use \`output_config.format\` instead.
See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
