### PR TITLE
fix(gemini): normalize array-type nullable notation in SchemaMap prop…

### DIFF
--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -55,6 +55,9 @@ class SchemaMap
             array_filter([
                 ...$schemaArray,
                 'type' => $this->mapType(),
+                'properties' => isset($schemaArray['properties'])
+                    ? $this->normalizeProperties($schemaArray['properties'])
+                    : null,
             ]),
             array_filter([
                 'items' => property_exists($this->schema, 'items') && $this->schema->items
@@ -73,6 +76,41 @@ class SchemaMap
                     : null,
             ])
         );
+    }
+
+    /**
+     * Normalize properties that use JSON Schema array-type notation for nullability
+     * (e.g. ["integer", "null"]) into Gemini's supported format ("nullable": true).
+     *
+     * This handles schemas passed as raw arrays (e.g. from Laravel's JsonSchema
+     * serializer) which bypass Prism's native schema objects and are never run
+     * through the per-property SchemaMap normalization.
+     *
+     * @param  array<string, mixed>  $properties
+     * @return array<string, mixed>
+     */
+    protected function normalizeProperties(array $properties): array
+    {
+        return array_map(function (array $property): array {
+            if (! is_array($property['type'] ?? null)) {
+                return $property;
+            }
+
+            $types = $property['type'];
+            $nullIndex = array_search('null', $types, true);
+
+            if ($nullIndex === false) {
+                return $property;
+            }
+
+            unset($types[$nullIndex]);
+            $remaining = array_values($types);
+
+            $property['type'] = count($remaining) === 1 ? $remaining[0] : $remaining;
+            $property['nullable'] = true;
+
+            return $property;
+        }, $properties);
     }
 
     protected function mapType(): string

--- a/tests/Providers/Gemini/SchemaMapTest.php
+++ b/tests/Providers/Gemini/SchemaMapTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Prism\Prism\Contracts\HasSchemaType;
+use Prism\Prism\Contracts\Schema;
 use Prism\Prism\Providers\Gemini\Maps\SchemaMap;
 use Prism\Prism\Schema\ArraySchema;
 use Prism\Prism\Schema\BooleanSchema;
@@ -118,6 +120,64 @@ it('maps object schema correctly', function (): void {
             ],
         ],
         'required' => ['testName'],
+        'nullable' => true,
+    ]);
+});
+
+it('normalizes array-type nullable notation in properties to Gemini nullable format', function (): void {
+    // Simulates schemas passed as raw arrays (e.g. via Laravel AI SDK's ObjectSchema
+    // which uses Illuminate's JsonSchema serializer). That serializer produces
+    // ["integer", "null"] for nullable fields — a valid JSON Schema draft-4 format
+    // that Gemini does not support. Gemini requires "nullable": true instead.
+    $schema = new class implements HasSchemaType, Schema
+    {
+        public function name(): string
+        {
+            return 'schema_definition';
+        }
+
+        public function schemaType(): string
+        {
+            return 'object';
+        }
+
+        public function toArray(): array
+        {
+            return [
+                'type' => 'object',
+                'properties' => [
+                    'videoViews' => ['type' => 'integer', 'description' => 'Total video views'],
+                    'averageWatchTimeInSeconds' => ['type' => ['integer', 'null'], 'description' => 'Average watch time'],
+                    'score' => ['type' => ['number', 'null'], 'description' => 'Score'],
+                    'label' => ['type' => ['string', 'null'], 'description' => 'Label'],
+                ],
+                'required' => ['videoViews'],
+            ];
+        }
+    };
+
+    $map = (new SchemaMap($schema))->toArray();
+
+    expect($map['properties']['videoViews'])->toBe([
+        'type' => 'integer',
+        'description' => 'Total video views',
+    ]);
+
+    expect($map['properties']['averageWatchTimeInSeconds'])->toBe([
+        'type' => 'integer',
+        'description' => 'Average watch time',
+        'nullable' => true,
+    ]);
+
+    expect($map['properties']['score'])->toBe([
+        'type' => 'number',
+        'description' => 'Score',
+        'nullable' => true,
+    ]);
+
+    expect($map['properties']['label'])->toBe([
+        'type' => 'string',
+        'description' => 'Label',
         'nullable' => true,
     ]);
 });


### PR DESCRIPTION
## Description

Tested on `gemini-2.5-flash` & 'gemini-3-flash'

Gemini doesn't support the standard JSON Schema array-type notation for nullable fields:

```json
{ "type": ["integer", "null"] }
```

It expects:

```json
{ "type": "integer", "nullable": true }
```

This affects schemas passed as raw arrays — e.g. via Laravel AI SDK's `ObjectSchema` which wraps Illuminate's `JsonSchema` serializer:

```php
public function schema(JsonSchema $schema): array
{
    return [
        'videoViews' => $schema->integer()->description('Total video views'),
        'averageWatchTime' => $schema->integer()->nullable()->description('Avg watch time in seconds'),
    ];
}
```

Laravel's serializer correctly follows JSON Schema draft-4 and converts `nullable()` to `["integer", "null"]`. However, `SchemaMap` only normalizes properties when `$this->schema instanceof ObjectSchema` — raw array schemas bypass this branch and are spread into the payload as-is.

`normalizeProperties()` intercepts `$schemaArray['properties']` before they reach Gemini, converting `["type", "null"]` arrays into `"nullable": true`.

---

## Breaking Changes

None.