### PR TITLE
feat: add provider-agnostic withReasoning() request method

### DIFF
--- a/src/Concerns/HasReasoning.php
+++ b/src/Concerns/HasReasoning.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+trait HasReasoning
+{
+    protected ?bool $reasoningEnabled = null;
+
+    /**
+     * Toggle reasoning / thinking output on or off in a provider-agnostic way.
+     *
+     * `withReasoning(false)` instructs the provider to skip reasoning when it
+     * supports doing so (e.g. Ollama `think: false`, OpenAI `reasoning.effort
+     * = minimal`). Providers that cannot disable reasoning treat the call as a
+     * graceful no-op.
+     *
+     * Calling `withReasoning(true)` is reserved for symmetry; today reasoning
+     * is enabled per-provider via existing options (e.g. Anthropic's
+     * `thinking.enabled`). This method does not override those settings.
+     *
+     * Not calling `withReasoning()` preserves prior behavior: providers honor
+     * whatever the user sets via `withProviderOptions()`.
+     */
+    public function withReasoning(bool $enabled = true): self
+    {
+        $this->reasoningEnabled = $enabled;
+
+        return $this;
+    }
+
+    public function reasoningEnabled(): ?bool
+    {
+        return $this->reasoningEnabled;
+    }
+}

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -93,7 +93,8 @@ class Structured
             'model' => $request->model(),
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()) ?: null,
-            'thinking' => $request->providerOptions('thinking.enabled') === true
+            'thinking' => $request->reasoningEnabled() !== false
+                && $request->providerOptions('thinking.enabled') === true
                 ? [
                     'type' => 'enabled',
                     'budget_tokens' => is_int($request->providerOptions('thinking.budgetTokens'))

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -75,7 +75,8 @@ class Text
             'model' => $request->model(),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()) ?: null,
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
-            'thinking' => $request->providerOptions('thinking.enabled') === true
+            'thinking' => $request->reasoningEnabled() !== false
+                && $request->providerOptions('thinking.enabled') === true
                 ? [
                     'type' => 'enabled',
                     'budget_tokens' => is_int($request->providerOptions('thinking.budgetTokens'))

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -490,6 +490,10 @@ class Stream
             ];
         }
 
+        if ($request->reasoningEnabled() === false && $thinkingConfig === null) {
+            $thinkingConfig = ['thinkingBudget' => 0];
+        }
+
         /** @var Response $response */
         $response = $this->client
             ->withOptions(['stream' => true])

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -120,6 +120,10 @@ class Structured
             ]);
         }
 
+        if ($request->reasoningEnabled() === false && $thinkingConfig === null) {
+            $thinkingConfig = ['thinkingBudget' => 0];
+        }
+
         /** @var Response $response */
         $response = $this->client->post(
             "{$request->model()}:generateContent",

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -83,6 +83,10 @@ class Text
             ]);
         }
 
