### PR TITLE
fix(gemini): switch structured output to response_json_schema

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -128,7 +128,7 @@ class Structured
                 'cachedContent' => $providerOptions['cachedContentName'] ?? null,
                 'generationConfig' => Arr::whereNotNull([
                     'response_mime_type' => 'application/json',
-                    'response_schema' => (new SchemaMap($request->schema()))->toArray(),
+                    'response_json_schema' => (new SchemaMap($request->schema()))->toArray(),
                     'temperature' => $request->temperature(),
                     'topP' => $request->topP(),
                     'maxOutputTokens' => $request->maxTokens(),

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -189,7 +189,7 @@ it('supports AnyOfSchema in structured output', function (): void {
     expect($response->structured['value'])->toBe('forty-two');
 
     Http::assertSent(function (Request $request): bool {
-        $schema = $request->data()['generationConfig']['response_schema'];
+        $schema = $request->data()['generationConfig']['response_json_schema'];
 
         expect($schema)->toHaveKey('properties');
         expect($schema['properties'])->toHaveKey('value');
@@ -256,7 +256,7 @@ it('supports AnyOfSchema with complex objects', function (): void {
     expect($response->structured['content']['title'])->toBe('Understanding AI');
 
     Http::assertSent(function (Request $request): bool {
-        $schema = $request->data()['generationConfig']['response_schema'];
+        $schema = $request->data()['generationConfig']['response_json_schema'];
         $anyOf = $schema['properties']['content']['anyOf'];
 
         expect($anyOf)->toHaveCount(2);
@@ -311,7 +311,7 @@ it('supports NumberSchema constraints in structured output', function (): void {
     expect($response->structured['score'])->toBeLessThanOrEqual(5.0);
 
     Http::assertSent(function (Request $request): bool {
-        $schema = $request->data()['generationConfig']['response_schema'];
+        $schema = $request->data()['generationConfig']['response_json_schema'];
 
         expect($schema['properties'])->toHaveKey('score');
         expect($schema['properties']['score'])->toHaveKey('minimum');
@@ -355,7 +355,7 @@ it('supports nullable AnyOfSchema in structured output', function (): void {
     expect($response->structured['value'])->toBeNull();
 
     Http::assertSent(function (Request $request): bool {
-        $schema = $request->data()['generationConfig']['response_schema'];
+        $schema = $request->data()['generationConfig']['response_json_schema'];
         $anyOf = $schema['properties']['value']['anyOf'];
 
         expect($anyOf)->toHaveCount(3);


### PR DESCRIPTION
Fixes #974.

Switches Gemini structured output from `response_schema` to `response_json_schema`, fixing 400 errors caused by `additionalProperties` in nested objects and nullable union types (`"type": ["string", "null"]`).