### PR TITLE
fix: handle GPT-5 reasoning model finish reason mapping and enrich exception messages

### DIFF
--- a/src/Providers/OpenAI/Concerns/MapsFinishReason.php
+++ b/src/Providers/OpenAI/Concerns/MapsFinishReason.php
@@ -14,6 +14,15 @@ trait MapsFinishReason
      */
     protected function mapFinishReason(array $data): FinishReason
     {
+        $topLevelStatus = data_get($data, 'status', '');
+
+        if ($topLevelStatus === 'incomplete') {
+            return match (data_get($data, 'incomplete_details.reason')) {
+                'content_filter' => FinishReason::ContentFilter,
+                default => FinishReason::Length,
+            };
+        }
+
         return FinishReasonMap::map(
             data_get($data, 'output.{last}.status', ''),
             data_get($data, 'output.{last}.type', ''),

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -78,11 +78,20 @@ class Structured
 
         $request->addMessage($responseMessage);
 
-        return match ($this->mapFinishReason($data)) {
+        return match ($finishReason = $this->mapFinishReason($data)) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response),
             FinishReason::Stop => $this->handleFinalStop($data, $request, $response),
-            FinishReason::Length => throw new PrismException('OpenAI: max tokens exceeded'),
-            default => throw new PrismException('OpenAI: unknown finish reason'),
+            FinishReason::Length => throw new PrismException(sprintf(
+                'OpenAI: max tokens exceeded (status: %s, type: %s). If using a reasoning model, increase max_tokens to account for internal reasoning token usage.',
+                data_get($data, 'output.{last}.status', 'n/a'),
+                data_get($data, 'output.{last}.type', 'n/a'),
+            )),
+            default => throw new PrismException(sprintf(
+                'OpenAI: unhandled finish reason "%s" (status: %s, type: %s)',
+                $finishReason->value,
+                data_get($data, 'output.{last}.status', 'n/a'),
+                data_get($data, 'output.{last}.type', 'n/a'),
+            )),
         };
     }
 

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -59,11 +59,20 @@ class Text
 
         $this->citations = $this->extractCitations($data);
 
-        return match ($this->mapFinishReason($data)) {
+        return match ($finishReason = $this->mapFinishReason($data)) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response),
             FinishReason::Stop => $this->handleStop($data, $request, $response),
-            FinishReason::Length => throw new PrismException('OpenAI: max tokens exceeded'),
-            default => throw new PrismException('OpenAI: unknown finish reason'),
+            FinishReason::Length => throw new PrismException(sprintf(
+                'OpenAI: max tokens exceeded (status: %s, type: %s). If using a reasoning model, increase max_tokens to account for internal reasoning token usage.',
+                data_get($data, 'output.{last}.status', 'n/a'),
+                data_get($data, 'output.{last}.type', 'n/a'),
+            )),
+            default => throw new PrismException(sprintf(
+                'OpenAI: unhandled finish reason "%s" (status: %s, type: %s)',
+                $finishReason->value,
+                data_get($data, 'output.{last}.status', 'n/a'),
+                data_get($data, 'output.{last}.type', 'n/a'),
+            )),
         };
     }
 

--- a/tests/Fixtures/openai/structured-max-tokens-exceeded-1.json
+++ b/tests/Fixtures/openai/structured-max-tokens-exceeded-1.json
@@ -1,0 +1,33 @@
+{
+    "id": "resp_test_structured_max_tokens",
+    "object": "response",
+    "created_at": 1741990201,
+    "status": "incomplete",
+    "model": "gpt-5-2026-01-01",
+    "output": [
+        {
+            "id": "msg_test_structured_max_tokens",
+            "type": "message",
+            "status": "incomplete",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "{\"weather\": \"truncated",
+                    "refusal": null
+                }
+            ]
+        }
+    ],
+    "usage": {
+        "input_tokens": 50,
+        "input_tokens_details": {
+            "cached_tokens": 0
+        },
+        "output_tokens": 16384,
+        "output_tokens_details": {
+            "reasoning_tokens": 16000
+        }
+    }
+}

--- a/tests/Fixtures/openai/structured-unknown-finish-reason-1.json
+++ b/tests/Fixtures/openai/structured-unknown-finish-reason-1.json
@@ -1,0 +1,33 @@
+{
+    "id": "resp_test_structured_unknown",
+    "object": "response",
+    "created_at": 1741990201,
+    "status": "completed",
+    "model": "gpt-4o-2024-08-06",
+    "output": [
+        {
+            "id": "msg_test_structured_unknown",
+            "type": "some_future_type",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "{\"weather\": \"sunny\"}",
+                    "refusal": null
+                }
+            ]
+        }
+    ],
+    "usage": {
+        "input_tokens": 11,
+        "input_tokens_details": {
+            "cached_tokens": 0
+        },
+        "output_tokens": 56,
+        "output_tokens_details": {
+            "reasoning_tokens": 0
+        }
+    }
+}

