### PR TITLE
fix(anthropic): provider tool use to response

### DIFF
--- a/src/Providers/Anthropic/Concerns/ExtractsProviderToolCalls.php
+++ b/src/Providers/Anthropic/Concerns/ExtractsProviderToolCalls.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Anthropic\Concerns;
+
+use Prism\Prism\ValueObjects\ProviderToolCall;
+
+trait ExtractsProviderToolCalls
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<int, ProviderToolCall>
+     */
+    protected function extractProviderToolCalls(array $data): array
+    {
+        $providerToolCalls = [];
+        $contents = data_get($data, 'content', []);
+
+        foreach ($contents as $content) {
+            $type = data_get($content, 'type', '');
+
+            if ($type === 'server_tool_use') {
+                $providerToolCalls[] = new ProviderToolCall(
+                    id: data_get($content, 'id', ''),
+                    type: data_get($content, 'name', ''),
+                    status: 'completed',
+                    data: $content,
+                );
+            }
+
+            if (str_ends_with((string) $type, '_tool_result')) {
+                $providerToolCalls[] = new ProviderToolCall(
+                    id: data_get($content, 'tool_use_id', ''),
+                    type: $type,
+                    status: 'result_received',
+                    data: $content,
+                );
+            }
+        }
+
+        return $providerToolCalls;
+    }
+}

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -13,6 +13,7 @@ use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsCitations;
+use Prism\Prism\Providers\Anthropic\Concerns\ExtractsProviderToolCalls;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsText;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsThinking;
 use Prism\Prism\Providers\Anthropic\Concerns\HandlesHttpRequests;
@@ -38,7 +39,7 @@ use Prism\Prism\ValueObjects\Usage;
 
 class Structured
 {
-    use CallsTools, ExtractsCitations, ExtractsText, ExtractsThinking, HandlesHttpRequests, ProcessesRateLimits;
+    use CallsTools, ExtractsCitations, ExtractsProviderToolCalls, ExtractsText, ExtractsThinking, HandlesHttpRequests, ProcessesRateLimits;
 
     protected ResponseBuilder $responseBuilder;
 
@@ -278,6 +279,7 @@ class Structured
             additionalContent: $tempResponse->additionalContent,
             structured: $isStructuredStep ? ($tempResponse->structured ?? []) : [],
             toolCalls: $toolCalls,
+            providerToolCalls: $this->extractProviderToolCalls($data),
             toolResults: $toolResults,
             raw: $data,
         ));

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -13,6 +13,7 @@ use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsCitations;
+use Prism\Prism\Providers\Anthropic\Concerns\ExtractsProviderToolCalls;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsText;
 use Prism\Prism\Providers\Anthropic\Concerns\ExtractsThinking;
 use Prism\Prism\Providers\Anthropic\Concerns\HandlesHttpRequests;
