### PR TITLE
fix: ToolCall::arguments() returns null for valid JSON null string

### DIFF
--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -36,11 +36,13 @@ class ToolCall implements Arrayable
 
             $arguments = $this->arguments;
 
-            return json_decode(
+            $decoded = json_decode(
                 $arguments,
                 true,
                 flags: JSON_THROW_ON_ERROR
             );
+
+            return is_array($decoded) ? $decoded : [];
         }
 
         /** @var array<string, mixed> $arguments */


### PR DESCRIPTION
Fixes #982
When a provider returns a tool call with no arguments, some models send the literal JSON string "null" (valid JSON representing a null value). json_decode('null', true) correctly parses it but returns PHP null, which violates the declared `: array` return type and throws a TypeError at the call site.

Fix: guard the json_decode result with is_array() and fall back to [] so callers always receive an array regardless of the model's output.

Reproducer: any tool with no required parameters called by a model that
emits "arguments": "null" instead of "arguments": "{}".


