### PR TITLE
feat(fim): add FIM request and response handling for Mistral AI

### DIFF
--- a/src/Fim/PendingRequest.php
+++ b/src/Fim/PendingRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Fim;
+
+use Illuminate\Http\Client\RequestException;
+use Prism\Prism\Concerns\ConfiguresClient;
+use Prism\Prism\Concerns\ConfiguresModels;
+use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\HasProviderOptions;
+
+class PendingRequest
+{
+    use ConfiguresClient;
+    use ConfiguresModels;
+    use ConfiguresProviders;
+    use HasProviderOptions;
+
+    protected string $prompt = '';
+
+    protected ?string $suffix = null;
+
+    protected ?int $maxTokens = null;
+
+    protected int|float|null $temperature = null;
+
+    protected int|float|null $topP = null;
+
+    /** @var array<string> */
+    protected array $stop = [];
+
+    public function withPrompt(string $prompt): self
+    {
+        $this->prompt = $prompt;
+
+        return $this;
+    }
+
+    public function withSuffix(?string $suffix): self
+    {
+        $this->suffix = $suffix;
+
+        return $this;
+    }
+
+    public function withMaxTokens(int $maxTokens): self
+    {
+        $this->maxTokens = $maxTokens;
+
+        return $this;
+    }
+
+    public function withTemperature(int|float $temperature): self
+    {
+        $this->temperature = $temperature;
+
+        return $this;
+    }
+
+    public function withTopP(int|float $topP): self
+    {
+        $this->topP = $topP;
+
+        return $this;
+    }
+
+    /**
+     * @param  string|array<string>  $stop
+     */
+    public function withStop(string|array $stop): self
+    {
+        $this->stop = is_string($stop) ? [$stop] : $stop;
+
+        return $this;
+    }
+
+    public function asText(): Response
+    {
+        $request = $this->toRequest();
+
+        try {
+            return $this->provider->fim($request);
+        } catch (RequestException $e) {
+            $this->provider->handleRequestException($request->model(), $e);
+        }
+    }
+
+    /**
+     * @deprecated Use `asText` instead.
+     */
+    public function generate(): Response
+    {
+        return $this->asText();
+    }
+
+    public function toRequest(): Request
+    {
+        return new Request(
+            model: $this->model,
+            providerKey: $this->providerKey(),
+            prompt: $this->prompt,
+            suffix: $this->suffix,
+            maxTokens: $this->maxTokens,
+            temperature: $this->temperature,
+            topP: $this->topP,
+            stop: $this->stop,
+            clientOptions: $this->clientOptions,
+            clientRetry: $this->clientRetry,
+            providerOptions: $this->providerOptions,
+        );
+    }
+}

