### PR TITLE
fix: OpenAI StructuredModeResolver should match versioned model names

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -24,7 +24,8 @@ class StructuredModeResolver
 
     protected static function supportsStructuredMode(string $model): bool
     {
-        return in_array($model, [
+        // Exact matches for models where only specific versions support structured output.
+        if (in_array($model, [
             'gpt-4o-mini',
             'gpt-4o-mini-2024-07-18',
             'gpt-4o-2024-08-06',
@@ -32,18 +33,25 @@ class StructuredModeResolver
             'chatgpt-4o-latest',
             'o3-mini',
             'o3-mini-2025-01-31',
+        ])) {
+            return true;
+        }
+
+        // Prefix matching for model families where structured output is a baseline feature.
+        // All versions of these families support structured mode.
+        $prefixes = [
             'gpt-4.1',
-            'gpt-4.1-nano',
-            'gpt-4.1-mini',
-            'gpt-4.5-preview',
-            'gpt-4.5-preview-2025-02-27',
+            'gpt-4.5',
             'gpt-5',
-            'gpt-5-mini',
-            'gpt-5-nano',
-            'gpt-5.1',
-            'gpt-5.2',
-            'gpt-5.4',
-        ]);
+        ];
+
+        foreach ($prefixes as $prefix) {
+            if (str_starts_with($model, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected static function supportsJsonMode(string $model): bool

--- a/tests/Providers/OpenAI/Support/StructuredModeResolverTest.php
+++ b/tests/Providers/OpenAI/Support/StructuredModeResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\OpenAI\Support;
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\OpenAI\Support\StructuredModeResolver;
+
+it('resolves structured mode for exact-match models', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Structured);
+})->with([
+    'gpt-4o',
+    'gpt-4o-mini',
+    'gpt-4o-mini-2024-07-18',
+    'gpt-4o-2024-08-06',
+    'chatgpt-4o-latest',
+    'o3-mini',
+    'o3-mini-2025-01-31',
+]);
+
+it('resolves structured mode for gpt-4.1+ family models', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Structured);
+})->with([
+    'gpt-4.1',
+    'gpt-4.1-nano',
+    'gpt-4.1-mini',
+    'gpt-4.1-nano-2025-04-14',
+    'gpt-4.1-mini-2025-04-14',
+    'gpt-4.5-preview',
+    'gpt-4.5-preview-2025-02-27',
+]);
+
+it('resolves structured mode for gpt-5 family models', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Structured);
+})->with([
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5-nano',
+    'gpt-5-mini-2025-08-07',
+    'gpt-5-nano-2025-08-07',
+    'gpt-5.1',
+    'gpt-5.1-2025-10-01',
+    'gpt-5.2',
+    'gpt-5.2-2025-12-11',
+    'gpt-5.4',
+]);
+
+it('resolves json mode for models without structured support', function (string $model): void {
+    expect(StructuredModeResolver::forModel($model))->toBe(StructuredMode::Json);
+})->with([
+    'gpt-4-turbo',
+    'gpt-4-0125-preview',
+    'gpt-3.5-turbo',
+    'some-custom-model',
+]);
+
+it('throws for unsupported models', function (string $model): void {
+    StructuredModeResolver::forModel($model);
+})->with([
+    'o1-mini',
+    'o1-mini-2024-09-12',
+    'o1-preview',
+    'o1-preview-2024-09-12',
+])->throws(PrismException::class);


### PR DESCRIPTION
## Summary

`StructuredModeResolver::supportsStructuredMode()` uses `in_array` with exact string matching. Versioned model names like `gpt-5-mini-2025-08-07` don't match `gpt-5-mini`, causing them to silently fall into JSON mode (`json_object`) instead of Structured mode (`json_schema` + `strict: true`).

In JSON mode the schema is embedded as plain text in a system message and `json_object` format is used — no constrained decoding. This results in significantly more verbose model output compared to proper structured mode.

## Approach

Uses a hybrid strategy:

- **Exact matching** for `gpt-4o` and `o3-mini` families, where only specific versions support structured output (e.g., `gpt-4o-2024-08-06` does, earlier versions don't)
- **Prefix matching** for `gpt-4.1+`, `gpt-4.5+`, and `gpt-5+` families, where structured output is a baseline feature across all versions

This avoids the need to update the allowlist every time OpenAI releases a new dated version of a gpt-5 family model, while remaining conservative for older model families with inconsistent support.

## Changes

- Split `supportsStructuredMode()` into exact matches (gpt-4o, o3) and prefix matches (gpt-4.1+, gpt-5+)
- Add `StructuredModeResolverTest` with 32 test cases covering exact matches, prefix matches, JSON mode fallback, and unsupported model exceptions

## Test plan

- [x] All existing tests pass (1495 passed, 8 skipped)
- [x] 32 new tests for model name resolution
- [x] `gpt-5-mini-2025-08-07` → Structured mode (was JSON mode)
- [x] `gpt-5-mini` → Structured mode (unchanged)
- [x] `gpt-4o-mini-2024-07-18` → Structured mode (unchanged, exact match preserved)
- [x] `gpt-4-turbo` → JSON mode (unchanged)
- [x] `o1-mini` → throws (unchanged)