### PR TITLE
feat(mistral): add reasoning_effort provider option

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -9,6 +9,31 @@
 ```
 ## Provider-specific options
 
+### Reasoning Effort
+
+Adjustable reasoning is currently supported by `mistral-small-latest` via the `reasoning_effort` parameter.
+
+```php
+use Prism\Prism\Facades\Prism;
+
+$response = Prism::text()
+    ->using('mistral', 'mistral-small-latest')
+    ->withPrompt('Solve this logic problem step by step.')
+    ->withProviderOptions([ // [!code focus]
+        'reasoning_effort' => 'high', // [!code focus]
+    ]) // [!code focus]
+    ->asText();
+
+// Access the final answer
+echo $response->text;
+
+// Access the reasoning process
+echo $response->additionalContent['thinking'];
+```
+
+More details in the official Mistral documentation:
+https://docs.mistral.ai/capabilities/reasoning/adjustable
+
 ## Reasoning Models
 ### Using Reasoning Models
 

--- a/src/Providers/Mistral/Handlers/Stream.php
+++ b/src/Providers/Mistral/Handlers/Stream.php
@@ -406,6 +406,7 @@ class Stream
                 ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
+                    'reasoning_effort' => $request->providerOptions('reasoning_effort'),
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
                 ]))

--- a/src/Providers/Mistral/Handlers/Structured.php
+++ b/src/Providers/Mistral/Handlers/Structured.php
@@ -59,6 +59,7 @@ class Structured
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
+                'reasoning_effort' => $request->providerOptions('reasoning_effort'),
                 'response_format' => ['type' => 'json_object'],
             ]))
         );

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -144,6 +144,7 @@ class Text
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
+                'reasoning_effort' => $request->providerOptions('reasoning_effort'),
                 'tools' => ToolMap::map($request->tools()),
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
             ]))

--- a/tests/Providers/Mistral/MistralTextTest.php
+++ b/tests/Providers/Mistral/MistralTextTest.php
@@ -162,6 +162,25 @@ describe('Text generation', function (): void {
         expect($response->steps->last())
             ->additionalContent->thinking->toBe($expectedThinking);
     });
+
+    it('forwards reasoning_effort provider option', function (): void {
+        FixtureResponse::fakeResponseSequence('v1/chat/completions', 'mistral/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Mistral, 'mistral-small-latest')
+            ->withPrompt('Who are you?')
+            ->withProviderOptions([
+                'reasoning_effort' => 'high',
+            ])
+            ->generate();
+
+        Http::assertSent(function (Request $request): bool {
+            $payload = $request->data();
+
+            return isset($payload['reasoning_effort'])
+                && $payload['reasoning_effort'] === 'high';
+        });
+    });
 });
 
 describe('Image support', function (): void {

--- a/tests/Providers/Mistral/StreamTest.php
+++ b/tests/Providers/Mistral/StreamTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Enums\Provider;
@@ -245,6 +246,32 @@ it('verifies correct request structure for streaming', function (): void {
         expect($data['messages'][0]['content'][0]['text'])->toBe('Test');
 
         return true;
+    });
+});
+
+it('forwards reasoning_effort provider option for streaming requests', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            "data: {\"choices\": [{\"delta\": {\"content\": \"Hello\"}}]}\n\ndata: {\"choices\": [{\"delta\": {\"content\": \" world\"}, \"finish_reason\": \"stop\"}]}\n\n",
+            200,
+            ['Content-Type' => 'text/event-stream']
+        ),
+    ])->preventStrayRequests();
+
+    Prism::text()
+        ->using(Provider::Mistral, 'mistral-small-latest')
+        ->withPrompt('Test')
+        ->withProviderOptions([
+            'reasoning_effort' => 'high',
+        ])
+        ->asStream()
+        ->current();
+
+    Http::assertSent(function (Request $request): bool {
+        $data = $request->data();
+
+        return isset($data['reasoning_effort'])
+            && $data['reasoning_effort'] === 'high';
     });
 });
 

--- a/tests/Providers/Mistral/StructuredTest.php
+++ b/tests/Providers/Mistral/StructuredTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Facades\Prism;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\ObjectSchema;
 use Prism\Prism\Schema\StringSchema;
@@ -51,3 +53,33 @@ it('returns structured output', function (): void {
     expect($response->usage->promptTokens)->toBe(45);
     expect($response->usage->completionTokens)->toBe(34);
 });
+
+it('forwards reasoning_effort provider option for structured requests', function (): void {
+    FixtureResponse::fakeResponseSequence('chat/completions', 'mistral/structured');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+        ],
+        ['weather']
+    );
+
+    Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Mistral, 'mistral-large-latest')
+        ->withPrompt('What is the weather?')
+        ->withProviderOptions([
+            'reasoning_effort' => 'high',
+        ])
+        ->asStructured();
+
+    Http::assertSent(function (Request $request): bool {
+        $payload = $request->data();
+
+        return isset($payload['reasoning_effort'])
+            && $payload['reasoning_effort'] === 'high';
+    });
+});
+


### PR DESCRIPTION
Add support for Mistral's `reasoning_effort` provider option across text, streaming, and structured requests, and document the feature in the Mistral provider docs.

More details in the official Mistral documentation:
https://docs.mistral.ai/capabilities/reasoning/adjustable