### PR TITLE
feat(audio): Allow diarization with Mistral

### DIFF
--- a/src/Providers/Mistral/Handlers/Audio.php
+++ b/src/Providers/Mistral/Handlers/Audio.php
@@ -37,6 +37,7 @@ class Audio
                 'language' => $request->providerOptions('language') ?? null,
                 'prompt' => $request->providerOptions('prompt') ?? null,
                 'response_format' => $request->providerOptions('response_format') ?? null,
+                'diarize' => $request->providerOptions('diarize') ?? null,
                 'temperature' => $request->providerOptions('temperature') ?? null,
                 'timestamp_granularities' => $request->providerOptions('timestamp_granularities') ?? null,
             ]));

--- a/tests/Providers/Mistral/AudioTest.php
+++ b/tests/Providers/Mistral/AudioTest.php
@@ -139,6 +139,31 @@ describe('Speech-to-Text', function (): void {
         expect($response->additionalContent['segments'])->toHaveCount(2);
     });
 
+    it('can transcribe with diarize parameter', function (): void {
+        FixtureResponse::fakeResponseSequence('audio/transcriptions', 'mistral/speech-to-text-basic');
+
+        $audioFile = Audio::fromBase64(base64_encode('usage-test-audio'), 'audio/flac');
+
+        $response = Prism::audio()
+            ->using('mistral', 'voxtral-mini-latest')
+            ->withInput($audioFile)
+            ->withProviderOptions([
+                'diarize' => true,
+            ])
+            ->asText();
+
+        expect($response->text)->toBe('Hello, this is a test transcription.');
+
+        Http::assertSent(function (Request $request): bool {
+            $data = $request->data();
+
+            $diarizeField = collect($data)->firstWhere('name', 'diarize');
+
+            return str_contains($request->url(), 'audio/transcriptions') &&
+                   $diarizeField && $diarizeField['contents'] === true;
+        });
+    });
+
     it('can transcribe with language parameter', function (): void {
         FixtureResponse::fakeResponseSequence('audio/transcriptions', 'mistral/speech-to-text-basic');
 


### PR DESCRIPTION
## Description

This passes the `diarize` option, as documented in [Mistral's official docs](https://docs.mistral.ai/capabilities/audio/speech_to_text/offline_transcription).

I also noticed we aren't passing `context_bias`, so you may want to look into that.