### PR TITLE
feat(gemini): add topK generation parameter support

### DIFF
--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -165,6 +165,15 @@ The value is passed through to the provider. The range depends on the provider a
 > [!TIP]
 > It is recommended to set either temperature or topP, but not both.
 
+`usingTopK`
+
+Top-K sampling.
+
+The value is passed through to the provider. Top-K sampling considers only the K most likely tokens. For example, a topK of 40 means only the top 40 tokens are considered for sampling. This parameter is supported by providers such as Gemini and Anthropic.
+
+> [!TIP]
+> It is recommended to set either temperature or topK, but not both.
+
 `withClientOptions`
 
 Under the hood we use Laravel's [HTTP client](https://laravel.com/docs/11.x/http-client#main-content). You can use this method to pass any of Guzzles [request options](https://docs.guzzlephp.org/en/stable/request-options.html) e.g. `->withClientOptions(['timeout' => 30])`.

--- a/src/Concerns/ConfiguresModels.php
+++ b/src/Concerns/ConfiguresModels.php
@@ -12,6 +12,8 @@ trait ConfiguresModels
 
     protected int|float|null $topP = null;
 
+    protected ?int $topK = null;
+
     public function withMaxTokens(?int $maxTokens): self
     {
         $this->maxTokens = $maxTokens;
@@ -29,6 +31,13 @@ trait ConfiguresModels
     public function usingTopP(int|float $topP): self
     {
         $this->topP = $topP;
+
+        return $this;
+    }
+
+    public function usingTopK(int $topK): self
+    {
+        $this->topK = $topK;
 
         return $this;
     }

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -501,6 +501,7 @@ class Stream
                     'generationConfig' => Arr::whereNotNull([
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
+                        'topK' => $request->topK(),
                         'maxOutputTokens' => $request->maxTokens(),
                         'thinkingConfig' => $thinkingConfig,
                     ]) ?: null,

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -131,6 +131,7 @@ class Structured
                     'response_schema' => (new SchemaMap($request->schema()))->toArray(),
                     'temperature' => $request->temperature(),
                     'topP' => $request->topP(),
+                    'topK' => $request->topK(),
                     'maxOutputTokens' => $request->maxTokens(),
                     'thinkingConfig' => $thinkingConfig,
                 ]),

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -86,6 +86,7 @@ class Text
         $generationConfig = Arr::whereNotNull([
             'temperature' => $request->temperature(),
             'topP' => $request->topP(),
+            'topK' => $request->topK(),
             'maxOutputTokens' => $request->maxTokens(),
             'thinkingConfig' => $thinkingConfig,
         ]);

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -80,6 +80,7 @@ class PendingRequest
             maxTokens: $this->maxTokens,
             temperature: $this->temperature,
             topP: $this->topP,
+            topK: $this->topK,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             schema: $this->schema,

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -38,6 +38,7 @@ class Request implements PrismRequest
         protected ?int $maxTokens,
         protected int|float|null $temperature,
         protected int|float|null $topP,
+        protected ?int $topK,
         protected array $clientOptions,
         protected array $clientRetry,
         protected Schema $schema,