--- a/src/Fim/Request.php
+++ b/src/Fim/Request.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Fim;
+
+use Prism\Prism\Concerns\ChecksSelf;
+use Prism\Prism\Concerns\HasProviderOptions;
+use Prism\Prism\Contracts\PrismRequest;
+
+class Request implements PrismRequest
+{
+    use ChecksSelf, HasProviderOptions;
+
+    /**
+     * @param  array<string>  $stop
+     * @param  array<string, mixed>  $clientOptions
+     * @param  array<mixed>  $clientRetry
+     * @param  array<string, mixed>  $providerOptions
+     */
+    public function __construct(
+        protected string $model,
+        protected string $providerKey,
+        protected string $prompt,
+        protected ?string $suffix,
+        protected ?int $maxTokens,
+        protected int|float|null $temperature,
+        protected int|float|null $topP,
+        protected array $stop,
+        protected array $clientOptions,
+        protected array $clientRetry,
+        array $providerOptions = [],
+    ) {
+        $this->providerOptions = $providerOptions;
+    }
+
+    public function model(): string
+    {
+        return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
+    }
+
+    public function prompt(): string
+    {
+        return $this->prompt;
+    }
+
+    public function suffix(): ?string
+    {
+        return $this->suffix;
+    }
+
+    public function maxTokens(): ?int
+    {
+        return $this->maxTokens;
+    }
+
+    public function temperature(): int|float|null
+    {
+        return $this->temperature;
+    }
+
+    public function topP(): int|float|null
+    {
+        return $this->topP;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function stop(): array
+    {
+        return $this->stop;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function clientOptions(): array
+    {
+        return $this->clientOptions;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function clientRetry(): array
+    {
+        return $this->clientRetry;
+    }
+}

--- a/src/Fim/Response.php
+++ b/src/Fim/Response.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Fim;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+
+/**
+ * @implements Arrayable<string, mixed>
+ */
+readonly class Response implements Arrayable
+{
+    public function __construct(
+        public string $text,
+        public FinishReason $finishReason,
+        public Usage $usage,
+        public Meta $meta,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function toArray(): array
+    {
+        return [
+            'text' => $this->text,
+            'finish_reason' => $this->finishReason->value,
+            'usage' => $this->usage->toArray(),
+            'meta' => $this->meta->toArray(),
+        ];
+    }
+}

--- a/src/Prism.php
+++ b/src/Prism.php
@@ -7,6 +7,7 @@ namespace Prism\Prism;
 use Illuminate\Support\Traits\Macroable;
 use Prism\Prism\Audio\PendingRequest as PendingAudioRequest;
 use Prism\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
+use Prism\Prism\Fim\PendingRequest as PendingFimRequest;
 use Prism\Prism\Images\PendingRequest as PendingImageRequest;
 use Prism\Prism\Moderation\PendingRequest as PendingModerationRequest;
 use Prism\Prism\Structured\PendingRequest as PendingStructuredRequest;
@@ -44,5 +45,10 @@ class Prism
     public function moderation(): PendingModerationRequest
     {
         return new PendingModerationRequest;
+    }
+
+    public function fim(): PendingFimRequest
+    {
+        return new PendingFimRequest;
     }
 }

--- a/src/Providers/Mistral/Handlers/Fim.php
+++ b/src/Providers/Mistral/Handlers/Fim.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Mistral\Handlers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Fim\Request;
+use Prism\Prism\Fim\Response;
+use Prism\Prism\Providers\Mistral\Concerns\ProcessRateLimits;
+use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+
+class Fim
+{
+    use ProcessRateLimits;
+    use ValidatesResponse;
+
+    public function __construct(protected PendingRequest $client) {}
+
+    public function handle(Request $request): Response
+    {
+        $response = $this->sendRequest($request);
+
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
+        return new Response(
+            text: data_get($data, 'choices.0.message.content', ''),
+            finishReason: $this->mapFinishReason($data),
+            usage: new Usage(
+                data_get($data, 'usage.prompt_tokens', 0),
+                data_get($data, 'usage.completion_tokens', 0),
+            ),
+            meta: new Meta(
+                id: data_get($data, 'id', ''),
+                model: data_get($data, 'model', ''),
+                rateLimits: $this->processRateLimits($response),
+            )
+        );
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        /** @var ClientResponse $response */
+        $response = $this->client->post(
+            'fim/completions',
+            array_merge([
+                'model' => $request->model(),
+                'prompt' => $request->prompt(),
+            ], Arr::whereNotNull([
+                'suffix' => $request->suffix(),
+                'max_tokens' => $request->maxTokens(),
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'stop' => empty($request->stop()) ? null : $request->stop(),
+            ]))
+        );
+
+        return $response;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function mapFinishReason(array $data): FinishReason
+    {
+        return match (data_get($data, 'choices.0.finish_reason')) {
+            'stop' => FinishReason::Stop,
+            'length' => FinishReason::Length,
+            default => FinishReason::Unknown,
+        };
+    }
+}

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -17,9 +17,12 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismProviderOverloadedException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Fim\Request as FimRequest;
+use Prism\Prism\Fim\Response as FimResponse;
 use Prism\Prism\Providers\Mistral\Concerns\ProcessRateLimits;
 use Prism\Prism\Providers\Mistral\Handlers\Audio;
 use Prism\Prism\Providers\Mistral\Handlers\Embeddings;
+use Prism\Prism\Providers\Mistral\Handlers\Fim;
 use Prism\Prism\Providers\Mistral\Handlers\OCR;
 use Prism\Prism\Providers\Mistral\Handlers\Stream;
 use Prism\Prism\Providers\Mistral\Handlers\Structured;
@@ -57,6 +60,19 @@ class Mistral extends Provider
     public function structured(StructuredRequest $request): StructuredResponse
     {
         $handler = new Structured(
+            $this->client(
+                $request->clientOptions(),
+                $request->clientRetry()
+            )
+        );
+
+        return $handler->handle($request);
+    }
+
+    #[\Override]
+    public function fim(FimRequest $request): FimResponse
+    {
+        $handler = new Fim(
             $this->client(
                 $request->clientOptions(),
                 $request->clientRetry()

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -16,6 +16,8 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismProviderOverloadedException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Fim\Request as FimRequest;
+use Prism\Prism\Fim\Response as FimResponse;
 use Prism\Prism\Images\Request as ImagesRequest;
 use Prism\Prism\Images\Response as ImagesResponse;
 use Prism\Prism\Moderation\Request as ModerationRequest;
@@ -61,6 +63,11 @@ abstract class Provider
     public function speechToText(SpeechToTextRequest $request): SpeechToTextResponse
     {
         throw PrismException::unsupportedProviderAction('speechToText', class_basename($this));
+    }
+
+    public function fim(FimRequest $request): FimResponse
+    {
+        throw PrismException::unsupportedProviderAction('fim', class_basename($this));
     }
 
     /**

--- a/tests/Fixtures/mistral/fim-completion-1.json
+++ b/tests/Fixtures/mistral/fim-completion-1.json
@@ -1,0 +1,23 @@
+{
+  "id": "447e3e0d457e42e98248b5d2ef52a2a3",
+  "object": "chat.completion",
+  "model": "codestral-2405",
+  "usage": {
+    "prompt_tokens": 8,
+    "completion_tokens": 91,
+    "total_tokens": 99
+  },
+  "created": 1759496862,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "content": "return a+b",
+        "tool_calls": null,
+        "prefix": false,
+        "role": "assistant"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}

--- a/tests/Providers/Mistral/MistralFimTest.php
+++ b/tests/Providers/Mistral/MistralFimTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+use Tests\Fixtures\FixtureResponse;
+
+beforeEach(function (): void {
+    config()->set('prism.providers.mistral.api_key', env('MISTRAL_API_KEY', 'sk-1234'));
+});
+
+describe('Fim completion', function (): void {
+    it('can generate fim completion', function (): void {
+        FixtureResponse::fakeResponseSequence('v1/fim/completions', 'mistral/fim-completion');
+
+        $response = Prism::fim()
+            ->using(Provider::Mistral, 'codestral-2405')
+            ->withPrompt('def add(a, b):')
+            ->withSuffix('    print("Done")')
+            ->asText();
+
+        expect($response->usage->promptTokens)->toBe(8);
+        expect($response->usage->completionTokens)->toBe(91);
+        expect($response->meta->id)->toBe('447e3e0d457e42e98248b5d2ef52a2a3');
+        expect($response->meta->model)->toBe('codestral-2405');
+        expect($response->text)->toBe('return a+b');
+        expect($response->finishReason)->toBe(FinishReason::Stop);
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['model'])->toBe('codestral-2405');
+            expect($data['prompt'])->toBe('def add(a, b):');
+            expect($data['suffix'])->toBe('    print("Done")');
+
+            return true;
+        });
+    });
+
+    it('sets the rate limits on meta', function (): void {
+        $this->freezeTime(function (Carbon $time): void {
+            $time = $time->toImmutable();
+
+            FixtureResponse::fakeResponseSequence('v1/fim/completions', 'mistral/fim-completion', [
+                'ratelimitbysize-limit' => 500000,
+                'ratelimitbysize-remaining' => 499900,
+                'ratelimitbysize-reset' => 28,
+            ]);
+
+            $response = Prism::fim()
+                ->using(Provider::Mistral, 'codestral-2405')
+                ->withPrompt('def mul(a, b):')
+                ->asText();
+
+            expect($response->meta->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
+            expect($response->meta->rateLimits[0]->name)->toEqual('tokens');
+            expect($response->meta->rateLimits[0]->limit)->toEqual(500000);
+            expect($response->meta->rateLimits[0]->remaining)->toEqual(499900);
+            expect($response->meta->rateLimits[0]->resetsAt->equalTo($time->addSeconds(28)))->toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
I've implemented the Mistral Fill-in-the-Middle (FIM) Completion endpoint. This involved creating a new generic FIM architecture within Prism so that other providers can also implement FIM in the future.

## Key Changes

### Core FIM Architecture
- **[NEW] [Request.php](file:///Users/mojtabasayari/Projects/prism/src/Fim/Request.php)**: Data object for FIM requests.
- **[NEW] [Response.php](file:///Users/mojtabasayari/Projects/prism/src/Fim/Response.php)**: Data object for FIM responses.
- **[NEW] [PendingRequest.php](file:///Users/mojtabasayari/Projects/prism/src/Fim/PendingRequest.php)**: Fluent builder for configuring FIM requests.
- **[MODIFY] [Prism.php](file:///Users/mojtabasayari/Projects/prism/src/Prism.php)**: Added `fim()` method.
- **[MODIFY] [Provider.php](file:///Users/mojtabasayari/Projects/prism/src/Providers/Provider.php)**: Added `fim()` signature.

### Mistral Provider Implementation
- **[MODIFY] [Mistral.php](file:///Users/mojtabasayari/Projects/prism/src/Providers/Mistral/Mistral.php)**: Integrated the FIM handler.
- **[NEW] [Fim.php](file:///Users/mojtabasayari/Projects/prism/src/Providers/Mistral/Handlers/Fim.php)**: Handler that interacts with Mistral's `/fim/completions` endpoint.

### Testing
- **[NEW] [MistralFimTest.php](file:///Users/mojtabasayari/Projects/prism/tests/Providers/Mistral/MistralFimTest.php)**: Comprehensive tests covering successful generation and rate limit metadata.
- **[NEW] [fim-completion-1.json](file:///Users/mojtabasayari/Projects/prism/tests/Fixtures/mistral/fim-completion-1.json)**: Test fixture for FIM responses.

## Usage Example

```php
use Prism\Prism\Facades\Prism;
use Prism\Prism\Enums\Provider;

$response = Prism::fim()
    ->using(Provider::Mistral, 'codestral-latest')
    ->withPrompt('def add(a, b):')
    ->withSuffix('    print("Done")')
    ->asText();

echo $response->text; // "return a+b"
```

Endpoint URLs:
[https://docs.mistral.ai/api/endpoint/fim](url)
[https://docs.mistral.ai/capabilities/code_generation](url)