@@ -35,7 +36,7 @@ use Prism\Prism\ValueObjects\Usage;
 
 class Text
 {
-    use CallsTools, ExtractsCitations, ExtractsText, ExtractsThinking, HandlesHttpRequests, ProcessesRateLimits;
+    use CallsTools, ExtractsCitations, ExtractsProviderToolCalls, ExtractsText, ExtractsThinking, HandlesHttpRequests, ProcessesRateLimits;
 
     protected Response $tempResponse;
 
@@ -135,7 +136,7 @@ class Text
             finishReason: $this->tempResponse->finishReason,
             toolCalls: $this->tempResponse->toolCalls,
             toolResults: $toolResults,
-            providerToolCalls: [],
+            providerToolCalls: $this->extractProviderToolCalls($data),
             usage: $this->tempResponse->usage,
             meta: $this->tempResponse->meta,
             messages: $this->request->messages(),

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -7,6 +7,7 @@ namespace Prism\Prism\Structured;
 use Illuminate\Support\Collection;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismStructuredDecodingException;
+use Prism\Prism\ValueObjects\ProviderToolCall;
 use Prism\Prism\ValueObjects\ToolCall;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
@@ -41,6 +42,7 @@ readonly class ResponseBuilder
             usage: $this->calculateTotalUsage(),
             meta: $finalStep->meta,
             toolCalls: $this->aggregateToolCalls(),
+            providerToolCalls: $this->aggregateProviderToolCalls(),
             toolResults: $this->aggregateToolResults(),
             additionalContent: $finalStep->additionalContent,
             raw: $finalStep->raw,
@@ -90,6 +92,17 @@ readonly class ResponseBuilder
     {
         return $this->steps
             ->flatMap(fn (Step $step): array => $step->toolCalls)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, ProviderToolCall>
+     */
+    protected function aggregateProviderToolCalls(): array
+    {
+        return $this->steps
+            ->flatMap(fn (Step $step): array => $step->providerToolCalls)
             ->values()
             ->all();
     }

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -146,6 +146,11 @@ describe('tools', function (): void {
             ->asText();
 
         expect($response->text)->toContain('4/3');
+
+        $finalStep = $response->steps->last();
+        expect($finalStep->providerToolCalls)->not->toBeEmpty();
+        expect($finalStep->providerToolCalls[0]->type)->toBe('code_execution');
+        expect($finalStep->providerToolCalls[0]->status)->toBe('completed');
     });
 
     it('handles a provider tool with a user defined tool', function (): void {

--- a/tests/Providers/Anthropic/StructuredWithToolsTest.php
+++ b/tests/Providers/Anthropic/StructuredWithToolsTest.php
@@ -400,6 +400,10 @@ describe('Structured output with tools for Anthropic', function (): void {
             ->and($response->structured)->toHaveKeys(['summary', 'recommendation'])
             ->and($response->structured['summary'])->toBeString()
             ->and($response->structured['recommendation'])->toBeString();
+
+        expect($response->providerToolCalls)->not->toBeEmpty();
+        expect($response->providerToolCalls[0]->type)->toBe('web_search');
+        expect($response->providerToolCalls[0]->status)->toBe('completed');
     });
 
     it('can generate structured output with provider tools using tool calling mode', function (): void {
@@ -427,6 +431,10 @@ describe('Structured output with tools for Anthropic', function (): void {
             ->and($response->structured)->toHaveKeys(['summary', 'recommendation'])
             ->and($response->structured['summary'])->toBeString()
             ->and($response->structured['recommendation'])->toBeString();
+
+        expect($response->providerToolCalls)->not->toBeEmpty();
+        expect($response->providerToolCalls[0]->type)->toBe('web_search');
+        expect($response->providerToolCalls[0]->status)->toBe('completed');
     });
 
     it('includes provider tools in native output format payload', function (): void {

--- a/tests/Providers/Perplexity/StreamTest.php
+++ b/tests/Providers/Perplexity/StreamTest.php
@@ -30,7 +30,6 @@ it('can generate text with a basic stream', function (): void {
 
         if ($event instanceof TextDeltaEvent) {
             $text .= $event->delta;
-            echo $text;
         }
     }
 


### PR DESCRIPTION
## Description

Provider tool calls (`server_tool_use`, `web_search_tool_result`, `code_execution_tool_result`, etc.) were only surfaced in streaming responses via `StreamCollector`. The non-streaming `Text` and `Structured` handlers hardcoded `providerToolCalls: []`, so consumers had no access to provider tool call data when using `asText()` or `asStructured()`.

### Changes

- **New `ExtractsProviderToolCalls` trait** — Extracts `ProviderToolCall` objects from Anthropic response content blocks, handling both `server_tool_use` and `*_tool_result` types
- **`Text.php`** — Uses the trait to populate `providerToolCalls` in step data instead of empty array
- **`Structured.php`** — Same: uses the trait to populate `providerToolCalls` in step data
- **`Structured\ResponseBuilder`** — Aggregates `providerToolCalls` across steps and passes them to the final `Response` object