### PR TITLE
fix: when calling tools on xai provider with no parameters causing an api error

### DIFF
--- a/src/Providers/XAI/Maps/ToolMap.php
+++ b/src/Providers/XAI/Maps/ToolMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\XAI\Maps;
 
 use Prism\Prism\Tool;
+use stdClass;
 
 class ToolMap
 {
@@ -21,7 +22,7 @@ class ToolMap
                 'description' => $tool->description(),
                 'parameters' => [
                     'type' => 'object',
-                    'properties' => $tool->parametersAsArray(),
+                    'properties' => $tool->parametersAsArray() ?: new stdClass(),
                     'required' => $tool->requiredParameters(),
                 ],
             ],


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
I encountered an issue when trying to test the xAI provider where:

1. I was trying to call text/stream
2. I was providing tools that both had parameters and did not have parameters

When providing a tool with no parameters I observed the following API response:

```json
{
  "code": "Client specified an invalid argument",
  "error": "Invalid request content: Schema validation failed: [standard_violation] /properties: [] is not of type "object""
}
```

The fix is to just return a default object instead of empty array for `properties`
