### PR TITLE
Enable structured output support for OpenAI gpt-5.4 model

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -42,6 +42,7 @@ class StructuredModeResolver
             'gpt-5-nano',
             'gpt-5.1',
             'gpt-5.2',
+            'gpt-5.4',
         ]);
     }
 


### PR DESCRIPTION
## Description
Enables native structured output support for OpenAI GPT 5.4 model.
I'm not listing gpt-5.3 as it is not recommended for API usage, and it doesn't seem like Prism tends to add model variations such as codex etc.

> GPT-5.3 Chat points to the GPT-5.3 Instant snapshot currently used in ChatGPT. We recommend [GPT-5.2](https://developers.openai.com/api/docs/models/gpt-5.2) for API usage, but feel free to use this GPT-5.3 Chat model to test our latest improvements for chat use cases.


<img width="1922" height="700" alt="CleanShot 2026-03-12 at 13 54 34@2x" src="https://github.com/user-attachments/assets/ded789a1-c11e-42df-8111-cacadcf2cd09" />

- https://developers.openai.com/api/docs/guides/structured-outputs#structured-outputs-vs-json-mode

## Breaking Changes
No breaking changes.