### PR TITLE
fix(openrouter): Null-coalesce json response to prevent TypeError on empty/invalid API responses.

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -79,7 +79,7 @@ class Structured
             ]))
         );
 
-        return $response->json();
+        return $response->json() ?? [];
     }
 
     /**

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -107,7 +107,7 @@ class Text
             ], $this->buildRequestOptions($request))
         );
 
-        return $response->json();
+        return $response->json() ?? [];
     }
 
     /**


### PR DESCRIPTION
Every other provider in the project already null-coalesces `->json()` calls to `[]`. The OpenRouter `sendRequest()` methods in both `Text` and `Structured` handlers were the odd ones out, returning `$response->json()` without the `?? []` guard.