--- a/tests/Fixtures/openai/text-incomplete-with-reasoning-1.json
+++ b/tests/Fixtures/openai/text-incomplete-with-reasoning-1.json
@@ -1,0 +1,25 @@
+{
+    "id": "resp_test_incomplete_reasoning",
+    "object": "response",
+    "created_at": 1741990201,
+    "status": "incomplete",
+    "model": "gpt-5-2026-01-01",
+    "output": [
+        {
+            "id": "rs_test_reasoning",
+            "type": "reasoning",
+            "status": "completed",
+            "summary": []
+        }
+    ],
+    "usage": {
+        "input_tokens": 50,
+        "input_tokens_details": {
+            "cached_tokens": 0
+        },
+        "output_tokens": 16384,
+        "output_tokens_details": {
+            "reasoning_tokens": 16384
+        }
+    }
+}

--- a/tests/Fixtures/openai/text-max-tokens-exceeded-1.json
+++ b/tests/Fixtures/openai/text-max-tokens-exceeded-1.json
@@ -1,0 +1,33 @@
+{
+    "id": "resp_test_max_tokens",
+    "object": "response",
+    "created_at": 1741990201,
+    "status": "incomplete",
+    "model": "gpt-5-2026-01-01",
+    "output": [
+        {
+            "id": "msg_test_max_tokens",
+            "type": "message",
+            "status": "incomplete",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "Truncated response due to reasoning token budget exhaustion...",
+                    "refusal": null
+                }
+            ]
+        }
+    ],
+    "usage": {
+        "input_tokens": 50,
+        "input_tokens_details": {
+            "cached_tokens": 0
+        },
+        "output_tokens": 16384,
+        "output_tokens_details": {
+            "reasoning_tokens": 16000
+        }
+    }
+}

--- a/tests/Fixtures/openai/text-unknown-finish-reason-1.json
+++ b/tests/Fixtures/openai/text-unknown-finish-reason-1.json
@@ -1,0 +1,33 @@
+{
+    "id": "resp_test_unknown",
+    "object": "response",
+    "created_at": 1741990201,
+    "status": "completed",
+    "model": "gpt-4o-2024-08-06",
+    "output": [
+        {
+            "id": "msg_test_unknown",
+            "type": "some_future_type",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "Some response",
+                    "refusal": null
+                }
+            ]
+        }
+    ],
+    "usage": {
+        "input_tokens": 11,
+        "input_tokens_details": {
+            "cached_tokens": 0
+        },
+        "output_tokens": 56,
+        "output_tokens_details": {
+            "reasoning_tokens": 0
+        }
+    }
+}

--- a/tests/Providers/OpenAI/FinishReasonMapTest.php
+++ b/tests/Providers/OpenAI/FinishReasonMapTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\OpenAI;
+
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+
+it('maps incomplete status to Length', function (): void {
+    expect(FinishReasonMap::map('incomplete'))->toBe(FinishReason::Length);
+});
+
+it('maps length status to Length', function (): void {
+    expect(FinishReasonMap::map('length'))->toBe(FinishReason::Length);
+});
+
+it('maps failed status to Error', function (): void {
+    expect(FinishReasonMap::map('failed'))->toBe(FinishReason::Error);
+});
+
+it('maps completed status with message type to Stop', function (): void {
+    expect(FinishReasonMap::map('completed', 'message'))->toBe(FinishReason::Stop);
+});
+
+it('maps completed status with function_call type to ToolCalls', function (): void {
+    expect(FinishReasonMap::map('completed', 'function_call'))->toBe(FinishReason::ToolCalls);
+});
+
+it('maps completed status with any _call suffix to ToolCalls', function (): void {
+    expect(FinishReasonMap::map('completed', 'web_search_call'))->toBe(FinishReason::ToolCalls);
+});
+
+it('maps completed status with reasoning type to Unknown', function (): void {
+    expect(FinishReasonMap::map('completed', 'reasoning'))->toBe(FinishReason::Unknown);
+});
+
+it('maps completed status with unknown type to Unknown', function (): void {
+    expect(FinishReasonMap::map('completed', 'other'))->toBe(FinishReason::Unknown);
+});
+
+it('maps empty status to Unknown', function (): void {
+    expect(FinishReasonMap::map(''))->toBe(FinishReason::Unknown);
+});
+
+it('maps unrecognized status to Unknown', function (): void {
+    expect(FinishReasonMap::map('some_new_status'))->toBe(FinishReason::Unknown);
+});

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -615,3 +615,49 @@ it('passes store parameter when specified', function (): void {
         return true;
     });
 });
