### PR TITLE
fix(xai): cast empty tool properties to object in xAI ToolMap

### DIFF
--- a/src/Providers/XAI/Maps/ToolMap.php
+++ b/src/Providers/XAI/Maps/ToolMap.php
@@ -21,7 +21,7 @@ class ToolMap
                 'description' => $tool->description(),
                 'parameters' => [
                     'type' => 'object',
-                    'properties' => $tool->parametersAsArray(),
+                    'properties' => (object) $tool->parametersAsArray(),
                     'required' => $tool->requiredParameters(),
                 ],
             ],


### PR DESCRIPTION
## Problem

When a tool has no parameters/inputs, the xAI provider sends
`"properties": []` (JSON array)
instead of
`"properties": {}` (JSON object)
in the tool definition.

xAI's API rejects this with a 400 error.

This is the same class of PHP empty-array serialization issue fixed in #896 for `MessageMap`, but in `ToolMap` (tool definitions rather than tool call arguments).

### Before

```json
{
    "type": "function",
    "function": {
        "name": "list_users",
        "description": "List all users",
        "parameters": {
            "type": "object",
            "properties": [],  // Causes 400 error
            "required": []
        }
    }
}
```

### After

```json
{
    "type": "function",
    "function": {
        "name": "list_users",
        "description": "List all users",
        "parameters": {
            "type": "object",
            "properties": {},  // Works
            "required": []
        }
    }
}
```

## Fix

Cast `$tool->parametersAsArray()` to `(object)` so empty arrays serialize as `{}`.
When tool parameters exist, the cast produces an identical JSON object, no behavioral changes.