### PR TITLE
fix(openai): interleave reasoning blocks with paired function calls in conversation history

### DIFF
--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -117,6 +117,32 @@ class MessageMap
 
     protected function mapAssistantMessage(AssistantMessage $message): void
     {
+        if ($message->toolCalls !== []) {
+            $grouped = collect($message->toolCalls)
+                ->groupBy(fn (ToolCall $toolCall): string => $toolCall->reasoningId ?? '');
+
+            foreach ($grouped as $reasoningId => $toolCalls) {
+                if ($reasoningId !== '') {
+                    $first = $toolCalls->first();
+                    $this->mappedMessages[] = [
+                        'type' => 'reasoning',
+                        'id' => $first->reasoningId,
+                        'summary' => $first->reasoningSummary,
+                    ];
+                }
+
+                foreach ($toolCalls as $toolCall) {
+                    $this->mappedMessages[] = [
+                        'id' => $toolCall->id,
+                        'call_id' => $toolCall->resultId,
+                        'type' => 'function_call',
+                        'name' => $toolCall->name,
+                        'arguments' => json_encode($toolCall->arguments() ?: (object) []),
+                    ];
+                }
+            }
+        }
+
         if ($message->content !== '' && $message->content !== '0') {
             $mappedMessage = [
                 'role' => 'assistant',
@@ -133,31 +159,6 @@ class MessageMap
             }
 
             $this->mappedMessages[] = $mappedMessage;
-        }
-
-        if ($message->toolCalls !== []) {
-            $reasoningBlocks = collect($message->toolCalls)
-                ->whereNotNull('reasoningId')
-                ->unique('reasoningId')
-                ->map(fn (ToolCall $toolCall): array => [
-                    'type' => 'reasoning',
-                    'id' => $toolCall->reasoningId,
-                    'summary' => $toolCall->reasoningSummary,
-                ])
-                ->values()
-                ->all();
-
-            array_push(
-                $this->mappedMessages,
-                ...$reasoningBlocks,
-                ...array_map(fn (ToolCall $toolCall): array => [
-                    'id' => $toolCall->id,
-                    'call_id' => $toolCall->resultId,
-                    'type' => 'function_call',
-                    'name' => $toolCall->name,
-                    'arguments' => json_encode($toolCall->arguments() ?: (object) []),
-                ], $message->toolCalls)
-            );
         }
     }
 }

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -169,15 +169,6 @@ it('maps assistant message with tool calls', function (): void {
 
     expect($messageMap())->toBe([
         [
-            'role' => 'assistant',
-            'content' => [
-                [
-                    'type' => 'output_text',
-                    'text' => 'I am Nyx',
-                ],
-            ],
-        ],
-        [
             'id' => 'tool_1234',
             'call_id' => 'call_1234',
             'type' => 'function_call',
@@ -185,6 +176,15 @@ it('maps assistant message with tool calls', function (): void {
             'arguments' => json_encode([
                 'query' => 'Laravel collection methods',
             ]),
+        ],
+        [
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'output_text',
+                    'text' => 'I am Nyx',
+                ],
+            ],
         ],
     ]);
 });
@@ -211,6 +211,68 @@ it('maps assistant message with tool calls with empty arguments as json object',
             'type' => 'function_call',
             'name' => 'get_schema',
             'arguments' => '{}',
+        ],
+    ]);
+});
+
+it('maps assistant message with multiple tool calls and different reasoning ids', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new AssistantMessage('I am Nyx', [
+                new ToolCall(
+                    'tool_1',
+                    'search',
+                    ['query' => 'Laravel collection methods'],
+                    'call_1',
+                    'rs_1',
+                    [],
+                ),
+                new ToolCall(
+                    'tool_2',
+                    'search',
+                    ['query' => 'Laravel query builder'],
+                    'call_2',
+                    'rs_2',
+                    [],
+                ),
+            ]),
+        ],
+        systemPrompts: []
+    );
+
+    expect($messageMap())->toBe([
+        [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [],
+        ],
+        [
+            'id' => 'tool_1',
+            'call_id' => 'call_1',
+            'type' => 'function_call',
+            'name' => 'search',
+            'arguments' => json_encode(['query' => 'Laravel collection methods']),
+        ],
+        [
+            'type' => 'reasoning',
+            'id' => 'rs_2',
+            'summary' => [],
+        ],
+        [
+            'id' => 'tool_2',
+            'call_id' => 'call_2',
+            'type' => 'function_call',
+            'name' => 'search',
+            'arguments' => json_encode(['query' => 'Laravel query builder']),
+        ],
+        [
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'output_text',
+                    'text' => 'I am Nyx',
+                ],
+            ],
         ],
     ]);
 });


### PR DESCRIPTION
Fixes #955.

When using OpenAI provider, with OpenAI reasoning enabled models (e.g. gpt-5-mini) with tool calling and conversational history, and a reasoning model decides to plan and execute a multi-tool calling chain (e.g. ListTenants -> ListTenantUsers(tenantId)), the GPT 5 models expect you to return reasoning items that are immediately followed by a paired function_call, and the assistant message last.

This PR reworks the order of returned messages to match that:
```
Before (current Prism code):
1. { role: "assistant", content: [{ type: "output_text", text: "I found 5 users in tenant..." }] }
2. { type: "reasoning", id: "rs_...fb60..." }
3. { type: "reasoning", id: "rs_...0054..." }
4. { type: "function_call", name: "ListTenants", id: "fc_...fe05..." }
5. { type: "function_call", name: "ListTenantUsers", id: "fc_...0325..." }

OpenAI sees rs_1 followed by rs_2 — rejects it  with error 400 because rs_1 needs its function_call immediately after.

The fix:
1. { type: "reasoning", id: "rs_...fb60..." }
2. { type: "function_call", name: "ListTenants", id: "fc_...fe05..." }
3. { type: "reasoning", id: "rs_...0054..." }
4. { type: "function_call", name: "ListTenantUsers", id: "fc_...0325..." }
5. { role: "assistant", content: [{ type: "output_text", text: "I found 5 users in tenant..." }] }
```