### PR TITLE
fix(ollama): exclude top-level keys from nested options in embeddings request

### DIFF
--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -43,6 +43,8 @@ class Embeddings
 
     protected function sendRequest(Request $request): Response
     {
+        $options = Arr::except($request->providerOptions(), ['dimensions', 'keep_alive']);
+
         /** @var Response $response */
         $response = $this->client->post(
             'api/embed',
@@ -51,7 +53,7 @@ class Embeddings
                 'input' => $request->inputs(),
                 'dimensions' => $request->providerOptions('dimensions'),
                 'keep_alive' => $request->providerOptions('keep_alive'),
-                'options' => $request->providerOptions() ?: null,
+                'options' => $options ?: null,
             ])
         );
 

--- a/src/Text/Response.php
+++ b/src/Text/Response.php
@@ -57,7 +57,7 @@ readonly class Response implements Arrayable
             'tool_results' => array_map(fn (ToolResult $toolResult): array => $toolResult->toArray(), $this->toolResults),
             'usage' => $this->usage->toArray(),
             'meta' => $this->meta->toArray(),
-            'messages' => $this->messages->map(fn (Message $message): array => $this->messageToArray($message))->toArray(),
+            'messages' => $this->messages->map($this->messageToArray(...))->toArray(),
             'additional_content' => $this->additionalContent,
             'raw' => $this->raw,
         ];

--- a/tests/Embeddings/ImageEmbeddingsTest.php
+++ b/tests/Embeddings/ImageEmbeddingsTest.php
@@ -103,7 +103,7 @@ it('supports both text and images in the same request', function () use ($testIm
 it('throws exception when no embeddings content is provided', function (): void {
     $pendingRequest = new PendingRequest;
 
-    expect(fn (): Response => $pendingRequest->asEmbeddings())
+    expect($pendingRequest->asEmbeddings(...))
         ->toThrow(PrismException::class, 'Embeddings input is required (text, images, audio, video, documents, or content parts)');
 });
 

--- a/tests/Embeddings/ImageEmbeddingsTest.php
+++ b/tests/Embeddings/ImageEmbeddingsTest.php
@@ -7,7 +7,6 @@ namespace Tests\Embeddings;
 use Prism\Prism\Embeddings\Content;
 use Prism\Prism\Embeddings\PendingRequest;
 use Prism\Prism\Embeddings\Request;
-use Prism\Prism\Embeddings\Response;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Media\Image;
 

--- a/tests/Embeddings/MultimodalEmbeddingsTest.php
+++ b/tests/Embeddings/MultimodalEmbeddingsTest.php
@@ -7,7 +7,6 @@ namespace Tests\Embeddings;
 use Prism\Prism\Embeddings\Content;
 use Prism\Prism\Embeddings\PendingRequest;
 use Prism\Prism\Embeddings\Request;
-use Prism\Prism\Embeddings\Response;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Media\Audio;
 use Prism\Prism\ValueObjects\Media\Document;

--- a/tests/Embeddings/MultimodalEmbeddingsTest.php
+++ b/tests/Embeddings/MultimodalEmbeddingsTest.php
@@ -70,6 +70,6 @@ it('supports multiple grouped multimodal content entries', function () use ($tes
 it('throws exception when no embeddings content is provided', function (): void {
     $pendingRequest = new PendingRequest;
 
-    expect(fn (): Response => $pendingRequest->asEmbeddings())
+    expect($pendingRequest->asEmbeddings(...))
         ->toThrow(PrismException::class, 'Embeddings input is required (text, images, audio, video, documents, or content parts)');
 });

--- a/tests/Providers/Ollama/EmbeddingsTest.php
+++ b/tests/Providers/Ollama/EmbeddingsTest.php
@@ -83,6 +83,13 @@ it('allows setting provider options like dimensions', function (): void {
         ->fromInput('The food was delicious and the waiter...')
         ->asEmbeddings();
 
+    Http::assertSent(function (Request $request): true {
+        expect($request->data()['dimensions'])->toBe(256);
+        expect($request->data())->not->toHaveKeys(['options']);
+
+        return true;
+    });
+
     $embeddings = json_decode(
         file_get_contents('tests/Fixtures/ollama/embeddings-with-dimensions-1.json'),
         true


### PR DESCRIPTION
## Description

`dimensions` and `keep_alive` provider options were sent twice in the Ollama embeddings payload — as top-level fields and again inside `options`. This caused Ollama to log `invalid option provided` warnings on every request.

Strips those keys from the nested `options` object since they're already handled at the top level.

Closes #1010