### PR TITLE
refactor(anthropic): GA structured output support

### DIFF
--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -72,8 +72,8 @@ $response = Prism::structured()
     // ... rest of your configuration
 ```
 
-### Anthropic: Tool Calling Mode
-Anthropic doesn't have native structured output, but Prism provides two approaches. For more reliable JSON parsing, especially with complex content or non-English text, use tool calling mode:
+### Anthropic
+Anthropic uses native structured outputs by default (Claude Sonnet 4.5+), providing guaranteed schema compliance through constrained decoding. For older models, you can use tool calling mode as a fallback:
 
 ```php
 use Prism\Prism\Facades\Prism;
@@ -88,9 +88,9 @@ $response = Prism::structured()
 ```
 
 **When to use tool calling mode with Anthropic:**
-- Working with non-English content that may contain quotes
-- Complex JSON structures that might confuse prompt-based parsing
-- When you need the most reliable structured output possible
+- Using older models that don't support native structured outputs
+- Working with non-English content that may contain quotes on older models
+- When you need to combine structured output with custom tools
 
 > [!NOTE]
 > Tool calling mode cannot be used with Anthropic's citations feature.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -6,7 +6,7 @@
     'api_key' => env('ANTHROPIC_API_KEY', ''),
     'version' => env('ANTHROPIC_API_VERSION', '2023-06-01'),
     'default_thinking_budget' => env('ANTHROPIC_DEFAULT_THINKING_BUDGET', 1024),
-    // Include beta strings as a comma separated list.
+    // Include beta strings as a comma separated list (e.g. output-128k-2025-02-19, code-execution-2025-05-22).
     'anthropic_beta' => env('ANTHROPIC_BETA', null),
 ]
 ```
@@ -270,9 +270,9 @@ Prism::text()
 
 ## Citations
 
