### PR TITLE
fix(gemini): emit system_instruction before contents so implicit cache can engage

### DIFF
--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -37,14 +37,19 @@ class MessageMap
      */
     public function __invoke(): array
     {
+        // System prompts are mapped before messages so that `system_instruction`
+        // appears before `contents` in the serialized request body. Gemini's
+        // implicit cache keys on the request-body prefix, so placing the stable
+        // portion of the payload first is required for cache hits to occur.
+        // See https://ai.google.dev/gemini-api/docs/caching for details.
+        foreach ($this->systemPrompts as $systemPrompt) {
+            $this->mapSystemMessage($systemPrompt);
+        }
+
         $this->contents['contents'] = [];
 
         foreach ($this->messages as $message) {
             $this->mapMessage($message);
-        }
-
-        foreach ($this->systemPrompts as $systemPrompt) {
-            $this->mapSystemMessage($systemPrompt);
         }
 
         return array_filter($this->contents);

--- a/tests/Providers/Gemini/MessageMapTest.php
+++ b/tests/Providers/Gemini/MessageMapTest.php
@@ -274,3 +274,19 @@ it('throws an exception of multiple system prompts are given', function (): void
 
     $messageMap();
 })->throws(PrismException::class, 'Gemini only supports one system instruction.');
+
+it('places system_instruction before contents so implicit caching can engage', function (): void {
+    $messageMap = new MessageMap(
+        messages: [
+            new UserMessage('hello'),
+        ],
+        systemPrompts: [
+            new SystemMessage('you are a helpful assistant'),
+        ]
+    );
+
+    // Gemini's implicit cache keys on the serialized request-body prefix.
+    // Prism must emit `system_instruction` before `contents` so the stable
+    // portion of the payload appears first and cache hits can occur.
+    expect(array_keys($messageMap()))->toBe(['system_instruction', 'contents']);
+});


### PR DESCRIPTION
## Summary

  Gemini's implicit cache keys on the serialized request-body **prefix**. Prism's `MessageMap::__invoke()` initializes
  `contents` first and sets `system_instruction` last, producing bodies shaped like:

      { "contents": [...variable per request...], "system_instruction": {...stable...}, ... }

  Because the variable portion appears first, every request diverges at the first bytes of the serialized body, and
  Gemini's implicit cache never finds a match — even when `system_instruction`, `tools`, and `tool_config` are
  byte-identical across calls. I verified this empirically against `gemini-3-flash-preview`: a batch of 15 calls to an
  agent with a ~2700-token stable prefix produced `cache_read_input_tokens = 0` on every response, and a global HTTP
  middleware that only reordered the top-level JSON keys restored cache hits on the 2nd+ calls.

  This PR swaps the loop order in `__invoke()` so system prompts are mapped first, producing:

      { "system_instruction": {...stable...}, "contents": [...variable...], ... }

  `array_filter` still strips empty `contents`, so system-only and messages-only mappings behave identically to before.

  ## Regression history

  This broke in #155 ("feat: Gemini Tool Calling", Jan 30 2025). Before that PR, the system prompt was assigned
  directly to `$this->contents['system_instruction']` in the constructor, making it the first inserted key. #155 moved
  the system prompt into the `$messages` array as a `SystemMessage` so it could flow through the unified `match()`
  dispatch, which unintentionally moved the `system_instruction` assignment to the middle of iteration — after
  `contents` had already been initialized. #189 later refactored to `systemPrompts`, but preserved the broken order.

  ## Test plan

  - [x] Added: `places system_instruction before contents so implicit caching can engage`
  - [x] All existing tests in `tests/Providers/Gemini/MessageMapTest.php` pass (12/12)
  - [x] Verified in a live app: cache hits returned after applying this fix