### PR TITLE
fix(openrouter): support monitoring cache tokens / reasoning tokens on OpenRouter response

### DIFF
--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -501,8 +501,10 @@ class Stream
         return new Usage(
             promptTokens: (int) data_get($usage, 'prompt_tokens', 0),
             completionTokens: (int) data_get($usage, 'completion_tokens', 0),
-            cacheReadInputTokens: (int) data_get($usage, 'prompt_tokens_details.cached_tokens', 0),
-            thoughtTokens: (int) data_get($usage, 'completion_tokens_details.reasoning_tokens', 0)
+            // OpenRouter: usage.prompt_tokens_details.cache_write_tokens / cached_tokens
+            cacheWriteInputTokens: (int) data_get($usage, 'prompt_tokens_details.cache_write_tokens', 0) ?: null,
+            cacheReadInputTokens: (int) data_get($usage, 'prompt_tokens_details.cached_tokens', 0) ?: null,
+            thoughtTokens: (int) data_get($usage, 'completion_tokens_details.reasoning_tokens', 0) ?: null,
         );
     }
 }

--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -156,6 +156,11 @@ class Structured
             usage: new Usage(
                 (int) data_get($data, 'usage.prompt_tokens', 0),
                 (int) data_get($data, 'usage.completion_tokens', 0),
+                // OpenRouter: usage.prompt_tokens_details.cache_write_tokens / cached_tokens
+                (int) data_get($data, 'usage.prompt_tokens_details.cache_write_tokens', 0) ?: null,
+                (int) data_get($data, 'usage.prompt_tokens_details.cached_tokens', 0) ?: null,
+                // OpenRouter: usage.completion_tokens_details.reasoning_tokens
+                (int) data_get($data, 'usage.completion_tokens_details.reasoning_tokens', 0) ?: null,
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -125,6 +125,11 @@ class Text
             usage: new Usage(
                 (int) data_get($data, 'usage.prompt_tokens', 0),
                 (int) data_get($data, 'usage.completion_tokens', 0),
+                // OpenRouter: usage.prompt_tokens_details.cache_write_tokens / cached_tokens
+                (int) data_get($data, 'usage.prompt_tokens_details.cache_write_tokens', 0) ?: null,
+                (int) data_get($data, 'usage.prompt_tokens_details.cached_tokens', 0) ?: null,
+                // OpenRouter: usage.completion_tokens_details.reasoning_tokens
+                (int) data_get($data, 'usage.completion_tokens_details.reasoning_tokens', 0) ?: null,
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),


### PR DESCRIPTION
Currently, you can't know how much was cache read or cache write.

### 1. I added two cache token details:

> ### Usage object fields
> 
> The usage object in API responses includes detailed cache metrics in the `prompt_tokens_details` field:
> 
> ```json
> {
>   "usage": {
>     "prompt_tokens": 10339,
>     "completion_tokens": 60,
>     "total_tokens": 10399,
>     "prompt_tokens_details": {
>       "cached_tokens": 10318,
>       "cache_write_tokens": 0
>     }
>   }
> }
> ```
> 

Document: https://openrouter.ai/docs/guides/best-practices/prompt-caching#usage-object-fields


### 2. Additionally, I also added `reasoning_tokens` too (but it's not about cache)
- Document: https://openrouter.ai/docs/api/reference/overview