+        if ($request->reasoningEnabled() === false && $thinkingConfig === null) {
+            $thinkingConfig = ['thinkingBudget' => 0];
+        }
+
         $generationConfig = Arr::whereNotNull([
             'temperature' => $request->temperature(),
             'topP' => $request->topP(),

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -339,7 +339,9 @@ class Stream
                 'tools' => ToolMap::map($request->tools()),
                 'stream' => true,
                 ...Arr::whereNotNull([
-                    'think' => $request->providerOptions('thinking'),
+                    'think' => $request->providerOptions('thinking') ?? (
+                        $request->reasoningEnabled() === false ? false : null
+                    ),
                     'keep_alive' => $request->providerOptions('keep_alive'),
                 ]),
                 'options' => Arr::whereNotNull(array_merge([

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -84,6 +84,9 @@ class Structured
             'format' => $request->schema()->toArray(),
             'stream' => false,
             ...Arr::whereNotNull([
+                'think' => $request->providerOptions('thinking') ?? (
+                    $request->reasoningEnabled() === false ? false : null
+                ),
                 'keep_alive' => $request->providerOptions('keep_alive'),
             ]),
             'options' => Arr::whereNotNull(array_merge([

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -77,7 +77,9 @@ class Text
                 'tools' => ToolMap::map($request->tools()),
                 'stream' => false,
                 ...Arr::whereNotNull([
-                    'think' => $request->providerOptions('thinking'),
+                    'think' => $request->providerOptions('thinking') ?? (
+                        $request->reasoningEnabled() === false ? false : null
+                    ),
                     'keep_alive' => $request->providerOptions('keep_alive'),
                 ]),
                 'options' => Arr::whereNotNull(array_merge([

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -588,7 +588,9 @@ class Stream
                         'verbosity' => $request->providerOptions('text_verbosity'),
                     ] : null,
                     'truncation' => $request->providerOptions('truncation'),
-                    'reasoning' => $request->providerOptions('reasoning'),
+                    'reasoning' => $request->providerOptions('reasoning') ?? (
+                        $request->reasoningEnabled() === false ? ['effort' => 'minimal'] : null
+                    ),
                 ]))
             );
 

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -216,7 +216,9 @@ class Structured
                 'previous_response_id' => $request->providerOptions('previous_response_id'),
                 'service_tier' => $request->providerOptions('service_tier'),
                 'truncation' => $request->providerOptions('truncation'),
-                'reasoning' => $request->providerOptions('reasoning'),
+                'reasoning' => $request->providerOptions('reasoning') ?? (
+                    $request->reasoningEnabled() === false ? ['effort' => 'minimal'] : null
+                ),
                 'store' => $request->providerOptions('store'),
                 'text' => [
                     'format' => $responseFormat,

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -147,7 +147,9 @@ class Text
                     'verbosity' => $request->providerOptions('text_verbosity'),
                 ] : null,
                 'truncation' => $request->providerOptions('truncation'),
-                'reasoning' => $request->providerOptions('reasoning'),
+                'reasoning' => $request->providerOptions('reasoning') ?? (
+                    $request->reasoningEnabled() === false ? ['effort' => 'minimal'] : null
+                ),
                 'store' => $request->providerOptions('store'),
             ]))
         );

--- a/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
+++ b/src/Providers/OpenRouter/Concerns/BuildsRequestOptions.php
@@ -31,6 +31,10 @@ trait BuildsRequestOptions
             'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
         ]));
 
+        if ($request->reasoningEnabled() === false && ! isset($options['reasoning'])) {
+            $options['reasoning'] = ['exclude' => true];
+        }
+
         return Arr::whereNotNull(array_merge($options, $additional));
     }
 }

--- a/src/Providers/Perplexity/Concerns/HandlesHttpRequests.php
+++ b/src/Providers/Perplexity/Concerns/HandlesHttpRequests.php
@@ -49,7 +49,9 @@ trait HandlesHttpRequests
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'top_k' => $request->providerOptions('top_k'),
-            'reasoning_effort' => $request->providerOptions('reasoning_effort'),
+            'reasoning_effort' => $request->providerOptions('reasoning_effort') ?? (
+                $request->reasoningEnabled() === false ? 'low' : null
+            ),
             'web_search_options' => $request->providerOptions('web_search_options'),
             'search_mode' => $request->providerOptions('search_mode'),
             'language_preference' => $request->providerOptions('language_preference'),

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -15,6 +15,7 @@ use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Concerns\HasProviderTools;
+use Prism\Prism\Concerns\HasReasoning;
 use Prism\Prism\Concerns\HasSchema;
 use Prism\Prism\Concerns\HasTools;
 use Prism\Prism\Contracts\Schema;
@@ -33,6 +34,7 @@ class PendingRequest
     use HasPrompts;
     use HasProviderOptions;
     use HasProviderTools;
+    use HasReasoning;
     use HasSchema;
     use HasTools;
 