-Prism supports [Anthropic's citations feature](https://docs.anthropic.com/en/docs/build-with-claude/citations) for both text and structured. 
+Prism supports [Anthropic's citations feature](https://docs.anthropic.com/en/docs/build-with-claude/citations) for both text and structured.
 
-Please note however that due to Anthropic not supporting "native" structured output, and Prism's workaround for this, the output can be unreliable. You should therefore ensure you implement proper error handling for the scenario where Anthropic does not return a valid decodable schema.
+Please note that citations cannot be used with native structured output mode (the default). If you need citations with structured output, use tool calling mode via `withProviderOptions(['use_tool_calling' => true, 'citations' => true])`. Note however that citations with tool calling mode can produce unreliable output, so you should implement proper error handling.
 
 ## Code execution
 
@@ -388,28 +388,11 @@ Note that when using streaming, Anthropic does not stream citations in the same 
 
 ### Structured Output
 
-Prism supports three approaches for structured output with Anthropic models:
+Prism supports two approaches for structured output with Anthropic models:
 
-#### Native Structured Outputs (Recommended for Claude Sonnet 4.5+)
+#### Native Structured Outputs (Default)
 
-Claude Sonnet 4.5 and Opus 4.1 support native structured outputs through Anthropic's `output_format` parameter. This provides guaranteed schema compliance through constrained decoding.
-
-To enable native structured outputs, set the beta header in your configuration:
-
-```php
-// In config/prism.php or .env
-'anthropic' => [
-    ...
-    'anthropic_beta' => env('ANTHROPIC_BETA', 'structured-outputs-2025-11-13'),
-]
-```
-
-Or in your `.env` file:
-```
-ANTHROPIC_BETA=structured-outputs-2025-11-13
-```
-
-Once enabled, Prism will automatically use native structured outputs when available:
+Prism uses Anthropic's native structured outputs by default. This provides guaranteed schema compliance through constrained decoding — no beta header required.
 
 ```php
 use Prism\Prism\Enums\Provider;
@@ -441,14 +424,8 @@ $response = Prism::structured()
 - Cannot be used with citations
 - Some JSON Schema features are not supported (see [Schema Limitations](#schema-limitations))
 
-#### Default JSON Mode (Prompt-based)
-- We automatically append instructions to your prompt that guide the model to output valid JSON matching your schema
-- If the response isn't valid JSON, Prism will raise a PrismException
-- This method can sometimes struggle with complex JSON containing quotes, especially in non-English languages
-- Used as fallback when native mode is not available
-
 #### Tool Calling Mode
-For more reliable structured output on older models, especially when dealing with complex content or non-English text that may contain quotes, you can enable tool calling mode:
+For older models that don't support native structured outputs, or when dealing with complex content or non-English text that may contain quotes, you can use tool calling mode:
 
 ```php
 use Prism\Prism\Enums\Provider;
@@ -534,7 +511,7 @@ For complete documentation on combining tools with structured output, see [Struc
 
 ### Strict Tool Use
 
-When using the `structured-outputs-2025-11-13` beta feature, you can enable strict validation for tool inputs. This guarantees that tool parameters exactly match your schema through constrained decoding.
+You can enable strict validation for tool inputs, which guarantees that tool parameters exactly match your schema through constrained decoding.
 
 To enable strict mode for a tool, use the `strict` provider option:
 

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -18,7 +18,6 @@ use Prism\Prism\Providers\Anthropic\Concerns\ExtractsThinking;
 use Prism\Prism\Providers\Anthropic\Concerns\HandlesHttpRequests;
 use Prism\Prism\Providers\Anthropic\Concerns\ProcessesRateLimits;
 use Prism\Prism\Providers\Anthropic\Handlers\StructuredStrategies\AnthropicStructuredStrategy;
-use Prism\Prism\Providers\Anthropic\Handlers\StructuredStrategies\JsonModeStructuredStrategy;
 use Prism\Prism\Providers\Anthropic\Handlers\StructuredStrategies\NativeOutputFormatStructuredStrategy;
 use Prism\Prism\Providers\Anthropic\Handlers\StructuredStrategies\ToolStructuredStrategy;
 use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
@@ -110,20 +109,9 @@ class Structured
 
     protected static function createStrategy(StructuredRequest $request): AnthropicStructuredStrategy
     {
-        if (self::hasNativeStructuredOutputSupport($request)) {
-            return new NativeOutputFormatStructuredStrategy(request: $request);
-        }
-
         return $request->providerOptions('use_tool_calling')
             ? new ToolStructuredStrategy(request: $request)
-            : new JsonModeStructuredStrategy(request: $request);
-    }
-
-    protected static function hasNativeStructuredOutputSupport(StructuredRequest $request): bool
-    {
-        $betaFeatures = config('prism.providers.anthropic.anthropic_beta');
-
-        return $betaFeatures && str_contains($betaFeatures, 'structured-outputs-2025-11-13');
+            : new NativeOutputFormatStructuredStrategy(request: $request);
     }
 
     /**

--- a/tests/Providers/Anthropic/AnthropicStructuredRequestTest.php
+++ b/tests/Providers/Anthropic/AnthropicStructuredRequestTest.php
@@ -45,14 +45,12 @@ it('sends correct basic structured generation payload', function (): void {
                     ],
                 ],
             ],
-            [
-                'role' => 'user',
-                'content' => [
-                    [
-                        'type' => 'text',
-                        'text' => "Respond with ONLY JSON (i.e. not in backticks or a code block, with NO CONTENT outside the JSON) that matches the following schema: \n ".json_encode($schema->toArray(), JSON_PRETTY_PRINT).' ',
-                    ],
-                ],
+        ]);
+
+        expect($payload['output_config'])->toBe([
+            'format' => [
+                'type' => 'json_schema',
+                'schema' => $schema->toArray(),
             ],
         ]);
 

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Providers\Anthropic;
 
 use Illuminate\Support\Carbon;
-use Prism\Prism\Enums\Citations\CitationSourceType;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Facades\Prism;
@@ -14,9 +13,6 @@ use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\ObjectSchema;
 use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Structured\Response;
-use Prism\Prism\ValueObjects\Media\Document;
-use Prism\Prism\ValueObjects\MessagePartWithCitations;
-use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
@@ -100,92 +96,6 @@ it('adds rate limit data to the responseMeta', function (): void {
     expect($response->meta->rateLimits[0]->resetsAt)->toEqual($requests_reset);
 });
 
-it('applies the citations request level providerOptions to all documents', function (): void {
-    Prism::fake();
-
-    $schema = new ObjectSchema(
-        'output',
-        'the output object',
-        [
-            new StringSchema('weather', 'The weather forecast'),
-            new StringSchema('game_time', 'The tigers game time'),
-            new BooleanSchema('coat_required', 'whether a coat is required'),
-        ],
-        ['weather', 'game_time', 'coat_required']
-    );
-
-    $request = Prism::structured()
-        ->withSchema($schema)
-        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-        ->withMessages([
-            (new UserMessage(
-                content: 'What color is the grass and sky?',
-                additionalContent: [
-                    Document::fromText('The grass is green. The sky is blue.'),
-                ]
-            )),
-        ])
-        ->withProviderOptions(['citations' => true]);
-
-    $payload = Structured::buildHttpRequestPayload($request->toRequest());
-
-    expect($payload['messages'])->toBe([[
-        'role' => 'user',
-        'content' => [
-            [
-                'type' => 'text',
-                'text' => 'What color is the grass and sky?',
-            ],
-            [
-                'type' => 'document',
-                'citations' => ['enabled' => true],
-                'source' => [
-                    'type' => 'text',
-                    'media_type' => 'text/plain',
-                    'data' => 'The grass is green. The sky is blue.',
-                ],
-            ],
-        ],
-    ]]);
-});
-
-it('saves message parts with citations to additionalContent on response steps and assistant message for text documents', function (): void {
-    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-structured-with-text-document-citations');
-
-    $response = Prism::structured()
-        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-        ->withMessages([
-            new UserMessage(
-                content: 'Is the grass green and the sky blue?',
-                additionalContent: [
-                    Document::fromChunks(['The grass is green.', 'Flamingos are pink.', 'The sky is blue.']),
-                ]
-            ),
-        ])
-        ->withSchema(new ObjectSchema('body', '', [new BooleanSchema('answer', '')], ['answer']))
-        ->withProviderOptions(['citations' => true])
-        ->asStructured();
-
-    expect($response->structured)->toBe(['answer' => true]);
-
-    expect($response->additionalContent['citations'])->toHaveCount(1);
-    expect($response->additionalContent['citations'][0])->toBeInstanceOf(MessagePartWithCitations::class);
-
-    /** @var MessagePartWithCitations */
-    $messagePart = $response->additionalContent['citations'][0];
-
-    expect($messagePart->outputText)->toBe('{"answer": true}');
-    expect($messagePart->citations)->toHaveCount(2);
-    expect($messagePart->citations[0]->sourceType)->toBe(CitationSourceType::Document);
-    expect($messagePart->citations[0]->sourceText)->toBe('The grass is green.');
-    expect($messagePart->citations[0]->sourceStartIndex)->toBe(0);
-    expect($messagePart->citations[0]->sourceEndIndex)->toBe(1);
-    expect($messagePart->citations[0]->source)->toBe(0);
-
-    expect($response->steps[0]->additionalContent['citations'])->toHaveCount(1);
-    expect($response->steps[0]->additionalContent['citations'][0])->toBeInstanceOf(MessagePartWithCitations::class);
-});
-
 it('can use extending thinking', function (): void {
     FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-with-extending-thinking');
 
@@ -202,7 +112,7 @@ it('can use extending thinking', function (): void {
     expect($response->additionalContent['thinking'])->toContain('meaning of life');
     expect($response->additionalContent['thinking_signature'])->toBe($expected_signature);
 
-    expect($response->steps->last()->messages[2])
+    expect($response->steps->last()->messages[1])
         ->additionalContent->thinking->toContain('meaning of life')
         ->additionalContent->thinking_signature->toBe($expected_signature);
 });
@@ -219,27 +129,6 @@ it('throws error when citations and tool calling are used together', function ()
         ->withProviderOptions(['citations' => true, 'use_tool_calling' => true])
         ->asStructured()
     )->toThrow(PrismException::class, 'Citations are not supported with tool calling mode');
-});
-
-it('returns structured output with default JSON mode', function (): void {
-    FixtureResponse::fakeResponseSequence(
-        'v1/messages',
-        'anthropic/structured-with-default-json'
-    );
-
-    $schema = new ObjectSchema('output', 'the output object', [
-        new StringSchema('answer', 'A simple answer'),
-    ], ['answer']);
-
-    $response = Prism::structured()
-        ->withSchema($schema)
-        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
-        ->withPrompt('What is 2+2?')
-        ->asStructured();
-
-    expect($response->structured)->toBeArray();
-    expect($response->structured)->toHaveKey('answer');
-    expect($response->structured['answer'])->toBeString();
 });
 
 it('works with thinking mode when use_tool_calling is true', function (): void {
@@ -307,114 +196,104 @@ it('handles Chinese output with double quotes using tool calling', function (): 
     expect($response->structured['coat_required'])->toBe(true);
 });
 
-describe('native structured outputs', function (): void {
-    beforeEach(function (): void {
-        config(['prism.providers.anthropic.anthropic_beta' => 'structured-outputs-2025-11-13']);
-    });
+it('uses native output format by default', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-with-native-output-format');
 
-    afterEach(function (): void {
-        config(['prism.providers.anthropic.anthropic_beta' => null]);
-    });
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+            new StringSchema('game_time', 'The tigers game time'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'game_time', 'coat_required']
+    );
 
-    it('uses native output format when beta header is set', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-with-native-output-format');
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
+        ->withSystemPrompt('The tigers game is at 3pm and the temperature will be 70º')
+        ->withPrompt('What time is the tigers game today and should I wear a coat?')
+        ->asStructured();
 
-        $schema = new ObjectSchema(
-            'output',
-            'the output object',
-            [
-                new StringSchema('weather', 'The weather forecast'),
-                new StringSchema('game_time', 'The tigers game time'),
-                new BooleanSchema('coat_required', 'whether a coat is required'),
-            ],
-            ['weather', 'game_time', 'coat_required']
-        );
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toHaveKeys(['weather', 'game_time', 'coat_required']);
+    expect($response->structured['weather'])->toBe('70º');
+    expect($response->structured['game_time'])->toBe('3pm');
+    expect($response->structured['coat_required'])->toBe(false);
+});
 
-        $response = Prism::structured()
-            ->withSchema($schema)
-            ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
-            ->withSystemPrompt('The tigers game is at 3pm and the temperature will be 70º')
-            ->withPrompt('What time is the tigers game today and should I wear a coat?')
-            ->asStructured();
+it('uses native output format for complex nested structures', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-native-complex');
 
-        expect($response->structured)->toBeArray();
-        expect($response->structured)->toHaveKeys(['weather', 'game_time', 'coat_required']);
-        expect($response->structured['weather'])->toBe('70º');
-        expect($response->structured['game_time'])->toBe('3pm');
-        expect($response->structured['coat_required'])->toBe(false);
-    });
+    $schema = new ObjectSchema(
+        'contact_info',
+        'contact information extracted from text',
+        [
+            new StringSchema('name', 'Full name'),
+            new StringSchema('email', 'Email address'),
+            new StringSchema('plan_interest', 'Plan they are interested in'),
+            new BooleanSchema('demo_requested', 'Whether they requested a demo'),
+        ],
+        ['name', 'email', 'plan_interest', 'demo_requested']
+    );
 
-    it('uses native output format for complex nested structures', function (): void {
-        FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-native-complex');
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
+        ->withPrompt('Extract the key information from this email: John Smith (john@example.com) is interested in our Enterprise plan and wants to schedule a demo for next Tuesday at 2pm.')
+        ->asStructured();
 
-        $schema = new ObjectSchema(
-            'contact_info',
-            'contact information extracted from text',
-            [
-                new StringSchema('name', 'Full name'),
-                new StringSchema('email', 'Email address'),
-                new StringSchema('plan_interest', 'Plan they are interested in'),
-                new BooleanSchema('demo_requested', 'Whether they requested a demo'),
-            ],
-            ['name', 'email', 'plan_interest', 'demo_requested']
-        );
+    expect($response->structured)->toBeArray();
+    expect($response->structured['name'])->toBe('John Smith');
+    expect($response->structured['email'])->toBe('john@example.com');
+    expect($response->structured['plan_interest'])->toBe('Enterprise');
+    expect($response->structured['demo_requested'])->toBe(true);
+});
 
-        $response = Prism::structured()
-            ->withSchema($schema)
-            ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
-            ->withPrompt('Extract the key information from this email: John Smith (john@example.com) is interested in our Enterprise plan and wants to schedule a demo for next Tuesday at 2pm.')
-            ->asStructured();
+it('sends output_config.format instead of deprecated output_format in the request payload', function (): void {
+    Prism::fake();
 
-        expect($response->structured)->toBeArray();
-        expect($response->structured['name'])->toBe('John Smith');
-        expect($response->structured['email'])->toBe('john@example.com');
-        expect($response->structured['plan_interest'])->toBe('Enterprise');
-        expect($response->structured['demo_requested'])->toBe(true);
-    });
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'coat_required']
+    );
 