@@ -96,6 +97,11 @@ class Request implements PrismRequest
     public function topP(): int|float|null
     {
         return $this->topP;
+    }
+
+    public function topK(): ?int
+    {
+        return $this->topK;
     }
 
     /**

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -140,6 +140,7 @@ class PendingRequest
             maxTokens: $this->maxTokens,
             temperature: $this->temperature,
             topP: $this->topP,
+            topK: $this->topK,
             tools: $tools,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -37,6 +37,7 @@ class Request implements PrismRequest
         protected ?int $maxTokens,
         protected int|float|null $temperature,
         protected int|float|null $topP,
+        protected ?int $topK,
         protected array $tools,
         protected array $clientOptions,
         protected array $clientRetry,
@@ -79,6 +80,11 @@ class Request implements PrismRequest
     public function topP(): int|float|null
     {
         return $this->topP;
+    }
+
+    public function topK(): ?int
+    {
+        return $this->topK;
     }
 
     /**

--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -440,3 +440,28 @@ it('can generate text stream using multiple parallel tool calls', function (): v
     expect($toolCalls[1]->reasoningId)->not->toBeNull();
     expect($toolCalls[0]->reasoningId)->toBe($toolCalls[1]->reasoningId);
 });
+
+it('sends topK in generationConfig for streaming', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/stream-basic-text');
+
+    $events = [];
+    $response = Prism::text()
+        ->using(Provider::Gemini, 'gemini-2.0-flash')
+        ->withPrompt('Explain how AI works')
+        ->usingTopK(40)
+        ->asStream();
+
+    foreach ($response as $event) {
+        $events[] = $event;
+    }
+
+    Http::assertSent(function (Request $request): true {
+        $data = $request->data();
+
+        expect($data['generationConfig'])
+            ->toHaveKey('topK')
+            ->and($data['generationConfig']['topK'])->toBe(40);
+
+        return true;
+    });
+});

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -404,3 +404,32 @@ it('filters out thought parts when includeThoughts is true', function (): void {
     expect($response->steps[0]->additionalContent['thoughtSummaries'])->toBeArray();
     expect($response->steps[0]->additionalContent['thoughtSummaries'][0])->toContain('Let me think about');
 });
+
+it('sends topK in generationConfig for structured output', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/generate-structured');
+
+    Prism::structured()
+        ->using(Provider::Gemini, 'gemini-1.5-flash-002')
+        ->withSchema(new ObjectSchema(
+            'output',
+            'the output object',
+            [
+                new StringSchema('weather', 'The weather forecast'),
+                new BooleanSchema('coat_required', 'whether a coat is required'),
+            ],
+            ['weather', 'coat_required'],
+        ))
+        ->withPrompt('What time is the tigers game today and should I wear a coat?')
+        ->usingTopK(40)
+        ->asStructured();
+
+    Http::assertSent(function (Request $request): true {
+        $data = $request->data();
+
+        expect($data['generationConfig'])
+            ->toHaveKey('topK')
+            ->and($data['generationConfig']['topK'])->toBe(40);
+
+        return true;
+    });
+});

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -620,3 +620,71 @@ describe('Thinking Mode for Gemini', function (): void {
         });
     });
 });
+
+describe('Top K for Gemini', function (): void {
+    it('sends topK in generationConfig', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-1.5-flash')
+            ->withPrompt('Who are you?')
+            ->usingTopK(40)
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['generationConfig'])
+                ->toHaveKey('topK')
+                ->and($data['generationConfig']['topK'])->toBe(40);
+
+            return true;
+        });
+    });
+
+    it('does not send topK when not set', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-1.5-flash')
+            ->withPrompt('Who are you?')
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['generationConfig'] ?? [])->not->toHaveKey('topK');
+
+            return true;
+        });
+    });
+
+    it('sends topK alongside other generation config params', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-1.5-flash')
+            ->withPrompt('Who are you?')
+            ->usingTemperature(0.7)
+            ->usingTopP(0.9)
+            ->usingTopK(40)
+            ->withMaxTokens(100)
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['generationConfig'])
+                ->toHaveKey('temperature')
+                ->toHaveKey('topP')
+                ->toHaveKey('topK')
+                ->toHaveKey('maxOutputTokens')
+                ->and($data['generationConfig']['temperature'])->toBe(0.7)
+                ->and($data['generationConfig']['topP'])->toBe(0.9)
+                ->and($data['generationConfig']['topK'])->toBe(40)
+                ->and($data['generationConfig']['maxOutputTokens'])->toBe(100);
+
+            return true;
+        });
+    });
+});

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -92,6 +92,19 @@ test('it generates a proper request object', function (): void {
         ->and($request->providerOptions())->toBe($providerOptions);
 });
 
+test('it sets top k', function (): void {
+    $schema = new StringSchema('test', 'test description');
+
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema($schema)
+        ->withPrompt('Test prompt')
+        ->usingTopK(40)
+        ->toRequest();
+
+    expect($request->topK())->toBe(40);
+});
+
 test('you can run toRequest multiple times', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')

--- a/tests/Structured/RequestTest.php
+++ b/tests/Structured/RequestTest.php
@@ -19,6 +19,7 @@ function createStructuredRequestWithToolChoice(string|ToolChoice|null $toolChoic
         maxTokens: null,
         temperature: null,
         topP: null,
+        topK: null,
         clientOptions: [],
         clientRetry: [3, 100],
         schema: new ObjectSchema(

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -168,6 +168,16 @@ test('it sets top p', function (): void {
     expect($generated->topP())->toBe(0.9);
 });
 
+test('it sets top k', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->usingTopK(40);
+
+    $generated = $request->toRequest();
+
+    expect($generated->topK())->toBe(40);
+});
+
 test('it sets max steps', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')

--- a/tests/Text/RequestTest.php
+++ b/tests/Text/RequestTest.php
@@ -17,6 +17,7 @@ function createTextRequestWithToolChoice(string|ToolChoice|null $toolChoice): Re
         maxTokens: null,
         temperature: null,
         topP: null,
+        topK: null,
         tools: [],
         clientOptions: [],
         clientRetry: [3, 100],


### PR DESCRIPTION
## Summary
- Adds `topK` as a first-class generation parameter via `usingTopK(int $topK)`, following the same pattern as `topP` and `temperature`
- Wires `topK` into all three Gemini handlers (Text, Stream, Structured) within the `generationConfig` object
- The Gemini API supports `topK` natively in `generationConfig` alongside `topP`, `temperature`, and `maxOutputTokens`

## Changes
- **`src/Concerns/ConfiguresModels.php`** — Added `$topK` property and `usingTopK()` fluent method
- **`src/Text/Request.php`** / **`src/Structured/Request.php`** — Added `$topK` constructor parameter and `topK()` accessor
- **`src/Text/PendingRequest.php`** / **`src/Structured/PendingRequest.php`** — Pass `topK` through to Request
- **`src/Providers/Gemini/Handlers/Text.php`**, **`Stream.php`**, **`Structured.php`** — Added `'topK' => $request->topK()` to `generationConfig`
- **`docs/core-concepts/text-generation.md`** — Documented `usingTopK` parameter

## Usage

```php
$response = Prism::text()
    ->using(Provider::Gemini, 'gemini-2.0-flash')
    ->withPrompt('Hello')
    ->usingTopK(40)
    ->asText();
```

## Test plan
- [x] Added tests for topK in Gemini Text handler (sends topK, omits when not set, works alongside other params)
- [x] Added test for topK in Gemini Stream handler
- [x] Added test for topK in Gemini Structured handler
- [x] Added unit tests for topK in Text and Structured PendingRequest
- [x] Updated existing Request constructor tests to include topK parameter
- [x] Full test suite passes (1469 tests, 0 failures)
- [x] Laravel Pint code style passes
- [x] PHPStan static analysis passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)