### PR TITLE
feat(gemini): add service_tier support for Flex Inference

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -507,6 +507,7 @@ class Stream
                     'tools' => $tools !== [] ? $tools : null,
                     'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
+                    'service_tier' => $providerOptions['serviceTier'] ?? null,
                 ])
             );
 

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -137,6 +137,7 @@ class Structured
                 'tools' => $tools !== [] ? $tools : null,
                 'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                 'safetySettings' => $providerOptions['safetySettings'] ?? null,
+                'service_tier' => $providerOptions['serviceTier'] ?? null,
             ])
         );
 

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -119,6 +119,7 @@ class Text
                 'tools' => $tools !== [] ? $tools : null,
                 'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                 'safetySettings' => $providerOptions['safetySettings'] ?? null,
+                'service_tier' => $providerOptions['serviceTier'] ?? null,
             ])
         );
 

--- a/tests/Providers/Gemini/GeminiStreamTest.php
+++ b/tests/Providers/Gemini/GeminiStreamTest.php
@@ -440,3 +440,27 @@ it('can generate text stream using multiple parallel tool calls', function (): v
     expect($toolCalls[1]->reasoningId)->not->toBeNull();
     expect($toolCalls[0]->reasoningId)->toBe($toolCalls[1]->reasoningId);
 });
+
+it('passes service_tier in the request body for streaming', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/stream-basic-text');
+
+    $response = Prism::text()
+        ->using(Provider::Gemini, 'gemini-2.5-flash')
+        ->withPrompt('Summarize this document.')
+        ->withProviderOptions(['serviceTier' => 'flex'])
+        ->asStream();
+
+    // Consume the stream
+    foreach ($response as $event) {
+        //
+    }
+
+    Http::assertSent(function (Request $request): true {
+        $data = $request->data();
+
+        expect($data)->toHaveKey('service_tier')
+            ->and($data['service_tier'])->toBe('flex');
+
+        return true;
+    });
+});

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -404,3 +404,32 @@ it('filters out thought parts when includeThoughts is true', function (): void {
     expect($response->steps[0]->additionalContent['thoughtSummaries'])->toBeArray();
     expect($response->steps[0]->additionalContent['thoughtSummaries'][0])->toContain('Let me think about');
 });
+
+it('passes service_tier in the request body for structured output', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/generate-structured');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+        ],
+        ['weather']
+    );
+
+    Prism::structured()
+        ->using(Provider::Gemini, 'gemini-2.5-flash')
+        ->withSchema($schema)
+        ->withPrompt('What is the weather?')
+        ->withProviderOptions(['serviceTier' => 'flex'])
+        ->asStructured();
+
+    Http::assertSent(function (Request $request): true {
+        $data = $request->data();
+
+        expect($data)->toHaveKey('service_tier')
+            ->and($data['service_tier'])->toBe('flex');
+
+        return true;
+    });
+});

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -620,3 +620,41 @@ describe('Thinking Mode for Gemini', function (): void {
         });
     });
 });
+
+describe('Flex Inference for Gemini', function (): void {
+    it('passes service_tier in the request body', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.5-flash')
+            ->withPrompt('Summarize this document.')
+            ->withProviderOptions(['serviceTier' => 'flex'])
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data)->toHaveKey('service_tier')
+                ->and($data['service_tier'])->toBe('flex');
+
+            return true;
+        });
+    });
+
+    it('does not include service_tier when not set', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.5-flash')
+            ->withPrompt('Hello')
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data)->not->toHaveKey('service_tier');
+
+            return true;
+        });
+    });
+});


### PR DESCRIPTION
## Description

Add `serviceTier` provider option to the Gemini provider's Text, Stream, and Structured handlers, enabling Google's [Flex Inference](https://ai.google.dev/gemini-api/docs/flex-inference) API.

Flex Inference provides **50% cost reduction** for latency-tolerant workloads (batch processing, background summarization, etc.) by opting into Google's `flex` service tier.

### Usage

```php
Prism::text()
    ->using(Provider::Gemini, 'gemini-2.5-flash')
    ->withPrompt('Summarize this document...')
    ->withProviderOptions(['serviceTier' => 'flex'])
    ->asText();
```

> **Note:** The Gemini API requires **lowercase** `'flex'` — uppercase `'FLEX'` is rejected despite appearing in some Google documentation examples. Also, Flex Inference has a latency target of 1-15 minutes, so users should increase their timeout accordingly.

### Implementation

- Follows the same pattern as the existing OpenAI `service_tier` implementation
- Passes `service_tier` at the top level of the Gemini REST request body (not inside `generationConfig`)
- Uses `Arr::whereNotNull` — when `serviceTier` is not set, the key is omitted entirely (zero impact on existing requests)
- Error handling already covered: `Gemini.php` handles 429 (`PrismRateLimitedException`) and 503 (`PrismProviderOverloadedException`)

### Provider option key naming

Uses `serviceTier` (camelCase) to follow the Gemini provider's existing convention (`thinkingConfig`, `thinkingBudget`, `cachedContentName`, `safetySettings`).

### Related

- Related: #925 (custom provider request parameters — this is a concrete implementation of that pattern for one specific key)
- Prior art: #689 (OpenAI `service_tier` support)

## Breaking Changes

None