### PR TITLE
fix: correct the Zai API URL

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -66,7 +66,7 @@ return [
             'url' => env('PERPLEXITY_URL', 'https://api.perplexity.ai'),
         ],
         'z' => [
-            'url' => env('Z_URL', 'https://api.z.ai/api/coding/paas/v4'),
+            'url' => env('Z_URL', 'https://api.z.ai/api/paas/v4'),
             'api_key' => env('Z_API_KEY', ''),
         ],
     ],


### PR DESCRIPTION
## Description

Corrects the Zai API URL from using the coding one to the general use one.

https://docs.z.ai/api-reference/llm/chat-completion

https://github.com/prism-php/prism/issues/945

## Breaking Changes
I don't think so