### PR TITLE
feat(openai): support fine-tuned models in structured output

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -11,39 +11,51 @@ class StructuredModeResolver
 {
     public static function forModel(string $model): StructuredMode
     {
-        if (self::unsupported($model)) {
+        $baseModel = self::resolveBaseModel($model);
+
+        if (self::unsupported($baseModel)) {
             throw new PrismException(sprintf('Structured output is not supported for %s', $model));
         }
 
-        if (self::supportsStructuredMode($model)) {
+        if (self::supportsStructuredMode($baseModel)) {
             return StructuredMode::Structured;
         }
 
         return StructuredMode::Json;
     }
 
+    /**
+     * Resolve the base model name, stripping the ft: prefix for fine-tuned models.
+     *
+     * Fine-tuned models use the format: ft:<base-model>:<org>:<name>:<hash>
+     */
+    protected static function resolveBaseModel(string $model): string
+    {
+        if (str_starts_with($model, 'ft:')) {
+            $parts = explode(':', $model, 3);
+
+            return $parts[1] ?? $model;
+        }
+
+        return $model;
+    }
+
     protected static function supportsStructuredMode(string $model): bool
     {
-        return in_array($model, [
-            'gpt-4o-mini',
-            'gpt-4o-mini-2024-07-18',
-            'gpt-4o-2024-08-06',
+        foreach ([
             'gpt-4o',
-            'chatgpt-4o-latest',
-            'o3-mini',
-            'o3-mini-2025-01-31',
             'gpt-4.1',
-            'gpt-4.1-nano',
-            'gpt-4.1-mini',
-            'gpt-4.5-preview',
-            'gpt-4.5-preview-2025-02-27',
+            'gpt-4.5',
             'gpt-5',
-            'gpt-5-mini',
-            'gpt-5-nano',
-            'gpt-5.1',
-            'gpt-5.2',
-            'gpt-5.4',
-        ]);
+            'chatgpt-4o',
+            'o3-mini',
+        ] as $prefix) {
+            if (str_starts_with($model, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected static function supportsJsonMode(string $model): bool

--- a/tests/Providers/OpenAI/StructuredModeResolverTest.php
+++ b/tests/Providers/OpenAI/StructuredModeResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\OpenAI;
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\OpenAI\Support\StructuredModeResolver;
+
+it('resolves structured mode for supported models', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Structured);
+})->with([
+    'gpt-4o-mini',
+    'gpt-4o-mini-2024-07-18',
+    'gpt-4o-2024-08-06',
+    'gpt-4o',
+    'chatgpt-4o-latest',
+    'o3-mini',
+    'o3-mini-2025-01-31',
+    'gpt-4.1',
+    'gpt-4.1-nano',
+    'gpt-4.1-mini',
+    'gpt-4.5-preview',
+    'gpt-4.5-preview-2025-02-27',
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5-nano',
+    'gpt-5.1',
+    'gpt-5.2',
+    'gpt-5.4',
+]);
+
+it('resolves json mode for unsupported structured models', function (): void {
+    expect(StructuredModeResolver::forModel('gpt-3.5-turbo'))->toBe(StructuredMode::Json);
+});
+
+it('throws for unsupported models', function (): void {
+    StructuredModeResolver::forModel('o1-mini');
+})->throws(PrismException::class, 'Structured output is not supported for o1-mini');
+
+it('resolves structured mode for fine-tuned models based on supported base models', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Structured);
+})->with([
+    'ft:gpt-4o:my-org:custom-name:abc123',
+    'ft:gpt-4o-mini:my-org:custom-name:abc123',
+    'ft:gpt-4o-mini-2024-07-18:my-org:custom-name:abc123',
+    'ft:gpt-4.1-mini:company:model-name:hash',
+    'ft:gpt-4.1:company:model-name:hash',
+    'ft:gpt-4.1-mini-2025-04-14:company:model-name:hash',
+    'ft:gpt-4o-2024-08-06:my-org:custom-name:abc123',
+]);
+
+it('resolves json mode for fine-tuned models based on unsupported structured base models', function (): void {
+    expect(StructuredModeResolver::forModel('ft:gpt-3.5-turbo:my-org:custom-name:abc123'))->toBe(StructuredMode::Json);
+});
+
+it('throws for fine-tuned models based on unsupported base models', function (): void {
+    StructuredModeResolver::forModel('ft:o1-mini:my-org:custom-name:abc123');
+})->throws(PrismException::class, 'Structured output is not supported for ft:o1-mini:my-org:custom-name:abc123');


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Enable OpenAI fine-tuned models to use structured output mode. Fine-tuned models use the format `ft:<base-model>:<org>:<name>:<hash>` where the base model may include version dates. The resolver now extracts the base model name and uses prefix matching to determine support, allowing dated variants like `gpt-4.1-mini-2025-04-14` to work seamlessly.

### Changes

- Extract base model from fine-tuned identifiers before checking support
- Replace exact matching with prefix matching for structured output support (handles all `gpt-4o`, `gpt-4.1`, `gpt-4.5`, `gpt-5`, `chatgpt-4o`, and `o3-mini` variants)
- Add 29 test cases covering all 18 supported models and fine-tuned variants

🤖 Generated with Claude Code