### PR TITLE
fix(Gemini): Add `Usage` to `StepFinishEvent`

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -241,7 +241,8 @@ class Stream
         $this->state->markStepFinished();
         yield new StepFinishEvent(
             id: EventID::generate(),
-            timestamp: time()
+            timestamp: time(),
+            usage: $this->state->usage(),
         );
 
         yield $this->emitStreamEndEvent();
@@ -341,7 +342,8 @@ class Stream
             $this->state->markStepFinished();
             yield new StepFinishEvent(
                 id: EventID::generate(),
-                timestamp: time()
+                timestamp: time(),
+                usage: $this->state->usage(),
             );
 
             $request->addMessage(new AssistantMessage($this->state->currentText(), $mappedToolCalls));

--- a/src/Streaming/Events/StepFinishEvent.php
+++ b/src/Streaming/Events/StepFinishEvent.php
@@ -5,9 +5,18 @@ declare(strict_types=1);
 namespace Prism\Prism\Streaming\Events;
 
 use Prism\Prism\Enums\StreamEventType;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class StepFinishEvent extends StreamEvent
 {
+    public function __construct(
+        string $id,
+        int $timestamp,
+        public ?Usage $usage = null,        // Token usage information
+    ) {
+        parent::__construct($id, $timestamp);
+    }
+
     public function type(): StreamEventType
     {
         return StreamEventType::StepFinish;

--- a/src/Streaming/Events/StepFinishEvent.php
+++ b/src/Streaming/Events/StepFinishEvent.php
@@ -27,6 +27,13 @@ readonly class StepFinishEvent extends StreamEvent
         return [
             'id' => $this->id,
             'timestamp' => $this->timestamp,
+            'usage' => $this->usage instanceof Usage ? [
+                'prompt_tokens' => $this->usage->promptTokens,
+                'completion_tokens' => $this->usage->completionTokens,
+                'cache_write_input_tokens' => $this->usage->cacheWriteInputTokens,
+                'cache_read_input_tokens' => $this->usage->cacheReadInputTokens,
+                'thought_tokens' => $this->usage->thoughtTokens,
+            ] : null,
         ];
     }
 }

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -336,7 +336,8 @@ class PrismFake extends Provider
 
         yield new StepFinishEvent(
             id: EventID::generate(),
-            timestamp: time()
+            timestamp: time(),
+            usage: $response->usage
         );
 
         yield new StreamEndEvent(

--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -310,8 +310,13 @@ it('emits step start and step finish events', function (): void {
     expect($stepStartEvents)->toHaveCount(1);
 
     // Check for StepFinishEvent before StreamEndEvent
-    $stepFinishEvents = array_filter($events, fn (StreamEvent $e): bool => $e instanceof StepFinishEvent);
+    $stepFinishEvents = array_values(array_filter($events, fn (StreamEvent $e): bool => $e instanceof StepFinishEvent));
     expect($stepFinishEvents)->toHaveCount(1);
+
+    // Verify StepFinishEvent contains usage data
+    expect($stepFinishEvents[0]->usage)->not->toBeNull();
+    expect($stepFinishEvents[0]->usage->promptTokens)->toBe(21);
+    expect($stepFinishEvents[0]->usage->completionTokens)->toBe(47);
 
     // Verify order: StreamStart -> StepStart -> ... -> StepFinish -> StreamEnd
     $eventTypes = array_map(get_class(...), $events);

--- a/tests/Streaming/PrismStreamIntegrationTest.php
+++ b/tests/Streaming/PrismStreamIntegrationTest.php
@@ -1011,4 +1011,86 @@ describe('step events', function (): void {
             expect($array)->toHaveKey('timestamp');
         }
     });
+
+    it('step finish event has default zero usage when fake response has no explicit usage', function (): void {
+        Prism::fake([
+            TextResponseFake::make()->withText('Test'),
+        ]);
+
+        $events = iterator_to_array(
+            Prism::text()
+                ->using('openai', 'gpt-4')
+                ->withPrompt('Test')
+                ->asStream()
+        );
+
+        $stepFinishEvents = array_values(array_filter(
+            $events,
+            fn (StreamEvent $e): bool => $e instanceof StepFinishEvent
+        ));
+
+        expect($stepFinishEvents)->not->toBeEmpty();
+        expect($stepFinishEvents[0]->usage)->not->toBeNull();
+        expect($stepFinishEvents[0]->usage->promptTokens)->toBe(0);
+        expect($stepFinishEvents[0]->usage->completionTokens)->toBe(0);
+    });
+
+    it('step finish event contains usage when fake response has usage', function (): void {
+        Prism::fake([
+            TextResponseFake::make()
+                ->withText('Test')
+                ->withUsage(new Usage(100, 50)),
+        ]);
+
+        $events = iterator_to_array(
+            Prism::text()
+                ->using('openai', 'gpt-4')
+                ->withPrompt('Test')
+                ->asStream()
+        );
+
+        $stepFinishEvents = array_values(array_filter(
+            $events,
+            fn (StreamEvent $e): bool => $e instanceof StepFinishEvent
+        ));
+
+        expect($stepFinishEvents)->not->toBeEmpty();
+        expect($stepFinishEvents[0]->usage)->not->toBeNull();
+        expect($stepFinishEvents[0]->usage->promptTokens)->toBe(100);
+        expect($stepFinishEvents[0]->usage->completionTokens)->toBe(50);
+    });
+
+    it('step finish event toArray includes usage when set', function (): void {
+        Prism::fake([
+            TextResponseFake::make()
+                ->withText('Test')
+                ->withUsage(new Usage(20, 10)),
+        ]);
+
+        $events = iterator_to_array(
+            Prism::text()
+                ->using('openai', 'gpt-4')
+                ->withPrompt('Test')
+                ->asStream()
+        );
+
+        $stepFinishEvents = array_values(array_filter(
+            $events,
+            fn (StreamEvent $e): bool => $e instanceof StepFinishEvent
+        ));
+
+        expect($stepFinishEvents)->not->toBeEmpty();
+        $array = $stepFinishEvents[0]->toArray();
+        expect($array)->toHaveKey('usage');
+        expect($array['usage'])->not->toBeNull();
+        expect($array['usage']['prompt_tokens'])->toBe(20);
+        expect($array['usage']['completion_tokens'])->toBe(10);
+    });
+
+    it('step finish event toArray has null usage when event is constructed without usage', function (): void {
+        $event = new StepFinishEvent(id: 'test-id', timestamp: 1234567890);
+        $array = $event->toArray();
+        expect($array)->toHaveKey('usage');
+        expect($array['usage'])->toBeNull();
+    });
 });


