### PR TITLE
fix: cast empty tool properties to object for Mistral API compatibility

### DIFF
--- a/src/Providers/Mistral/Maps/ToolMap.php
+++ b/src/Providers/Mistral/Maps/ToolMap.php
@@ -21,7 +21,7 @@ class ToolMap
                 'description' => $tool->description(),
                 'parameters' => [
                     'type' => 'object',
-                    'properties' => $tool->parametersAsArray(),
+                    'properties' => $tool->parametersAsArray() ?: (object) [],
                     'required' => $tool->requiredParameters(),
                 ],
             ],


### PR DESCRIPTION
## Description

When a tool has no parameters, [parametersAsArray()](cci:1://file:///c:/Xervit/www/rezmo_admin/vendor/prism-php/prism/src/Tool.php:223:4-231:5) returns an empty PHP array `[]`.
When JSON-encoded, this becomes `[]` (JSON array), but Mistral API expects
`"properties"` to be a JSON object `{}`.

This causes a 400 error from Mistral:
> Invalid tool schema: [] is not of type 'object'

Fix: fallback to `(object) []` which JSON-encodes to `{}` when properties are empty.

## Breaking Changes

No breaking changes. This only affects tools with empty parameter schemas.