@@ -89,6 +91,7 @@ class PendingRequest
             maxSteps: $this->maxSteps,
             providerOptions: $this->providerOptions,
             providerTools: $this->providerTools,
+            reasoningEnabled: $this->reasoningEnabled,
         );
     }
 }

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -7,6 +7,7 @@ namespace Prism\Prism\Structured;
 use Closure;
 use Prism\Prism\Concerns\ChecksSelf;
 use Prism\Prism\Concerns\HasProviderOptions;
+use Prism\Prism\Concerns\HasReasoning;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Contracts\Schema;
@@ -18,7 +19,7 @@ use Prism\Prism\ValueObjects\ProviderTool;
 
 class Request implements PrismRequest
 {
-    use ChecksSelf, HasProviderOptions;
+    use ChecksSelf, HasProviderOptions, HasReasoning;
 
     /**
      * @param  SystemMessage[]  $systemPrompts
@@ -47,8 +48,10 @@ class Request implements PrismRequest
         protected int $maxSteps,
         array $providerOptions = [],
         protected array $providerTools = [],
+        ?bool $reasoningEnabled = null,
     ) {
         $this->providerOptions = $providerOptions;
+        $this->reasoningEnabled = $reasoningEnabled;
     }
 
     /**

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -17,6 +17,7 @@ use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Concerns\HasProviderTools;
+use Prism\Prism\Concerns\HasReasoning;
 use Prism\Prism\Concerns\HasTools;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Streaming\Adapters\BroadcastAdapter;
@@ -38,6 +39,7 @@ class PendingRequest
     use HasPrompts;
     use HasProviderOptions;
     use HasProviderTools;
+    use HasReasoning;
     use HasTools;
 
     /**
@@ -146,6 +148,7 @@ class PendingRequest
             toolChoice: $this->toolChoice,
             providerOptions: $this->providerOptions,
             providerTools: $this->providerTools,
+            reasoningEnabled: $this->reasoningEnabled,
         );
     }
 }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -7,6 +7,7 @@ namespace Prism\Prism\Text;
 use Closure;
 use Prism\Prism\Concerns\ChecksSelf;
 use Prism\Prism\Concerns\HasProviderOptions;
+use Prism\Prism\Concerns\HasReasoning;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Enums\ToolChoice;
@@ -16,7 +17,7 @@ use Prism\Prism\ValueObjects\ProviderTool;
 
 class Request implements PrismRequest
 {
-    use ChecksSelf, HasProviderOptions;
+    use ChecksSelf, HasProviderOptions, HasReasoning;
 
     /**
      * @param  SystemMessage[]  $systemPrompts
@@ -43,8 +44,10 @@ class Request implements PrismRequest
         protected string|ToolChoice|null $toolChoice,
         array $providerOptions = [],
         protected array $providerTools = [],
+        ?bool $reasoningEnabled = null,
     ) {
         $this->providerOptions = $providerOptions;
+        $this->reasoningEnabled = $reasoningEnabled;
     }
 
     public function toolChoice(): string|ToolChoice|null

--- a/tests/Providers/Anthropic/AnthropicTextRequestTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextRequestTest.php
@@ -196,6 +196,43 @@ it('sends correct thinking mode in payload', function (): void {
     });
 });
 
+it('omits thinking when withReasoning(false) is used even with thinking.enabled', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-haiku-latest')
+        ->withMessages([new UserMessage('Test')])
+        ->withProviderOptions(['thinking' => ['enabled' => true]])
+        ->withReasoning(false)
+        ->asText();
+
+    Http::assertSent(function (Request $request): bool {
+        $payload = $request->data();
+
+        expect($payload)->not->toHaveKey('thinking');
+
+        return true;
+    });
+});
+
+it('does not include thinking when withReasoning(false) on a non-thinking model', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-haiku-latest')
+        ->withMessages([new UserMessage('Test')])
+        ->withReasoning(false)
+        ->asText();
+
+    Http::assertSent(function (Request $request): bool {
+        $payload = $request->data();
+
+        expect($payload)->not->toHaveKey('thinking');
+
+        return true;
+    });
+});
+
 it('sends correct thinking mode with default budget tokens', function (): void {
     FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/generate-text-with-a-prompt');
 

--- a/tests/Providers/Ollama/StreamTest.php
+++ b/tests/Providers/Ollama/StreamTest.php
@@ -187,6 +187,28 @@ it('does not include think parameter when not provided for streaming', function 
     });
 });
 
+it('sends think:false on stream when withReasoning(false) is used', function (): void {
+    FixtureResponse::fakeStreamResponses('api/chat', 'ollama/stream-without-thinking');
+
+    $response = Prism::text()
+        ->using('ollama', 'gpt-oss')
+        ->withPrompt('Test prompt')
+        ->withReasoning(false)
+        ->asStream();
+
+    foreach ($response as $chunk) {
+        break;
+    }
+
+    Http::assertSent(function (Request $request): true {
+        $body = $request->data();
+        expect($body)->toHaveKey('think');
+        expect($body['think'])->toBe(false);
+
+        return true;
+    });
+});
+
 it('includes keep_alive parameter when provided for streaming', function (): void {
     FixtureResponse::fakeStreamResponses('api/chat', 'ollama/stream-without-thinking');
 

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -148,6 +148,43 @@ describe('Thinking parameter', function (): void {
             return true;
         });
     });
+
+    it('sends think:false when withReasoning(false) is used', function (): void {
+        FixtureResponse::fakeResponseSequence('api/chat', 'ollama/text-without-thinking');
+
+        Prism::text()
+            ->using('ollama', 'gpt-oss')
+            ->withPrompt('Test prompt')
+            ->withReasoning(false)
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $body = $request->data();
+            expect($body)->toHaveKey('think');
+            expect($body['think'])->toBe(false);
+
+            return true;
+        });
+    });
+
+    it('honors explicit thinking provider option over withReasoning(false)', function (): void {
+        FixtureResponse::fakeResponseSequence('api/chat', 'ollama/text-with-thinking-enabled');
+
+        Prism::text()
+            ->using('ollama', 'gpt-oss')
+            ->withPrompt('Test prompt')
+            ->withProviderOptions(['thinking' => true])
+            ->withReasoning(false)
+            ->asText();
+
+        Http::assertSent(function (Request $request): true {
+            $body = $request->data();
+            expect($body)->toHaveKey('think');
+            expect($body['think'])->toBe(true);
+
+            return true;
+        });
+    });
 });
 
 describe('Keep alive parameter', function (): void {

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -598,6 +598,46 @@ it('sends reasoning effort when defined', function (): void {
     ]);
 });
 
+it('maps withReasoning(false) to reasoning.effort=minimal', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-reasoning-effort');
+
+    Prism::text()
+        ->using('openai', 'gpt-5')
+        ->withPrompt('Who are you?')
+        ->withReasoning(false)
+        ->asText();
+
+    Http::assertSent(fn (Request $request): bool => $request->data()['reasoning']['effort'] === 'minimal');
+});
+
+it('does not include reasoning key when withReasoning is not called', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-reasoning-effort');
+
+    Prism::text()
+        ->using('openai', 'gpt-5')
+        ->withPrompt('Who are you?')
+        ->asText();
+
+    Http::assertSent(function (Request $request): true {
+        expect($request->data())->not->toHaveKey('reasoning');
+
+        return true;
+    });
+});
+
+it('honors explicit reasoning provider option over withReasoning(false)', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/responses', 'openai/text-reasoning-effort');
+
+    Prism::text()
+        ->using('openai', 'gpt-5')
+        ->withPrompt('Who are you?')
+        ->withProviderOptions(['reasoning' => ['effort' => 'high']])
+        ->withReasoning(false)
+        ->asText();
+
+    Http::assertSent(fn (Request $request): bool => $request->data()['reasoning']['effort'] === 'high');
+});
+
 describe('provider tool results', function (): void {
     it('captures web search provider tool in providerToolCalls', function (): void {
         FixtureResponse::fakeResponseSequence('v1/responses', 'openai/generate-text-with-web-search-citations');


### PR DESCRIPTION
## Description

Adds a `withReasoning(bool $enabled = true)` fluent setter on text and structured pending requests so callers can express the semantic intent of "skip reasoning" once and have each provider translate it to the right wire-format key.

### Why

Each provider that supports reasoning / thinking exposes it through a different field today:

- Ollama uses `think: true|false`
- OpenAI Responses uses `reasoning: { effort: "minimal"|"low"|... }`
- Anthropic uses `thinking: { type: "enabled", budget_tokens: ... }` (and simply omits the block when disabled)
- Gemini uses `thinkingConfig: { thinkingBudget: 0|... }`
- OpenRouter uses `reasoning: { exclude: true|... }`
- Perplexity uses `reasoning_effort: "low"|...`

To disable hidden chain-of-thought today, a caller has to know each provider's wire format and hand-roll it via `withProviderOptions()`. Code that wants to be portable across providers (e.g. an agent framework choosing between an OpenAI and an Ollama backend at runtime) has to maintain a translation table. This PR puts that table inside Prism.

### What changed

- New `Prism\Prism\Concerns\HasReasoning` trait with a `?bool` state and `withReasoning()` / `reasoningEnabled()` accessors. Composed onto `Text\PendingRequest`, `Text\Request`, `Structured\PendingRequest`, `Structured\Request`.
- Each provider's text, stream, and structured handler reads `$request->reasoningEnabled()` and emits the right key when it is `false` and the user has not already set the equivalent provider option:

| Provider   | Wire format when `withReasoning(false)` |
|------------|------------------------------------------|
| Ollama     | `think: false`                           |
| OpenAI     | `reasoning: { effort: "minimal" }`     |
| Anthropic  | `thinking` block omitted                 |
| Gemini     | `thinkingConfig: { thinkingBudget: 0 }`  |
| OpenRouter | `reasoning: { exclude: true }`           |
| Perplexity | `reasoning_effort: "low"`              |

Other providers (Groq, Mistral, DeepSeek, xAI, etc.) treat the call as a graceful no-op — no error, no extra key sent.

### Example

```php
// Before: caller has to know the wire format
$response = Prism::text()
    ->using('ollama', 'qwen3:14b')
    ->withPrompt($prompt)
    ->withProviderOptions(['thinking' => false])
    ->asText();

// After: portable across providers
$response = Prism::text()
    ->using($provider, $model)
    ->withPrompt($prompt)
    ->withReasoning(false)
    ->asText();
```

### Backward compatibility

Fully additive. If `withReasoning()` is never called the request behaves exactly as it does today. If a caller sets the equivalent provider option explicitly (e.g. `withProviderOptions(['reasoning' => ['effort' => 'high']])`), that explicit value still wins — `withReasoning(false)` only fills in the default when no provider option is set.

### Tests

- New per-provider assertions for `withReasoning(false)` in `tests/Providers/Ollama/TextTest.php`, `tests/Providers/Ollama/StreamTest.php`, `tests/Providers/OpenAI/TextTest.php`, `tests/Providers/Anthropic/AnthropicTextRequestTest.php`. Each covers (a) the new wire-format key is sent, (b) explicit provider options still win, (c) absence of the key when `withReasoning()` is not called.
- Full suite green: `vendor/bin/pest --parallel` reports 1471 passing / 8 pre-existing skipped.
- `vendor/bin/pint --test` and `vendor/bin/phpstan analyse` both clean.

### Naming

Followed existing conventions: `withMaxSteps`, `withMaxTokens`, `withProviderOptions` already use a `with*` prefix on `PendingRequest`. `withReasoning(bool $enabled = true)` mirrors that shape and lets the common case read naturally as `->withReasoning(false)`.
