### PR TITLE
fix(Media): normalize mimeType for audio/wav

### DIFF
--- a/src/ValueObjects/Media/Media.php
+++ b/src/ValueObjects/Media/Media.php
@@ -253,7 +253,7 @@ class Media implements Arrayable
             $this->mimeType = (new finfo(FILEINFO_MIME_TYPE))->buffer($content) ?: null;
         }
 
-        $this->mimeType = match (strtolower($this->mimeType)) {
+        $this->mimeType = match ($this->mimeType) {
             'audio/x-wav', 'audio/wave', 'audio/x-pn-wav', 'audio/vnd.wave' => 'audio/wav',
             default => $this->mimeType,
         };

--- a/src/ValueObjects/Media/Media.php
+++ b/src/ValueObjects/Media/Media.php
@@ -249,13 +249,14 @@ class Media implements Arrayable
 
     public function mimeType(): ?string
     {
-        if ($this->mimeType) {
-            return $this->mimeType;
-        }
-
-        if ($content = $this->rawContent()) {
+        if ($this->mimeType === null && $content = $this->rawContent()) {
             $this->mimeType = (new finfo(FILEINFO_MIME_TYPE))->buffer($content) ?: null;
         }
+
+        $this->mimeType = match (strtolower($this->mimeType)) {
+            'audio/x-wav', 'audio/wave', 'audio/x-pn-wav', 'audio/vnd.wave' => 'audio/wav',
+            default => $this->mimeType,
+        };
 
         return $this->mimeType;
     }

--- a/tests/Providers/Gemini/GeminiMediaTest.php
+++ b/tests/Providers/Gemini/GeminiMediaTest.php
@@ -153,7 +153,7 @@ describe('Media support with Gemini', function (): void {
                     'text' => 'Transcribe this audio',
                 ])
                 ->and($message[1]['inline_data'])->toHaveKeys(['mime_type', 'data'])
-                ->and($message[1]['inline_data']['mime_type'])->toBe('audio/x-wav')
+                ->and($message[1]['inline_data']['mime_type'])->toBe('audio/wav')
                 ->and($message[1]['inline_data']['data'])->toBe(
                     base64_encode(file_get_contents('tests/Fixtures/sample-audio.wav'))
                 );
@@ -171,7 +171,7 @@ describe('Media support with Gemini', function (): void {
             $audioUrl => Http::response(
                 file_get_contents('tests/Fixtures/sample-audio.wav'),
                 200,
-                ['Content-Type' => 'audio/x-wav']
+                ['Content-Type' => 'audio/wav']
             ),
         ]);
 
@@ -197,7 +197,7 @@ describe('Media support with Gemini', function (): void {
                         'text' => 'What is in this audio',
                     ])
                     ->and($message[1]['inline_data'])->toHaveKeys(['mime_type', 'data'])
-                    ->and($message[1]['inline_data']['mime_type'])->toBe('audio/x-wav')
+                    ->and($message[1]['inline_data']['mime_type'])->toBe('audio/wav')
                     ->and($message[1]['inline_data']['data'])->toBe(
                         base64_encode(file_get_contents('tests/Fixtures/sample-audio.wav'))
                     );


### PR DESCRIPTION
Normalizes legacy formats to audio/wav

## Description
Normalizes the mimetype. For now, just for .wav files

Fixes https://github.com/prism-php/prism/issues/981