+
+it('includes status details when max tokens exceeded', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/structured-max-tokens-exceeded');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+        ],
+        ['weather']
+    );
+
+    try {
+        Prism::structured()
+            ->withSchema($schema)
+            ->using(Provider::OpenAI, 'gpt-5')
+            ->withPrompt('What is the weather?')
+            ->asStructured();
+        $this->fail('Expected PrismException was not thrown');
+    } catch (PrismException $e) {
+        expect($e->getMessage())
+            ->toContain('incomplete')
+            ->toContain('reasoning model');
+    }
+});
+
+it('includes status details for unknown finish reasons', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/structured-unknown-finish-reason');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+        ],
+        ['weather']
+    );
+
+    expect(fn () => Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::OpenAI, 'gpt-4o')
+        ->withPrompt('What is the weather?')
+        ->asStructured()
+    )->toThrow(PrismException::class, 'some_future_type');
+});

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Citations\CitationSourceType;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\ValueObjects\Media\Document;
@@ -851,4 +852,46 @@ it('does not loop infinitely when using specific tool choice', function (): void
     expect($response->steps)->toHaveCount(2);
     expect($response->text)->not->toBeEmpty();
     expect($response->finishReason)->toBe(FinishReason::Stop);
+});
+
+it('includes status details when max tokens exceeded', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-max-tokens-exceeded');
+
+    try {
+        Prism::text()
+            ->using('openai', 'gpt-4o')
+            ->withPrompt('Write a long essay')
+            ->asText();
+        $this->fail('Expected PrismException was not thrown');
+    } catch (PrismException $e) {
+        expect($e->getMessage())
+            ->toContain('incomplete')
+            ->toContain('reasoning model');
+    }
+});
+
+it('throws Length when top-level status is incomplete even if last output is completed reasoning', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-incomplete-with-reasoning');
+
+    try {
+        Prism::text()
+            ->using('openai', 'gpt-4o')
+            ->withPrompt('Write something')
+            ->asText();
+        $this->fail('Expected PrismException was not thrown');
+    } catch (PrismException $e) {
+        expect($e->getMessage())
+            ->toContain('max tokens exceeded')
+            ->toContain('reasoning model');
+    }
+});
+
+it('includes status details for unknown finish reasons', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-unknown-finish-reason');
+
+    expect(fn () => Prism::text()
+        ->using('openai', 'gpt-4o')
+        ->withPrompt('Hello')
+        ->asText()
+    )->toThrow(PrismException::class, 'some_future_type');
 });


### PR DESCRIPTION
## Summary

- **Root cause fix:** `MapsFinishReason` now checks the top-level response `status` field first — when the response itself is `"incomplete"`, it returns `Length` regardless of what the last output item says. Also checks `incomplete_details.reason` to distinguish `content_filter` from `max_output_tokens`.
- **Enriched exception messages** in `Structured.php` and `Text.php` handlers to include actual API `status` and `type` values, plus a hint about reasoning model token usage.
- Changed the default branch message from "unknown finish reason" to include the actual mapped `FinishReason` value and raw API fields.

## Problem

When GPT-5 family models exhaust their `max_output_tokens` budget on internal reasoning tokens, the Responses API returns top-level `status: "incomplete"`. However, the last output item can be a `reasoning` block with `status: "completed"` and `type: "reasoning"`. 

`MapsFinishReason` only looked at `output.{last}.status` and `output.{last}.type`, so `completed` + `reasoning` mapped to `Unknown` (since `reasoning` isn't `message` or `function_call`). The handler then threw the opaque:

```
OpenAI: unknown finish reason
```

Even when the mapping was correct (`incomplete` + `message` → `Length`), the exception was just:

```
OpenAI: max tokens exceeded
```

...with no indication that reasoning tokens were the cause.

## After this PR

The `MapsFinishReason` trait checks the top-level response `status` first:
- `status: "incomplete"` + `incomplete_details.reason: "content_filter"` → `ContentFilter`
- `status: "incomplete"` + anything else → `Length`
- Otherwise falls through to per-output-item mapping via `FinishReasonMap`

**Length exception now shows:**
```
OpenAI: max tokens exceeded (status: incomplete, type: message). If using a reasoning model, increase max_tokens to account for internal reasoning token usage.
```

**Unknown finish reason now shows:**
```
OpenAI: unhandled finish reason "unknown" (status: completed, type: some_future_type)
```

## Bugs reproduced (Prism v0.99.21)

```php
// Bug 1: completed + reasoning → Unknown (should be Length when response is incomplete)
FinishReasonMap::map('completed', 'reasoning'); // Returns "unknown" ❌

// Bug 2: Top-level "incomplete" ignored when last output is completed reasoning
$data = ['status' => 'incomplete', 'output' => [['type' => 'reasoning', 'status' => 'completed']]];
// MapsFinishReason returns Unknown instead of Length ❌

// Bug 3: Opaque "max tokens exceeded" with no diagnostic info
// When FinishReason::Length IS correct, message gives no clue about reasoning tokens ❌
```

## Test plan

- [x] `FinishReasonMapTest.php` — 10 unit tests covering all `FinishReasonMap::map()` branches
- [x] `TextTest.php` — 3 new tests: max tokens exceeded details, incomplete with reasoning last output, unknown finish reason details
- [x] `StructuredTest.php` — 2 new tests: max tokens exceeded details, unknown finish reason details
- [x] Full test suite passes (1389 tests, 0 failures)
- [x] Pint formatting clean

Closes #546, closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)