### PR DESCRIPTION
## Description

When using `->withTools()->asStream()` in Gemini, we're missing token usage on the intermediate LLM call:

```
  User Message
       │
       ▼
  ┌─────────┐    usage: prompt=100, comp=200, thought=50
  │ LLM #1  │──→ StepFinishEvent  ❌ no usage field
  └────┬────┘
       │ tool calls
       ▼
  ┌──────────┐
  │ Tool Exe │
  └────┬─────┘
       │ tool results
       ▼
  ┌─────────┐    usage: prompt=200, comp=400, thought=0
  │ LLM #2  │──→ StepFinishEvent  ❌ no usage field
  └────┬────┘
       │ final text
       ▼
  StreamEndEvent
    usage: prompt=200, comp=400  ← ❌ only LLM #2
```

There is a code block in Gemini `Stream` handler that supposedly updates usage to include previous usage: https://github.com/prism-php/prism/blob/5d6cc65b80b19cf3f22744703ac0c727b68cdca8/src/Providers/Gemini/Handlers/Stream.php#L359-L367

However, this is effectively dead code as `StreamEndEvent` is fired before this and there's no way to retrieve this updated usage. There are no tests that hit this block.

## Proposed solution

I propose to expose `Usage` via `StepFinishEvent`. This PR only adds it to Gemini provider (as that's what I have access to), but I'd be able to add it to all instances of `StepFinishEvent` if needed.