### PR TITLE
fix: sanitize control characters in ToolCall::arguments() before json_decode

### DIFF
--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -34,7 +34,10 @@ class ToolCall implements Arrayable
                 return [];
             }
 
-            $arguments = $this->arguments;
+            // Sanitize control characters that some providers (e.g. DeepSeek) may include
+            // in streamed tool call arguments. Raw 0x00-0x1F / 0x7F bytes are never valid
+            // in JSON (RFC 8259) and cause json_decode to throw "Control character error".
+            $arguments = preg_replace('/[\x00-\x1F\x7F]/', '', $this->arguments);
 
             return json_decode(
                 $arguments,

--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -40,7 +40,7 @@ class ToolCall implements Arrayable
             $arguments = preg_replace('/[\x00-\x1F\x7F]/', '', $this->arguments);
 
             return json_decode(
-                $arguments,
+                (string) $arguments,
                 true,
                 flags: JSON_THROW_ON_ERROR
             );


### PR DESCRIPTION
## Summary

- Sanitize raw control characters (0x00-0x1F, 0x7F) from tool call argument strings before `json_decode` in `ToolCall::arguments()`
- These bytes are invalid in JSON per RFC 8259 and cause `JsonException: Control character error, possibly incorrectly encoded`
- Observed 11 times in production with the DeepSeek streaming provider

## Context

Some providers (notably DeepSeek) occasionally include raw control characters in streamed tool call argument JSON. The OpenRouter handler already has defensive handling for malformed arguments — this adds similar protection at the `ToolCall` level so all providers benefit.

Fixes #936