### PR TITLE
fix(anthropic): handle Unix timestamp in rate limit reset headers

### DIFF
--- a/src/Providers/Anthropic/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/Anthropic/Concerns/ProcessesRateLimits.php
@@ -40,7 +40,9 @@ trait ProcessesRateLimits
                 remaining: data_get($fields, 'remaining') !== null
                     ? (int) data_get($fields, 'remaining')
                     : null,
-                resetsAt: data_get($fields, 'reset') !== null ? new Carbon($resets_at) : null
+                resetsAt: $resets_at !== null
+                    ? (is_numeric($resets_at) ? Carbon::createFromTimestamp((int) $resets_at) : new Carbon($resets_at))
+                    : null
             );
         }));
     }

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -259,6 +259,31 @@ it('adds rate limit data to the responseMeta', function (): void {
     expect($response->meta->rateLimits[0]->resetsAt)->toEqual($requests_reset);
 });
 
+it('handles unix timestamp rate limit reset headers', function (): void {
+    // Unix timestamps have second precision, so we truncate microseconds for comparison.
+    $requests_reset = Carbon::now()->addSeconds(30)->startOfSecond();
+
+    FixtureResponse::fakeResponseSequence(
+        'v1/messages',
+        'anthropic/generate-text-with-a-prompt',
+        [
+            'anthropic-ratelimit-requests-limit' => 1000,
+            'anthropic-ratelimit-requests-remaining' => 500,
+            'anthropic-ratelimit-requests-reset' => (string) $requests_reset->timestamp,
+        ]
+    );
+
+    $response = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20240620')
+        ->withPrompt('Who are you?')
+        ->asText();
+
+    expect($response->meta->rateLimits)->toHaveCount(1);
+    expect($response->meta->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
+    expect($response->meta->rateLimits[0]->name)->toEqual('requests');
+    expect($response->meta->rateLimits[0]->resetsAt)->toEqual($requests_reset);
+});
+
 describe('Anthropic citations', function (): void {
     it('applies the citations request level providerOptions to all documents', function (): void {
         Prism::fake();


### PR DESCRIPTION
## Description

Anthropic's `anthropic-ratelimit-*-reset` headers can return Unix timestamps as strings (e.g. `"1772373600"`). Newer API features such as `oauth-2025-04-20` include these headers with Unix timestamps, which causes the current `new Carbon($resets_at)` call to throw a `DateMalformedStringException` since Carbon's constructor interprets numeric strings as malformed date strings.

The fix checks whether the value is numeric before parsing — numeric values use `Carbon::createFromTimestamp()`, while non-numeric values fall through to the existing `new Carbon()` constructor. This handles both Unix timestamps and ISO 8601 strings.