### PR TITLE
Fix typo in exception message in PrismException

### DIFF
--- a/src/Contracts/ProviderMediaMapper.php
+++ b/src/Contracts/ProviderMediaMapper.php
@@ -26,7 +26,7 @@ abstract class ProviderMediaMapper
 
             $calledClass = static::class;
 
-            throw new PrismException("The $providerName provider does not support the mediums available in the provided `$calledClass`. Pleae consult the Prism documentation for more information on which mediums the $providerName provider supports.");
+            throw new PrismException("The $providerName provider does not support the mediums available in the provided `$calledClass`. Please consult the Prism documentation for more information on which mediums the $providerName provider supports.");
         }
     }
 }


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/prism-php/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

This PR fixes a small typo in the Prism exception message.

The message currently contains "Pleae consult the Prism documentation", which has been corrected to "Please consult the Prism documentation".

This change has no functional impact and only improves the clarity and professionalism of the error message.