-    it('sends output_config.format instead of deprecated output_format in the request payload', function (): void {
-        Prism::fake();
+    $request = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
+        ->withPrompt('What is the weather?');
 
-        $schema = new ObjectSchema(
-            'output',
-            'the output object',
-            [
-                new StringSchema('weather', 'The weather forecast'),
-                new BooleanSchema('coat_required', 'whether a coat is required'),
-            ],
-            ['weather', 'coat_required']
-        );
+    $payload = Structured::buildHttpRequestPayload($request->toRequest());
 
-        $request = Prism::structured()
-            ->withSchema($schema)
-            ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
-            ->withPrompt('What is the weather?');
+    expect($payload)->not->toHaveKey('output_format');
+    expect($payload)->toHaveKey('output_config');
+    expect($payload['output_config'])->toBe([
+        'format' => [
+            'type' => 'json_schema',
+            'schema' => $schema->toArray(),
+        ],
+    ]);
+});
 
-        $payload = Structured::buildHttpRequestPayload($request->toRequest());
+it('throws error when citations and native output format are used together', function (): void {
+    $schema = new ObjectSchema('output', 'the output object', [
+        new StringSchema('answer', 'The answer'),
+    ], ['answer']);
 
-        expect($payload)->not->toHaveKey('output_format');
-        expect($payload)->toHaveKey('output_config');
-        expect($payload['output_config'])->toBe([
-            'format' => [
-                'type' => 'json_schema',
-                'schema' => $schema->toArray(),
-            ],
-        ]);
-    });
-
-    it('throws error when citations and native output format are used together', function (): void {
-        $schema = new ObjectSchema('output', 'the output object', [
-            new StringSchema('answer', 'The answer'),
-        ], ['answer']);
-
-        expect(fn (): Response => Prism::structured()
-            ->withSchema($schema)
-            ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
-            ->withPrompt('What is the answer?')
-            ->withProviderOptions(['citations' => true])
-            ->asStructured()
-        )->toThrow(PrismException::class, 'Citations are not supported with native output_format');
-    });
+    expect(fn (): Response => Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-sonnet-4-5-20250929')
+        ->withPrompt('What is the answer?')
+        ->withProviderOptions(['citations' => true])
+        ->asStructured()
+    )->toThrow(PrismException::class, 'Citations are not supported with native output_format');
 });
 
 it('allows automatic caching enabled via providerOptions', function (): void {


### PR DESCRIPTION
## Description

Anthropic's structured outputs feature has moved from beta to GA. Native structured output is now the default strategy for Anthropic — no beta header (`structured-outputs-2025-11-13`) required.

### Changes

**Strategy selection** (`Structured.php`):
- Native output format is now the default (previously required beta header)
- `use_tool_calling` provider option is the explicit opt-out for older models
- Removed `hasNativeStructuredOutputSupport()` beta header check
- Removed `JsonModeStructuredStrategy` import (no longer reachable)

**Tests**:
- Flattened `describe('native structured outputs')` block — no longer gated behind beta config
- Removed two citation + structured output tests (this combination is [incompatible at the Anthropic API level](https://docs.anthropic.com/en/docs/build-with-claude/citations))
- Updated payload test to expect `output_config` instead of JSON-mode prompt injection
- Fixed message index in thinking test (no extra JSON-mode message appended)

**Docs**:
- Native structured output documented as default (no beta setup needed)
- Strict tool use no longer references beta header
- Citations section clarifies incompatibility with structured output
- Config comment updated to reference remaining beta features (output-128k, code-execution)

### Breaking Changes

- Structured output now uses native mode by default instead of prompt-based JSON mode
- Citations can no longer be used with structured output (previously worked via JSON mode workaround, but this is [unsupported by the Anthropic API](https://docs.anthropic.com/en/docs/build-with-claude/citations))
- Users who had the beta header configured for structured outputs can remove it
